### PR TITLE
Modify pytest workflow to include JAX_ENABLE_X64

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,10 +31,10 @@ jobs:
 
       - name: Run fast tests (default, excludes slow)
         run: |
-          uv run pytest -m 'not slow'
-          uv run pytest --float64 -m 'not slow'
+          JAX_ENABLE_X64=0 uv run pytest -m 'not slow'
+          JAX_ENABLE_X64=1 uv run pytest -m 'not slow'
 
       - name: Run slow demo tests
         run: |
-          uv run pytest -m slow
-          uv run pytest --float64 -m slow
+          JAX_ENABLE_X64=0 uv run pytest -m slow
+          JAX_ENABLE_X64=1 uv run pytest -m slow


### PR DESCRIPTION
Update pytest workflow to run tests with and without the JAX_ENABLE_X64 flag. See if this helps the accuracy of the demos.