### PR TITLE
Make functions exportable in __init__.py, update typehints

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -49,6 +49,9 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
+[lint.isort]
+combine-as-imports = true
+
 [format]
 # Like Black, use double quotes for strings.
 quote-style = "double"

--- a/src/jaxfun/__init__.py
+++ b/src/jaxfun/__init__.py
@@ -1,28 +1,35 @@
-# ruff: noqa: F401
-
-from jaxfun import Chebyshev, Fourier, Jacobi, Legendre
-from jaxfun.arguments import JAXFunction, TestFunction, TrialFunction
-from jaxfun.basespace import BaseSpace, Domain
-from jaxfun.coordinates import CoordSys, get_CoordSys
-from jaxfun.functionspace import FunctionSpace
-from jaxfun.inner import inner
+from jaxfun import (
+    Chebyshev as Chebyshev,
+    Fourier as Fourier,
+    Jacobi as Jacobi,
+    Legendre as Legendre,
+)
+from jaxfun.arguments import (
+    JAXFunction as JAXFunction,
+    TestFunction as TestFunction,
+    TrialFunction as TrialFunction,
+)
+from jaxfun.basespace import BaseSpace as BaseSpace, Domain as Domain
+from jaxfun.coordinates import CoordSys as CoordSys, get_CoordSys as get_CoordSys
+from jaxfun.functionspace import FunctionSpace as FunctionSpace
+from jaxfun.inner import inner as inner
 from jaxfun.operators import (
-    Cross,
-    Curl,
-    Div,
-    Dot,
-    Grad,
-    Outer,
-    cross,
-    curl,
-    divergence,
-    dot,
-    gradient,
-    outer,
+    Cross as Cross,
+    Curl as Curl,
+    Div as Div,
+    Dot as Dot,
+    Grad as Grad,
+    Outer as Outer,
+    cross as cross,
+    curl as curl,
+    divergence as divergence,
+    dot as dot,
+    gradient as gradient,
+    outer as outer,
 )
 from jaxfun.tensorproductspace import (
-    TensorProduct,
-    TensorProductSpace,
-    VectorTensorProductSpace,
+    TensorProduct as TensorProduct,
+    TensorProductSpace as TensorProductSpace,
+    VectorTensorProductSpace as VectorTensorProductSpace,
 )
-from jaxfun.utils import common, fastgl
+from jaxfun.utils import common as common, fastgl as fastgl

--- a/src/jaxfun/basespace.py
+++ b/src/jaxfun/basespace.py
@@ -28,13 +28,13 @@ class BaseSpace:
         self.name = name
         self.fun_str = fun_str
         self.system = CartCoordSys("N", (x,)) if system is None else system
-    
-    is_transient = False 
-    
+
+    is_transient = False
+
     @partial(jax.jit, static_argnums=0)
     def evaluate(self, X: float, c: Array) -> float:
         raise RuntimeError
-    
+
 
 class OrthogonalSpace(BaseSpace):
     def __init__(
@@ -45,7 +45,6 @@ class OrthogonalSpace(BaseSpace):
         name: str = "OrthogonalSpace",
         fun_str: str = "psi",
     ) -> None:
-        
         self.N = N
         self.M = N
         self._domain = Domain(*domain) if domain is not None else None

--- a/src/jaxfun/pinns/__init__.py
+++ b/src/jaxfun/pinns/__init__.py
@@ -1,10 +1,31 @@
-# ruff: noqa: F401
-#from .bcs import DirichletBC
-from .embeddings import Embedding, FourierEmbs, PeriodEmbs
-from .freeze import freeze_layer, unfreeze_layer
-from .hessoptimizer import hess
-from .loss import LSQR
-from .mesh import Annulus, AnnulusPolar, Line, Rectangle, UnitLine, UnitSquare
-from .module import Comp, FlaxFunction
-from .nnspaces import MLPSpace, MLPVectorSpace, PirateSpace
-from .optimizer import run_optimizer, train
+from .embeddings import (
+    Embedding as Embedding,
+    FourierEmbs as FourierEmbs,
+    PeriodEmbs as PeriodEmbs,
+)
+from .freeze import freeze_layer as freeze_layer, unfreeze_layer as unfreeze_layer
+from .hessoptimizer import hess as hess
+from .loss import LSQR as LSQR
+from .mesh import (
+    Annulus as Annulus,
+    AnnulusPolar as AnnulusPolar,
+    Line as Line,
+    Rectangle as Rectangle,
+    UnitLine as UnitLine,
+    UnitSquare as UnitSquare,
+)
+from .module import (
+    Comp as Comp,
+    FlaxFunction as FlaxFunction,
+)
+from .nnspaces import (
+    MLPSpace as MLPSpace,
+    MLPVectorSpace as MLPVectorSpace,
+    PirateSpace as PirateSpace,
+)
+from .optimizer import (
+    run_optimizer as run_optimizer,
+    train as train,
+)
+
+# from .bcs import DirichletBC

--- a/src/jaxfun/pinns/freeze.py
+++ b/src/jaxfun/pinns/freeze.py
@@ -6,17 +6,19 @@ import jax
 class FrozenLayer:
     def __init__(self, layer):
         self.layer = layer
-        
+
     @partial(jax.jit, static_argnums=0)
     def __call__(self, x):
         return self.layer(x)
+
 
 def freeze_layer(model, layer, i=None):
     if i is None:
         model.__setattr__(layer, FrozenLayer(model.__getattribute__(layer)))
     else:
-        model.__getattribute__(layer)[i] = FrozenLayer(model.__getattribute__(layer)[i]) 
+        model.__getattribute__(layer)[i] = FrozenLayer(model.__getattribute__(layer)[i])
     return model
+
 
 def unfreeze_layer(model, layer, i=None):
     if i is None:

--- a/src/jaxfun/pinns/loss.py
+++ b/src/jaxfun/pinns/loss.py
@@ -30,7 +30,7 @@ def get_flaxfunctions(
     return flax_found
 
 
-def eval_flaxfunction(expr, x: Array):
+def eval_flaxfunction(expr, x: Array) -> Array:
     f = get_flaxfunctions(expr)
     assert len(f) == 1
     f = f.pop()
@@ -83,7 +83,8 @@ class Residual:
         t, expr = expand(f)
         self.eqs = [get_fn(h, s) for h in expr]
         self.x = x
-        # Place all terms without flaxfunctions in the target, because these will not need to be computed more than once
+        # Place all terms without flaxfunctions in the target,
+        # because these will not need to be computed more than once
         self.target = target
         if len(t.free_symbols) > 0:
             self.target = target - lambdify(s, t, modules="jax")(*x.T)

--- a/src/jaxfun/pinns/mesh.py
+++ b/src/jaxfun/pinns/mesh.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from numbers import Number
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -11,13 +12,15 @@ from jax.typing import ArrayLike
 from jaxfun.typing import Array
 from jaxfun.utils import leggauss
 
+type SampleMethod = Literal["uniform", "legendre", "random"]
+
 
 @dataclass
 class UnitLine:
     N: int
     key: ArrayLike = field(kw_only=True, default_factory=nnx.rnglib.Rngs(101))
 
-    def get_points_inside_domain(self, kind: str = "uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         if kind == "uniform":
             return jnp.linspace(0, 1, self.N + 2)[1:-1, None]
 
@@ -26,17 +29,20 @@ class UnitLine:
 
         elif kind == "random":
             return jax.random.uniform(self.key, (self.N, 1))
+
         raise NotImplementedError
 
-    def get_points_on_domain(self, kind: str = "uniform"):
+    def get_points_on_domain(self, kind: SampleMethod = "uniform") -> Array:
         return jnp.array([[0.0], [1.0]])
 
-    def get_weights_inside_domain(self, kind: str = "uniform"):
+    def get_weights_inside_domain(
+        self, kind: SampleMethod = "uniform"
+    ) -> Array | Literal[1]:
         if kind in ("uniform", "random"):
             return 1
         return leggauss(self.N)[1] * self.N
 
-    def get_weights_on_domain(self, kind: str = "uniform"):
+    def get_weights_on_domain(self, kind: SampleMethod = "uniform") -> Literal[1]:
         return 1
 
 
@@ -45,11 +51,11 @@ class Line(UnitLine):
     left: Number
     right: Number
 
-    def get_points_inside_domain(self, kind="uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         x = super().get_points_inside_domain(kind)
         return self.left + (self.right - self.left) * x
 
-    def get_points_on_domain(self, kind="uniform"):
+    def get_points_on_domain(self, kind: SampleMethod = "uniform") -> Array:
         return jnp.array([[self.left], [self.right]], dtype=float)
 
 
@@ -59,7 +65,7 @@ class UnitSquare:
     Ny: int
     key: ArrayLike = field(kw_only=True, default_factory=nnx.rnglib.Rngs(101))
 
-    def get_points_inside_domain(self, kind: str = "uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         if kind == "uniform":
             x = jnp.linspace(0, 1, self.Nx + 2)[1:-1]
             y = jnp.linspace(0, 1, self.Ny + 2)[1:-1]
@@ -73,7 +79,9 @@ class UnitSquare:
 
         return jnp.array(jnp.meshgrid(x, y, indexing="ij")).reshape((2, -1)).T
 
-    def get_points_on_domain(self, kind: str = "uniform", corners: bool = True):
+    def get_points_on_domain(
+        self, kind: SampleMethod = "uniform", corners: bool = True
+    ) -> Array:
         if kind == "uniform":
             x = np.linspace(0, 1, self.Nx + 2)[1:-1]
             y = np.linspace(0, 1, self.Ny + 2)[1:-1]
@@ -97,21 +105,25 @@ class UnitSquare:
         xy[(2 * self.Nx + self.Ny) : (2 * self.Nx + 2 * self.Ny), 0] = 1
         return jnp.array(xy)
 
-    def get_weights_inside_domain(self, kind: str = "uniform"):
+    def get_weights_inside_domain(
+        self, kind: SampleMethod = "uniform"
+    ) -> Array | Literal[1]:
         if kind in ("uniform", "random"):
             return 1
         wx = np.polynomial.legendre.leggauss(self.Nx)[1] * self.Nx
         wy = np.polynomial.legendre.leggauss(self.Ny)[1] * self.Ny
         return jnp.outer(wx, wy).flatten()
 
-    def get_weights_on_domain(self, kind: str = "uniform", corners: bool = True):
+    def get_weights_on_domain(
+        self, kind: SampleMethod = "uniform", corners: bool = True
+    ) -> Array | Literal[1]:
         if kind in ("uniform", "random"):
             return 1
         wx = np.polynomial.legendre.leggauss(self.Nx)[1] * (2 * self.Nx + 2 * self.Ny)
         wy = np.polynomial.legendre.leggauss(self.Ny)[1] * (2 * self.Nx + 2 * self.Ny)
         w = jnp.hstack((wx, wx, wy, wy))
         if corners:
-            w = np.hstack((w, jnp.ones(4)))
+            w = jnp.hstack((w, jnp.ones(4)))
         return w
 
 
@@ -122,13 +134,15 @@ class Rectangle(UnitSquare):
     bottom: Number
     top: Number
 
-    def get_points_inside_domain(self, kind="uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         mesh = super().get_points_inside_domain(kind)
         x = self.left + (self.right - self.left) * mesh[:, 0]
         y = self.bottom + (self.top - self.bottom) * mesh[:, 1]
         return jnp.array([x, y]).T
 
-    def get_points_on_domain(self, kind="uniform", corners: bool = True):
+    def get_points_on_domain(
+        self, kind: SampleMethod = "uniform", corners: bool = True
+    ) -> Array:
         mesh = super().get_points_on_domain(kind, corners=corners)
         x = self.left + (self.right - self.left) * mesh[:, 0]
         y = self.bottom + (self.top - self.bottom) * mesh[:, 1]
@@ -140,13 +154,16 @@ def points_along_axis(a: Number | Array, b: Array | Number) -> Array:
     b = jnp.atleast_1d(b)
     return jnp.array(jnp.meshgrid(a, b, indexing="ij")).reshape((2, -1)).T
 
+
 class AnnulusPolar(Rectangle):
-    def __init__(self, Nx: int, Ny: int, radius_inner: Number, radius_outer: Number):
+    def __init__(
+        self, Nx: int, Ny: int, radius_inner: Number, radius_outer: Number
+    ) -> None:
         self.radius_inner = radius_inner
         self.radius_outer = radius_outer
         Rectangle.__init__(self, Nx, Ny, radius_inner, radius_outer, 0, 2 * jnp.pi)
 
-    def get_points_inside_domain(self, kind: str = "uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         if kind == "uniform":
             x = jnp.linspace(0, 1, self.Nx + 2)[1:-1]
             y = jnp.linspace(0, 1, self.Ny + 1)[:-1]  # wrap around periodic
@@ -157,7 +174,9 @@ class AnnulusPolar(Rectangle):
 
         return Rectangle.get_points_inside_domain(self, kind)
 
-    def get_points_on_domain(self, kind="uniform", corners: bool = False):
+    def get_points_on_domain(
+        self, kind: SampleMethod = "uniform", corners: bool = False
+    ) -> Array:
         if kind == "uniform":
             y = np.linspace(0, 1, self.Ny + 1)[:-1]
             xy = np.vstack((np.hstack((y, y)),) * 2).T
@@ -171,12 +190,14 @@ class AnnulusPolar(Rectangle):
 
 
 class Annulus(AnnulusPolar):
-    def __init__(self, Nx: int, Ny: int, radius_inner: Number, radius_outer: Number):
+    def __init__(
+        self, Nx: int, Ny: int, radius_inner: Number, radius_outer: Number
+    ) -> None:
         self.radius_inner = radius_inner
         self.radius_outer = radius_outer
         AnnulusPolar.__init__(self, Nx, Ny, radius_inner, radius_outer)
 
-    def convert_to_cartesian(self, xc):
+    def convert_to_cartesian(self, xc) -> Array:
         r, theta = sp.symbols("r,theta", real=True, positive=True)
         rv = (r * sp.cos(theta), r * sp.sin(theta))
         mesh = []
@@ -184,10 +205,12 @@ class Annulus(AnnulusPolar):
             mesh.append(sp.lambdify((r, theta), xi, modules="jax")(*xc.T))
         return jnp.array(mesh).T
 
-    def get_points_inside_domain(self, kind: str = "uniform"):
+    def get_points_inside_domain(self, kind: SampleMethod = "uniform") -> Array:
         xc = AnnulusPolar.get_points_inside_domain(self, kind)
         return self.convert_to_cartesian(xc)
 
-    def get_points_on_domain(self, kind="uniform", corners: bool = False):
+    def get_points_on_domain(
+        self, kind: SampleMethod = "uniform", corners: bool = False
+    ) -> Array:
         xc = AnnulusPolar.get_points_on_domain(self, kind, False)
         return self.convert_to_cartesian(xc)

--- a/src/jaxfun/pinns/module.py
+++ b/src/jaxfun/pinns/module.py
@@ -144,7 +144,8 @@ class MLP(nnx.Module):
         Args:
             V: Functionspace with detailed layer structure for the MLP
             rngs: Seed
-            kernel_init (optional): Initializer for kernel. Defaults to default_kernel_init.
+            kernel_init (optional): Initializer for kernel. Defaults
+                to default_kernel_init.
             bias_init (optional): Initializer for bias. Defaults to default_bias_init.
         """
         hidden_size = (

--- a/src/jaxfun/pinns/nnspaces.py
+++ b/src/jaxfun/pinns/nnspaces.py
@@ -126,7 +126,8 @@ class PirateSpace(NNSpace):
     ) -> None:
         NNSpace.__init__(self, dims, rank, transient, system, name)
 
-        # PirateSpace requires at least one hidden layer, so change integer hidden_size to [hidden_size]
+        # PirateSpace requires at least one hidden layer, so change integer hidden_size
+        # to [hidden_size]
         self.hidden_size = (
             hidden_size if isinstance(hidden_size, list | tuple) else [hidden_size]
         )

--- a/src/jaxfun/pinns/optimizer.py
+++ b/src/jaxfun/pinns/optimizer.py
@@ -39,7 +39,7 @@ def run_optimizer(
     print_final_loss: bool = False,
     update_global_weights: int = -1,
     print_global_weights: bool = False,
-):
+) -> None:
     train_step = train(loss_fn)
     loss_old = 1.0
     for epoch in range(1, num + 1):

--- a/src/jaxfun/utils/__init__.py
+++ b/src/jaxfun/utils/__init__.py
@@ -1,2 +1,12 @@
-from .common import *
-from .fastgl import leggauss
+from .common import (
+    Domain as Domain,
+    diff as diff,
+    diffx as diffx,
+    fromdense as fromdense,
+    jacn as jacn,
+    lambdify as lambdify,
+    matmat as matmat,
+    tosparse as tosparse,
+    ulp as ulp,
+)
+from .fastgl import leggauss as leggauss

--- a/src/jaxfun/utils/common.py
+++ b/src/jaxfun/utils/common.py
@@ -12,7 +12,7 @@ from scipy import sparse as scipy_sparse
 from scipy.special import sph_harm
 from sympy import Expr, Number, Symbol
 
-Ynm = lambda n, m, x, y : sph_harm(m, n, y, x)
+Ynm = lambda n, m, x, y: sph_harm(m, n, y, x)
 n = Symbol("n", positive=True, integer=True)
 
 
@@ -55,7 +55,7 @@ def diffx(
 
 def jacn(fun: Callable[[float], Array], k: int = 1) -> Callable[[Array], Array]:
     for i in range(k):
-        fun = jax.jacrev(fun) if i % 2 else jax.jacfwd(fun) 
+        fun = jax.jacrev(fun) if i % 2 else jax.jacfwd(fun)
     return jax.vmap(fun, in_axes=0, out_axes=0)
 
 
@@ -91,12 +91,12 @@ def lambdify(
     doctring_limit: int = 1000,
 ) -> Callable[[Iterable[Array]], Array]:
     from jaxfun.forms import get_system
-    
+
     system = get_system(expr)
     expr = system.expr_base_scalar_to_psi(expr)
     args = system.expr_base_scalar_to_psi(args)
-    modules_default = ["jax", {'Ynm': Ynm}]
-    modules = modules_default if modules is None else [modules]+modules_default
+    modules_default = ["jax", {"Ynm": Ynm}]
+    modules = modules_default if modules is None else [modules] + modules_default
     return sp.lambdify(
         args,
         expr,


### PR DESCRIPTION
This pull request refactors imports and type annotations throughout the codebase for consistency and clarity, especially in the `jaxfun` package and its submodules. The main changes include switching to explicit `as` imports, improving type annotations for domain sampling methods, optimizer and mesh classes.

Changing to explicit `import ... as ...` exposes the methods, such that they can be imported directly from e.g. `jaxfun.pinns`. The alternative to this is to do `from ... import *` and `__all__ += module.__all__`.

### Import Refactoring

* Changed all imports in `src/jaxfun/__init__.py` and `src/jaxfun/pinns/__init__.py` to use explicit `as` imports for each symbol, improving clarity and avoiding import conflicts. [[1]](diffhunk://#diff-082b74e1af204a05c436e71119b7d6732c88681c01643b4423b20ddbce408c9fL1-R35) [[2]](diffhunk://#diff-f22704333f6d1136873122589c92d8375af08f63b9a159dd36a622110461a40bL1-L10)
* Updated `src/jaxfun/utils/__init__.py` to use explicit `as` imports, making symbol exports clearer and more maintainable.

### Type Annotation Improvements

* Added and propagated the `SampleMethod` type alias (using `Literal["uniform", "legendre", "random"]`) throughout mesh classes in `src/jaxfun/pinns/mesh.py`, updating method signatures for domain sampling and weights to use more precise type annotations. [[1]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88R3) [[2]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88R15-R23) [[3]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88R32-R45) [[4]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L48-R58) [[5]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L62-R68) [[6]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L76-R84) [[7]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L100-R126) [[8]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L125-R145) [[9]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88R157-R166) [[10]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L160-R179) [[11]](diffhunk://#diff-6573f23b2c89a819354defc700974872ff7444d9f172692b06465a7c11dfdb88L174-R214)

### Optimizer and Loss Function Updates

* Refactored the type annotations for the Hessian optimizer in `src/jaxfun/pinns/hessoptimizer.py`, introduced a default linesearch object, and updated function signatures. [[1]](diffhunk://#diff-270f7936f601a2540a4700279ba8d238c6b97c64938c2eb7af83064eadc3ae36L1-R14) [[2]](diffhunk://#diff-270f7936f601a2540a4700279ba8d238c6b97c64938c2eb7af83064eadc3ae36L62-R59)
* Added return type annotations to functions in `src/jaxfun/pinns/loss.py` and `src/jaxfun/pinns/optimizer.py`. [[1]](diffhunk://#diff-ae87ca3ec58489d0e82101892d9447375521f5155637fd528133643e8944df5eL33-R33) [[2]](diffhunk://#diff-a3208d952ec659df425f90478de24b080c9767fead3e92463a3b2ea11598c4fdL42-R42)

### Minor Code Quality and Documentation Improvements

* Minor formatting and whitespace fixes, such as in `src/jaxfun/basespace.py` and `src/jaxfun/pinns/freeze.py`. [[1]](diffhunk://#diff-6212a8fb8bb2fb23e1850881f703d12ab2f1c020f1cdf40e3b572133e7fa3788L48) [[2]](diffhunk://#diff-ae88b4e4ba8a6d249cba1ad4a0e7fa798d178d7a6bca4d41f0f9a635af88db93R14-R22)

### Configuration Update

* Added `[lint.isort]` section to `ruff.toml` to enable combining `as` imports, ensuring import statements are grouped and formatted consistently.