### PR TITLE
Matrix fixes and adding PinnedSystem for constrained solve

### DIFF
--- a/examples/poisson1D_periodic.py
+++ b/examples/poisson1D_periodic.py
@@ -23,8 +23,8 @@ x = D.system.x  # use the same coordinate as u and v
 ue = sp.cos(2 * x) + sp.I * sp.sin(1 * x)
 
 A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
-
-uh = jnp.hstack((jnp.array([0.0]), b[1:] / A.diagonal()[1:]))
+A_pin = A.pin({0: 0.0})
+uh = A_pin.solve(b)
 
 uj = D.backward(uh)
 xj = D.mesh()

--- a/examples/poisson2D.py
+++ b/examples/poisson2D.py
@@ -30,8 +30,8 @@ ue = (1 - x**2) * (1 - y**2)  # * sp.exp(sp.cos(sp.pi * x)) * sp.exp(sp.sin(sp.p
 # A, b = inner(-Dot(Grad(u), Grad(v)) - v * Div(Grad(ue)), sparse=False)
 A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
 
-A0 = tpmats_to_kron(A)
-uh = A0.solve(b.flatten()).reshape(b.shape)
+C = tpmats_to_kron(A)
+uh = C.solve(b.flatten()).reshape(b.shape)
 
 N = 100
 uj = T.backward(uh, kind="uniform", N=(N, N))

--- a/src/jaxfun/galerkin/Chebyshev.py
+++ b/src/jaxfun/galerkin/Chebyshev.py
@@ -5,7 +5,7 @@ from jax import Array
 from sympy import Expr, Symbol
 
 from jaxfun.coordinates import CoordSys
-from jaxfun.la import DiaMatrix, diags
+from jaxfun.la import DiaMatrix, Matrix, diags
 from jaxfun.typing import MeshKind
 from jaxfun.utils.common import Domain, jit_vmap
 
@@ -359,8 +359,8 @@ class Chebyshev(Jacobi):
 
 def matrices(
     test: tuple[Chebyshev, int], trial: tuple[Chebyshev, int]
-) -> DiaMatrix | None:
-    """Sparse operator matrices between test/trial Chebyshev modes.
+) -> Matrix | DiaMatrix | None:
+    """Return (possibly sparse) operator matrices between test/trial Chebyshev modes.
 
     Constructs (possibly rectangular) sparse differentiation / mass-like
     matrices for combinations of test index i and trial index j flags:
@@ -377,27 +377,21 @@ def matrices(
         trial: Tuple (u, j) with Chebyshev space u and number of derivatives j.
 
     Returns:
-        DiaMatrix | None if combination unsupported.
+        Matrix | DiaMatrix | None if combination unsupported.
     """
     v, i = test
     u, j = trial
-    if (i, j) not in {(0, 0), (0, 1), (1, 0), (0, 2), (2, 0)}:
+    if (i, j) not in ((0, 0), (0, 1), (1, 0), (0, 2), (2, 0)):
         return None
+
     if i == 0 and j == 0:
-        return diags(
-            [v.norm_squared()],
-            offsets=(0,),
-            shape=(v.N, u.N),
-        )
+        return diags([v.norm_squared()], offsets=(0,), shape=(v.N, u.N))
 
-    if j == 0:
-        if i not in (1, 2):
-            return None
-
+    if i in (1, 2) and j == 0:
         m = matrices(trial, test)
         if m is not None:
-            return m.T
-        return None
+            m = m.T
+        return m
 
     offsets = jnp.arange(j, u.N, 2)
     if len(offsets) == 0:
@@ -420,7 +414,5 @@ def matrices(
     _getkey = _getkey1 if j == 1 else _getkey2
 
     return diags(
-        [_getkey(m) for m in offsets],
-        tuple(offsets.tolist()),
-        (v.N, u.N),
-    )
+        [_getkey(m) for m in offsets], tuple(offsets.tolist()), (v.N, u.N)
+    ).to_Matrix()  # Matrix is upper triangular, better and faster to use dense.

--- a/src/jaxfun/galerkin/ChebyshevU.py
+++ b/src/jaxfun/galerkin/ChebyshevU.py
@@ -5,7 +5,7 @@ from jax import Array
 from sympy import Expr, Symbol
 
 from jaxfun.coordinates import CoordSys
-from jaxfun.la import DiaMatrix, diags
+from jaxfun.la import DiaMatrix, Matrix, diags
 from jaxfun.typing import MeshKind
 from jaxfun.utils.common import Domain, dst, jit_vmap
 
@@ -225,7 +225,7 @@ class ChebyshevU(Jacobi):
 
 def matrices(
     test: tuple[ChebyshevU, int], trial: tuple[ChebyshevU, int]
-) -> DiaMatrix | None:
+) -> Matrix | DiaMatrix | None:
     """Sparse operator matrices between test/trial ChebyshevU modes.
 
     Constructs (possibly rectangular) sparse differentiation / mass-like
@@ -239,7 +239,7 @@ def matrices(
         trial: Tuple (u, j) with ChebyshevU space u and number of derivatives j.
 
     Returns:
-        DiaMatrix or None if combination unsupported.
+        Matrix or DiaMatrix or None if combination unsupported.
     """
     v, i = test
     u, j = trial

--- a/src/jaxfun/galerkin/Legendre.py
+++ b/src/jaxfun/galerkin/Legendre.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from jaxfun.coordinates import CoordSys
-from jaxfun.la import DiaMatrix, diags
+from jaxfun.la import DiaMatrix, Matrix, diags
 from jaxfun.utils.common import Domain, jit_vmap
 from jaxfun.utils.fastgl import leggauss
 
@@ -188,8 +188,8 @@ class Legendre(Jacobi):
 
 def matrices(
     test: tuple[Legendre, int], trial: tuple[Legendre, int]
-) -> DiaMatrix | None:
-    """Return sparse operator matrices for Legendre derivative coupling.
+) -> Matrix | DiaMatrix | None:
+    """Return (sparse) operator matrices for Legendre derivative coupling.
 
     Supported (i,j) derivative orders:
         (0,0): Mass (diagonal)
@@ -203,7 +203,7 @@ def matrices(
         trial: (space, derivative order) trial side.
 
     Returns:
-        DiaMatrix diagonal mass matrix or None if unsupported.
+        Matrix or DiaMatrix diagonal mass matrix or None if unsupported.
     """
 
     v, i = test
@@ -218,7 +218,7 @@ def matrices(
             [jnp.full(v.N - k, 2.0) for k in jnp.arange(1, v.N, 2).tolist()],
             offsets=tuple(jnp.arange(1, v.N, 2).tolist()),
             shape=(v.N, u.N),
-        )
+        ).to_Matrix()  # Matrix is upper triangular, better and faster to use dense.
 
     if i == 1 and j == 0:
         m = matrices(trial, test)
@@ -244,7 +244,7 @@ def matrices(
             [_getkey(j) for j in offsets],
             offsets=tuple(offsets),
             shape=(v.N, u.N),
-        )
+        ).to_Matrix()  # Matrix is upper triangular, better and faster to use dense.
     if i == 2 and j == 0:
         m = matrices(trial, test)
         if m is not None:

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -12,7 +12,7 @@ from jax import Array
 from sympy import Number
 
 from jaxfun.coordinates import CoordSys
-from jaxfun.la import DiaMatrix, diags
+from jaxfun.la import DiaMatrix, Matrix, MatrixProtocol, diags
 from jaxfun.typing import MeshKind
 from jaxfun.utils.common import Domain, matmat, n
 
@@ -159,7 +159,7 @@ class Composite(OrthogonalSpace):
             stencil = get_stencil_matrix(self.bcs, self.orthogonal)
         self.scaling = scaling
         self.stencil = {(si[0]): si[1] / scaling for si in sorted(stencil.items())}
-        self.S = self.stencil_to_diamatrix()
+        self.S: DiaMatrix = self.stencil_to_diamatrix()
         self.ST: DiaMatrix = self.S.T  # pre-computed transpose; avoids creating
         # a new DiaMatrix inside jax.jit traces (which breaks metadata comparison)
         self._mass_matrix: DiaMatrix = self._compute_mass_matrix()
@@ -259,19 +259,45 @@ class Composite(OrthogonalSpace):
         """Map underlying orthogonal coefficients -> composite coefficients."""
         return a @ self.get_inverse_stencil()
 
-    def apply_stencil_galerkin(self, b: Array) -> Array:
+    @overload
+    def apply_stencil_galerkin(self, b: Matrix) -> Matrix: ...
+    @overload
+    def apply_stencil_galerkin(self, b: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def apply_stencil_galerkin(self, b: MatrixProtocol) -> MatrixProtocol: ...
+    def apply_stencil_galerkin(self, b: MatrixProtocol) -> MatrixProtocol:
         """Apply stencil on both sides (Galerkin mass-like transform)."""
         return self.S @ b @ self.ST
 
-    def apply_stencils_petrovgalerkin(self, b: Array, P: DiaMatrix) -> Array:
+    @overload
+    def apply_stencils_petrovgalerkin(self, b: Matrix, PT: DiaMatrix) -> Matrix: ...
+    @overload
+    def apply_stencils_petrovgalerkin(
+        self, b: DiaMatrix, PT: DiaMatrix
+    ) -> DiaMatrix: ...
+    @overload
+    def apply_stencils_petrovgalerkin(
+        self, b: MatrixProtocol, PT: DiaMatrix
+    ) -> MatrixProtocol: ...
+    def apply_stencils_petrovgalerkin(
+        self, b: MatrixProtocol, PT: DiaMatrix
+    ) -> MatrixProtocol:
         """Apply test (S) and trial (P) stencils (Petrov-Galerkin)."""
-        return self.S @ b @ P.T
+        return self.S @ b @ PT
 
-    def apply_stencil_left(self, b: Array) -> Array:
+    @overload
+    def apply_stencil_left(self, b: Array) -> Array: ...
+    @overload
+    def apply_stencil_left(self, b: MatrixProtocol) -> MatrixProtocol: ...
+    def apply_stencil_left(self, b: Array | MatrixProtocol) -> Array | MatrixProtocol:
         """Left-multiply by stencil (test projection)."""
         return self.S @ b
 
-    def apply_stencil_right(self, a: Array) -> Array:
+    @overload
+    def apply_stencil_right(self, a: Array) -> Array: ...
+    @overload
+    def apply_stencil_right(self, a: MatrixProtocol) -> MatrixProtocol: ...
+    def apply_stencil_right(self, a: Array | MatrixProtocol) -> Array | MatrixProtocol:
         """Right-multiply by stencil transpose (trial projection)."""
         return a @ self.ST
 

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -102,8 +102,8 @@ def inner(
     allforms = split(expr * measure)
     a_forms = allforms["bilinear"]
     b_forms = allforms["linear"]
-    aresults = []
-    bresults = []
+    aresults: list[MatrixProtocol | TPMatrix | TensorMatrix] = []
+    bresults: list[Array] = []
     all_linear = not (
         len(a_forms) > 0
         and jnp.any(
@@ -119,7 +119,7 @@ def inner(
         # If the form contains a JAXFunction, then the matrix assembled will
         # be multiplied with the JAXFunction and a vector will be returned
 
-        mats: list[tuple[tuple[Array, Array] | Matrix, tuple[int, int]]] = []
+        mats: list[tuple[tuple[Array, Array] | MatrixProtocol, tuple[int, int]]] = []
         # Split coefficients into linear (JAXFunction) and bilinear (constant
         # coefficients) contributions.
         coeffs = split_coeff(a0["coeff"])
@@ -192,6 +192,7 @@ def inner(
             pass
 
         elif test_space.dims == 1 and "bilinear" in coeffs:
+            assert isinstance(mats[0][0], MatrixProtocol)
             aresults.append(mats[0][0])
 
         elif isinstance(mats[0][0], tuple):
@@ -237,11 +238,10 @@ def inner(
                     aresults.append(TensorMatrix(Am))
 
         elif len(mats) > 1:  # regular separable multivariable form
-            mats_: list[Array] = [cast(Matrix, m[0]).data for m in mats]
+            mats_: list[MatrixProtocol] = [cast(MatrixProtocol, m[0]) for m in mats]
             gi = [m[1] for m in mats]
 
             assert isinstance(test_space, TensorProductSpace | VectorTensorProductSpace)
-
             if has_bcs:
                 assert len(mats_) == 2  # BCs only implemented for 2D at present
                 if trial_space is not None:
@@ -271,18 +271,14 @@ def inner(
             else:
                 if "linear" in coeffs:
                     sign = 1 if all_linear else -1
-                    if test_space.dims == 2:
-                        res = (sign * coeffs["linear"]["scale"]) * (
-                            mats_[0] @ coeffs["linear"]["jaxcoeff"].array @ mats_[1].T
-                        )
-                    else:
-                        res = sign * jnp.einsum(
-                            "il,jm,kn,lmn->ijk",
-                            mats_[0],
-                            mats_[1],
-                            mats_[2],
-                            coeffs["linear"]["jaxcoeff"].array,
-                        )
+                    res = (
+                        sign
+                        * coeffs["linear"].get("scale", 1)
+                        * coeffs["linear"]["jaxcoeff"].array
+                    )
+                    for i, mat in enumerate(mats_):
+                        res = mat.matvec(res, axis=i)
+
                     bresults.append(vectorize_bresult(res, test_space, gi[0][0]))
 
                 if "bilinear" in coeffs:
@@ -402,31 +398,31 @@ def vectorize_bresult(
 
 @overload
 def process_results(
-    aresults: list[Matrix | TPMatrix | TensorMatrix],
+    aresults: list[MatrixProtocol | TPMatrix | TensorMatrix],
     bresults: list[Array],
     return_all_items: Literal[True],
     dims: int,
     sparse: bool,
     sparse_tol: int,
-) -> tuple[list[Matrix | TPMatrix | TensorMatrix], list[Array]]: ...
+) -> tuple[list[MatrixProtocol | TPMatrix | TensorMatrix], list[Array]]: ...
 @overload
 def process_results(
-    aresults: list[Matrix | TPMatrix | TensorMatrix],
+    aresults: list[MatrixProtocol | TPMatrix | TensorMatrix],
     bresults: list[Array],
     return_all_items: Literal[False],
     dims: int,
     sparse: Literal[False],
     sparse_tol: int,
 ) -> (
-    Matrix
+    MatrixProtocol
     | TPMatrix
     | TensorMatrix
     | Array
-    | tuple[Matrix | TPMatrix | TensorMatrix, Array]
+    | tuple[MatrixProtocol | TPMatrix | TensorMatrix, Array]
 ): ...
 @overload
 def process_results(
-    aresults: list[Matrix | TPMatrix | TensorMatrix],
+    aresults: list[MatrixProtocol | TPMatrix | TensorMatrix],
     bresults: list[Array],
     return_all_items: Literal[False],
     dims: int,
@@ -440,7 +436,7 @@ def process_results(
     | tuple[DiaMatrix | TPMatrix | TensorMatrix, Array]
 ): ...
 def process_results(
-    aresults: list[Matrix | TPMatrix | TensorMatrix],
+    aresults: list[MatrixProtocol | TPMatrix | TensorMatrix],
     bresults: list[Array],
     return_all_items: bool,
     dims: int,
@@ -462,21 +458,41 @@ def process_results(
     """
     if return_all_items:
         return aresults, bresults
-    if len(aresults) > 0 and dims == 1:
-        aresults: Matrix = Matrix(
-            jnp.sum(jnp.array([cast(Matrix, a).data for a in aresults]), axis=0)
-        )
-        if sparse:
-            aresults: DiaMatrix = tosparse(aresults.data, tol=sparse_tol)
 
-    if len(aresults) > 0 and dims > 1 and sparse:
+    if len(aresults) > 0 and dims == 1:
+        if not sparse:
+            aresults: Matrix = Matrix(
+                jnp.sum(
+                    jnp.array([cast(MatrixProtocol, a).todense() for a in aresults]),
+                    axis=0,
+                )
+            )
+        else:
+            # Matrices are either Matrix or DiaMatrix. Convert all matrices to DiaMatrix
+            adia = [
+                a
+                if isinstance(a, DiaMatrix)
+                else tosparse(cast(Matrix, a).data, tol=sparse_tol)
+                for a in aresults
+            ]
+            aresults: DiaMatrix = sum(adia[1:], adia[0])
+
+    if len(aresults) > 0 and dims > 1:
         aresults: list[TPMatrix] = cast(list[TPMatrix], aresults)
         for a0 in aresults:
             if isinstance(a0, TPMatrix):
-                a0.mats = nnx.List(
-                    tosparse(cast(Matrix, a0.mats[i]).data, sparse_tol)
-                    for i in range(a0.dims)
-                )
+                if sparse:
+                    a0.mats = nnx.List(
+                        mat
+                        if isinstance(mat, DiaMatrix)
+                        else tosparse(mat.data, tol=sparse_tol)
+                        for mat in a0.mats
+                    )
+                else:
+                    a0.mats = nnx.List(
+                        mat if isinstance(mat, Matrix) else Matrix(mat.todense())
+                        for mat in a0.mats
+                    )
 
     if len(bresults) > 0:
         bresults: Array = jnp.sum(jnp.array(bresults), axis=0)
@@ -500,7 +516,7 @@ def inner_bilinear(
     multivar: Literal[False],
     num_quad_points: int,
     use_precomputed_matrices: bool,
-) -> Matrix: ...
+) -> MatrixProtocol: ...
 @overload
 def inner_bilinear(
     ai: sp.Expr,
@@ -519,7 +535,7 @@ def inner_bilinear(
     multivar: bool,
     num_quad_points: int,
     use_precomputed_matrices: bool,
-) -> Matrix | tuple[Array, Array]:
+) -> MatrixProtocol | tuple[Array, Array]:
     """Assemble single bilinear form contribution term.
 
     Detects derivative orders on test/trial factors, applies optional
@@ -534,7 +550,7 @@ def inner_bilinear(
         multivar: True if coefficient not separable (handled upstream).
         num_quad_points: Number of quadrature points.
     Returns:
-        Matrix, or (Pi, Pj) tuple for multivar separation.
+        MatrixProtocol, or (Pi, Pj) tuple for multivar separation.
     """
     vo = v.orthogonal
     uo = u.orthogonal
@@ -573,18 +589,15 @@ def inner_bilinear(
         else:
             scale *= float(aii)  # ty:ignore[invalid-argument-type]
 
-    z = None
+    z: Matrix | None = None
     if len(scale) == 1 and use_precomputed_matrices and not multivar:
         # Look up matrix
         mod = importlib.import_module(vo.__class__.__module__)
-        z = mod.matrices((vo, i), (uo, j))
-        if z is None:
-            pass
-        else:
+        z: MatrixProtocol | None = mod.matrices((vo, i), (uo, j))
+        if z is not None:
             s = scale * df ** (i + j - 1)
             if s.item() != 1:
                 z.data = z.data * s
-            z = z.todense()
 
     if z is None:
         w = wj * df ** (i + j - 1) * scale
@@ -596,18 +609,19 @@ def inner_bilinear(
             multj: Array = u.apply_stencil_right(jnp.conj(Pj))
             return multi, multj
 
-        z = matmat(Pi.T * w[None, :], jnp.conj(Pj))
+        z: Matrix = Matrix(matmat(Pi.T * w[None, :], jnp.conj(Pj)))
 
-    if u == v and isinstance(u, Composite):
+    z: MatrixProtocol = cast(MatrixProtocol, z)
+    if isinstance(v, Composite) and u == v:
         z = v.apply_stencil_galerkin(z)
     elif isinstance(v, Composite) and isinstance(u, Composite):
-        z = v.apply_stencils_petrovgalerkin(z, u.S)
+        z = v.apply_stencils_petrovgalerkin(z, u.ST)
     elif isinstance(v, Composite):
         z = v.apply_stencil_left(z)
     elif isinstance(u, Composite):
         z = u.apply_stencil_right(z)
 
-    return Matrix(z)
+    return z
 
 
 def inner_linear(

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -25,7 +25,7 @@ import sympy as sp
 
 from jaxfun.basespace import BaseSpace
 from jaxfun.coordinates import CoordSys
-from jaxfun.la import DiaMatrix, diags
+from jaxfun.la import DiaMatrix, Matrix, MatrixProtocol, diags
 from jaxfun.typing import Array, MeshKind
 from jaxfun.utils.common import Domain, jacn, jit_vmap, lambdify
 
@@ -236,22 +236,36 @@ class OrthogonalSpace(BaseSpace):
             wj = wj * sg
         return (u * wj) @ jnp.conj(Pi)  # Truncated to (self.N,)
 
-    @jax.jit(static_argnums=0)
-    def apply_stencil_galerkin(self, b: Array) -> Array:
+    @overload
+    def apply_stencil_galerkin(self, b: Matrix) -> Matrix: ...
+    @overload
+    def apply_stencil_galerkin(self, b: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def apply_stencil_galerkin(self, b: MatrixProtocol) -> MatrixProtocol: ...
+    def apply_stencil_galerkin(self, b: MatrixProtocol) -> MatrixProtocol:
         """Apply (left,right) stencil in Galerkin case (identity here)."""
         return b
 
-    @jax.jit(static_argnums=0)
-    def apply_stencils_petrovgalerkin(self, b: Array, P: DiaMatrix) -> Array:
+    @overload
+    def apply_stencils_petrovgalerkin(self, b: Matrix, PT: DiaMatrix) -> Matrix: ...
+    @overload
+    def apply_stencils_petrovgalerkin(
+        self, b: DiaMatrix, PT: DiaMatrix
+    ) -> DiaMatrix: ...
+    @overload
+    def apply_stencils_petrovgalerkin(
+        self, b: MatrixProtocol, PT: DiaMatrix
+    ) -> MatrixProtocol: ...
+    def apply_stencils_petrovgalerkin(
+        self, b: MatrixProtocol, PT: DiaMatrix
+    ) -> MatrixProtocol:
         """Apply trial stencil only (identity left) for Petrov–Galerkin."""
-        return b @ P.T
+        return b @ PT
 
-    @jax.jit(static_argnums=0)
     def apply_stencil_left(self, b: Array) -> Array:
         """Apply test-side stencil (identity in pure orthogonal space)."""
         return b
 
-    @jax.jit(static_argnums=0)
     def apply_stencil_right(self, a: Array) -> Array:
         """Apply trial-side stencil (identity in pure orthogonal space)."""
         return a

--- a/src/jaxfun/la/__init__.py
+++ b/src/jaxfun/la/__init__.py
@@ -5,3 +5,4 @@ from .diamatrix import (
 )
 from .matrix import Matrix as Matrix
 from .matrixprotocol import MatrixProtocol as MatrixProtocol
+from .pinned import PinnedSystem as PinnedSystem

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -405,7 +405,11 @@ class DiaMatrix(nnx.Pytree):
             band_lu = _lu_banded_no_pivot_kernel(band, p, q, center)
 
             if float(jnp.min(jnp.abs(band_lu[center]))) == 0.0:
-                raise ValueError("Matrix is singular: zero pivot in LU factorisation.")
+                raise ValueError(
+                    "Matrix is singular: zero pivot in LU factorisation. "
+                    "Consider pinning (:meth:`DiaMatrix.pin`) additional DOFs or "
+                    "enabling pivoting for this matrix."
+                )
 
             l_offsets = tuple(
                 off
@@ -460,7 +464,11 @@ class DiaMatrix(nnx.Pytree):
 
         # Singularity check: the main diagonal of U lives at band row `center`.
         if float(jnp.min(jnp.abs(band_lu[center]))) == 0.0:
-            raise ValueError("Matrix is singular: zero pivot in LU factorisation.")
+            raise ValueError(
+                "Matrix is singular: zero pivot in LU factorisation. "
+                "Consider pinning (:meth:`DiaMatrix.pin`) additional DOFs "
+                "for this matrix."
+            )
 
         # ---------- extract L -------------------------------------------
         # band_lu[center - t, :] is already the column-aligned DIA row for

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import jax
 import jax.numpy as jnp
@@ -9,8 +9,8 @@ from flax import nnx
 
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
-
-    from .matrix import Matrix
+    from jaxfun.la import Matrix, MatrixProtocol
+    from jaxfun.la.pinned import PinnedSystem
 
 Array = jax.Array
 
@@ -106,10 +106,6 @@ class DiaMatrix(nnx.Pytree):
             no-pivot and pivoting factorisations are cached independently.
             Stored via ``object.__setattr__`` so it is invisible to JAX's
             pytree machinery and does not affect JIT tracing or compilation.
-        _T_cache: Private ``_CacheBox`` wrapping the transposed DiaMatrix,
-            populated on the first call to the :attr:`T` property.
-            Stored via ``object.__setattr__``, invisible to JAX's pytree
-            machinery.
 
     Example (tridiagonal 3x3):
     >>> import jax.numpy as jnp
@@ -241,19 +237,69 @@ class DiaMatrix(nnx.Pytree):
         return jnp.moveaxis(y_moved, 0, axis)
 
     @jax.jit(static_argnums=(2,))
-    def matmat(self, x: Array, axis: int = 0) -> Array:
-        """Multiply ``A @ x`` where ``x.shape[axis] == m``.
+    def rmatvec(self, x: Array, axis: int = -1) -> Array:
+        """Multiply ``x @ A`` contracting ``axis`` of ``x`` against rows of ``A``.
 
-        This is a convenience alias for :meth:`matvec` that makes it
-        explicit that ``x`` is treated as a collection of column vectors.
-        Equivalent to ``self.matvec(x, axis=axis)``.
+        Symmetric dual of :meth:`matvec`: where ``matvec`` maps column indices
+        of ``A`` to row indices, ``rmatvec`` maps row indices of ``A`` to
+        column indices.
+
+        Args:
+            x: Input array.  ``x.shape[axis]`` must equal ``n``
+                   (number of rows of ``A``).
+            axis:  The axis of ``x`` to contract.  The output has the same
+                   shape as ``x`` except ``shape[axis]`` becomes ``m``
+                   (number of columns of ``A``).
+
+        For a 1-D ``x`` the ``axis`` argument is ignored.
+
+        Examples::
+
+            A.rmatvec(x)  # x shape (n,)      → (m,)
+            A.rmatvec(X, axis=-1)  # X shape (k, n)    → (k, m)
+            A.rmatvec(X, axis=0)  # X shape (n, k)    → (m, k)
+
+        Implementation note:
+            ``y[j] = Σ_p data[p, j] * x[j - k_p]``.  Pad ``x`` by
+            ``(m-1, m-1)`` zeros so that
+            ``dynamic_slice(x_pad, (m-1) - k, m)`` always lands in-bounds
+            for any offset ``k ∈ [-(n-1), m-1]``.
         """
-        return self.matvec(x, axis=axis)
+        n, m = self.shape
+        offsets_arr = jnp.array(self.offsets, dtype=int)
 
-    @jax.jit(static_argnums=(2,))
-    def apply(self, x: Array, axis: int = 0) -> Array:
-        """Apply ``A`` along ``axis`` of ``x`` (alias for :meth:`matvec`)."""
-        return self.matvec(x, axis=axis)
+        if x.ndim == 1:
+            # y[j] = sum_p data[p,j] * x[j - k_p]
+            x_pad = jnp.pad(x, (m - 1, m - 1))  # length n + 2(m-1)
+
+            def _extract_1d(args: tuple) -> Array:
+                v_row, k = args
+                sliced = jax.lax.dynamic_slice(x_pad, ((m - 1) - k,), (m,))
+                return v_row * sliced
+
+            contribs = jax.vmap(_extract_1d)((self.data, offsets_arr))  # (n_diags, m)
+            return contribs.sum(axis=0)
+
+        axis = axis % x.ndim
+        x_moved = jnp.moveaxis(x, axis, -1)  # (..., n)
+        rest_shape = x_moved.shape[:-1]
+        batch = x_moved.size // n
+        x2d = x_moved.reshape(batch, n)  # (batch, n)
+
+        # Pad last axis: (batch, n) → (batch, n + 2(m-1))
+        x_pad = jnp.pad(x2d, ((0, 0), (m - 1, m - 1)))
+
+        def _extract_nd(args: tuple) -> Array:
+            v_row, k = args  # v_row: (m,), k: scalar
+            sliced = jax.lax.dynamic_slice(x_pad, (0, (m - 1) - k), (batch, m))
+            return v_row[None, :] * sliced  # (batch, m)
+
+        contribs = jax.vmap(_extract_nd)(
+            (self.data, offsets_arr)
+        )  # (n_diags, batch, m)
+        result2d = contribs.sum(axis=0)  # (batch, m)
+        result_moved = result2d.reshape(rest_shape + (m,))
+        return jnp.moveaxis(result_moved, -1, axis)
 
     @jax.jit
     def todense(self) -> Array:
@@ -280,6 +326,12 @@ class DiaMatrix(nnx.Pytree):
 
     # Alias so DiaMatrix satisfies MatrixProtocol (which uses to_dense).
     to_dense = todense
+
+    def to_Matrix(self) -> Matrix:
+        """Convert this DiaMatrix to a dense Matrix."""
+        from .matrix import Matrix
+
+        return Matrix(self.todense())
 
     def lu_factor(self, *, pivot: bool = False) -> LUFactors:
         """Compute a banded LU factorisation of this (square) matrix.
@@ -503,22 +555,12 @@ class DiaMatrix(nnx.Pytree):
         Shape becomes ``(m, n)``.  Each diagonal at offset ``k`` maps to
         offset ``-k`` in the transpose.  The data is re-aligned to the new
         column count ``n``.
-
-        The result is cached as ``_T_cache`` (a :class:`_CacheBox`) via
-        ``object.__setattr__`` so it is invisible to JAX's pytree machinery.
-        Repeated calls always return the same transposed instance.
         """
-        cached: DiaMatrix | None = getattr(self, "_T_cache", None)
-        if cached is not None:
-            return cached.value
-
         n, m = self.shape
+        new_offsets = tuple(-k for k in self.offsets)
         new_shape = (m, n)
 
         def _transpose_row(d: Array, k: Array) -> Array:
-            # Original: data[d] has length m, valid at columns [max(0,k), max(0,k)+length).  # noqa: E501
-            # Transposed offset is -k; new data has length n.
-            # new_data[i] = old_data[i + k]  for 0 <= i < n and 0 <= i+k < m.
             i = jnp.arange(n)
             j = i + k  # original column index
             valid = (j >= 0) & (j < m)
@@ -526,11 +568,8 @@ class DiaMatrix(nnx.Pytree):
             return jnp.where(valid, d[safe_j], jnp.zeros((), dtype=d.dtype))
 
         offsets_arr = jnp.asarray(self.offsets, dtype=int)
-        new_data = jax.vmap(_transpose_row)(self.data, offsets_arr)  # (n_diags, n)
-        new_offsets = tuple(-k for k in self.offsets)
-        result = DiaMatrix(data=new_data, offsets=new_offsets, shape=new_shape)
-        object.__setattr__(self, "_T_cache", _CacheBox(result))
-        return result
+        new_data = jax.vmap(_transpose_row)(self.data, offsets_arr)
+        return DiaMatrix(data=new_data, offsets=new_offsets, shape=new_shape)
 
     def diagonal(self, k: int = 0) -> Array:
         """Return the ``k``-th diagonal as a 1-D array.
@@ -925,27 +964,38 @@ class DiaMatrix(nnx.Pytree):
         q_offs = other.offsets
 
         # Build all (Q, l) column-index arrays in one shot.
-        # a_cols[q, j] = j - q_off[q]  — the A-column needed at output column j
+        # a_cols[q, j] = j - q_off[q]  — the A-column (= B-row) needed at output col j
         j = jnp.arange(l)
+        p_offs_arr = jnp.array(p_offs)  # (P,)
         a_cols = j[None, :] - jnp.array(q_offs)[:, None]  # (Q, l)
-        valid = (a_cols >= 0) & (a_cols < m)  # (Q, l)
-        safe_a_cols = jnp.where(valid, a_cols, 0)  # (Q, l)
+        col_valid = (a_cols >= 0) & (a_cols < m)  # (Q, l): B-row / A-column in bounds
+        safe_a_cols = jnp.where(col_valid, a_cols, 0)  # (Q, l)
+
+        # Row-validity: self.data[p, a_col] represents A[a_col - p_off, a_col].
+        # That row must also be in [0, n) — padding values outside the band must not
+        # contribute even if they are non-zero.
+        # a_rows[p, q, j] = a_cols[q, j] - p_off[p]  — row index of A accessed
+        a_rows = a_cols[None, :, :] - p_offs_arr[:, None, None]  # (P, Q, l)
+        row_valid = (a_rows >= 0) & (a_rows < n)  # (P, Q, l)
 
         # Gather: contribs[p, q, j] = self.data[p, safe_a_cols[q, j]] * other.data[q, j]
         # self.data[:, safe_a_cols] has shape (P, Q, l) via advanced indexing.
         contribs = jnp.where(
-            valid[None],
+            col_valid[None] & row_valid,
             self.data[:, safe_a_cols] * other.data[None],
             jnp.zeros((), dtype=self.data.dtype),
         )  # (P, Q, l)
 
         # Group output-diagonal offsets in Python (static, no JAX graph nodes).
+        # Only include offsets within the valid range for an (n, l) matrix.
         from collections import defaultdict
 
         groups: dict[int, list[tuple[int, int]]] = defaultdict(list)
         for pi, po in enumerate(p_offs):
             for qi, qo in enumerate(q_offs):
-                groups[po + qo].append((pi, qi))
+                out_off = po + qo
+                if -(n - 1) <= out_off <= l - 1:
+                    groups[out_off].append((pi, qi))
 
         if not groups:
             return jnp.zeros((1, l), dtype=self.data.dtype), (0,), (n, l)
@@ -962,10 +1012,14 @@ class DiaMatrix(nnx.Pytree):
     @overload
     def __matmul__(self, other: Array) -> Array: ...
     @overload
+    def __matmul__(self, other: JAXFunction) -> Array: ...
+    @overload
     def __matmul__(self, other: DiaMatrix) -> DiaMatrix: ...
     @overload
-    def __matmul__(self, other: JAXFunction) -> Array: ...
-    def __matmul__(self, other: Array | DiaMatrix | JAXFunction) -> Array | DiaMatrix:
+    def __matmul__(self, other: Matrix) -> Matrix: ...
+    @overload
+    def __matmul__(self, other: MatrixProtocol) -> MatrixProtocol: ...
+    def __matmul__(self, other: Array | JAXFunction | MatrixProtocol) -> Any:
         """Support ``A @ x`` (vector/matrix) and ``A @ B`` (DiaMatrix).
 
         DiaMatrix x DiaMatrix is computed purely in DIA format without
@@ -973,12 +1027,18 @@ class DiaMatrix(nnx.Pytree):
 
         """
         from jaxfun.galerkin import JAXFunction
+        from jaxfun.la import Matrix
 
         if isinstance(other, JAXFunction):
-            return self.apply(other.array)
+            return self.matvec(other.array)
 
-        if not isinstance(other, DiaMatrix):
-            return self.apply(other)
+        if isinstance(other, Array):
+            return self.matvec(other)
+
+        if isinstance(other, Matrix):
+            return Matrix(self.matvec(other.data))
+
+        assert isinstance(other, DiaMatrix)
 
         data_out, offsets_out, shape_out = self._matmul_compute(other)
         return DiaMatrix(
@@ -987,55 +1047,47 @@ class DiaMatrix(nnx.Pytree):
             shape=(int(shape_out[0]), int(shape_out[1])),
         )
 
-    def __rmatmul__(self, other: Array) -> Array:
+    @overload
+    def __rmatmul__(self, other: Array) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: JAXFunction) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __rmatmul__(self, other: Matrix) -> Matrix: ...
+    @overload
+    def __rmatmul__(self, other: MatrixProtocol) -> MatrixProtocol: ...
+    def __rmatmul__(self, other: Array | JAXFunction | MatrixProtocol) -> Any:
         """Support ``x @ A`` (row-vector or matrix on the left).
 
-        Computes ``x @ A`` directly from DIA storage using the same
-        ``vmap + lax.dynamic_slice`` technique as :meth:`matvec`, avoiding
-        per-diagonal Python loop nodes in the JAX trace.
-
-        For diagonal at offset ``k``:  ``A[j-k, j] = data[k_idx, j]``, so the
-        contribution to output column ``j`` is ``data[k_idx, j] * other[..., j-k]``.
-
-        Padding strategy (dual of matvec):
-            Pad ``other`` (axis ``n``) by ``(m-1)`` zeros on each side so that
-            ``dynamic_slice(other_pad, m-1-k, m)`` always lands in-bounds for
-            any offset ``k ∈ [-(n-1), m-1]``.
-
-        Works for 1-D and N-D ``other`` (contracting axis is the last axis).
+        Delegates to :meth:`rmatvec` which contracts the last axis of ``other``
+        against the rows of ``A`` using the same sparse ``dynamic_slice + vmap``
+        technique as :meth:`matvec`, without materialising a dense matrix or
+        computing the transpose.
         """
-        n, m = self.shape
-        dtype = jnp.result_type(other.dtype, self.data.dtype)
-        offsets_arr = jnp.array(self.offsets, dtype=int)
+        from jaxfun.galerkin import JAXFunction
+        from jaxfun.la import Matrix
 
-        if other.ndim == 1:
-            # other shape (n,) → result shape (m,)
-            # x_pad[m-1-k + j] = other[j-k]  for j in [0, m)
-            x_pad = jnp.pad(other.astype(dtype), (m - 1, m - 1))  # (n + 2m - 2,)
+        if isinstance(other, JAXFunction):
+            return self.rmatvec(other.array, axis=-1)
 
-            def _extract_1d(k: Array) -> Array:
-                x_shifted = jax.lax.dynamic_slice(x_pad, (m - 1 - k,), (m,))
-                return x_shifted  # (m,)
+        if isinstance(other, Array):
+            return self.rmatvec(other, axis=-1)
 
-            x_shifted_all = jax.vmap(_extract_1d)(offsets_arr)  # (n_diags, m)
-            return (x_shifted_all * self.data.astype(dtype)).sum(axis=0)
+        # NOTE: unreachable via @ when both operands are concrete DiaMatrix/Matrix
+        # instances — Matrix.__matmul__ and DiaMatrix.__matmul__ both handle those
+        # cases first. These branches act as fallbacks for subclasses that do not
+        # override __matmul__.
+        if isinstance(other, Matrix):
+            return Matrix(other.data @ self)
 
-        # other shape (..., n) → result shape (..., m)
-        batch_shape = other.shape[:-1]
-        batch = other[..., 0].size
-        x2d = other.reshape(batch, n).astype(dtype)  # (batch, n)
-        x_pad = jnp.pad(x2d, ((0, 0), (m - 1, m - 1)))  # (batch, n+2m-2)
-
-        def _extract_nd(k: Array) -> Array:
-            return jax.lax.dynamic_slice(
-                x_pad, (0, m - 1 - k), (batch, m)
-            )  # (batch, m)
-
-        x_shifted_all = jax.vmap(_extract_nd)(offsets_arr)  # (n_diags, batch, m)
-        res2d = (x_shifted_all * self.data[:, None, :].astype(dtype)).sum(
-            axis=0
-        )  # (batch, m)
-        return res2d.reshape(batch_shape + (m,))
+        assert isinstance(other, DiaMatrix)
+        data_out, offsets_out, shape_out = other._matmul_compute(self)
+        return DiaMatrix(
+            data=data_out,
+            offsets=tuple(int(k) for k in offsets_out),
+            shape=(int(shape_out[0]), int(shape_out[1])),
+        )
 
     def astype(self, dtype: jnp.dtype) -> DiaMatrix:
         """Return a copy with data cast to ``dtype``."""
@@ -1055,6 +1107,69 @@ class DiaMatrix(nnx.Pytree):
     @property
     def dtype(self) -> jnp.dtype:
         return self.data.dtype
+
+    def pin(self, constraints: dict[int, float]) -> PinnedSystem:
+        """Return a :class:`PinnedSystem` with the given DOFs fixed.
+
+        For each ``(row_index, value)`` pair in *constraints* the corresponding
+        row of the matrix is replaced by the identity row ``e_{row_index}``.
+        The original sparsity pattern is preserved; if the main diagonal
+        (offset 0) is not already stored it is added automatically.
+
+        The LU factorisation of the modified matrix is cached on the returned
+        :class:`PinnedSystem` so that repeated :meth:`~PinnedSystem.solve`
+        calls are cheap.
+
+        Args:
+            constraints: Mapping from DOF index to pinned value, e.g.
+                ``{0: 0.0}`` or ``{0: 0.0, -1: 1.0}``.  Negative indices
+                are supported (Python-style, relative to ``n``).
+
+        Returns:
+            :class:`PinnedSystem` whose :meth:`~PinnedSystem.solve` method
+            modifies the RHS and solves in one call.
+
+        Example::
+
+            A_sys = A.pin({0: 0.0})  # singular Fourier system
+            x = A_sys.solve(b)
+        """
+        import numpy as np
+
+        from jaxfun.la.pinned import PinnedSystem
+
+        n, m = self.shape
+        d_np = np.array(self.data)
+        offsets: list[int] = list(self.offsets)
+
+        # Ensure the main diagonal is present so we can write A[i,i] = 1.
+        if 0 not in offsets:
+            insert_pos = next(
+                (k for k, off in enumerate(offsets) if off > 0), len(offsets)
+            )
+            offsets.insert(insert_pos, 0)
+            d_np = np.insert(d_np, insert_pos, np.zeros(m, dtype=d_np.dtype), axis=0)
+
+        main_idx = offsets.index(0)
+
+        # Normalise negative indices.
+        norm_constraints: dict[int, float] = {
+            (idx % n): val for idx, val in constraints.items()
+        }
+
+        for row_idx, _val in norm_constraints.items():
+            # Zero all stored entries in this row: A[row_idx, row_idx + k].
+            for di, k in enumerate(offsets):
+                j = row_idx + k
+                if 0 <= j < m:
+                    d_np[di, j] = 0.0
+            # Set diagonal entry to 1.
+            d_np[main_idx, row_idx] = 1.0
+
+        new_offsets = tuple(offsets)
+        new_data = jnp.array(d_np)
+        pinned_matrix = DiaMatrix(data=new_data, offsets=new_offsets, shape=self.shape)
+        return PinnedSystem(pinned_matrix, norm_constraints)
 
     def __repr__(self) -> str:
         n, m = self.shape
@@ -1356,7 +1471,7 @@ def _forward_elimination(L: DiaMatrix, b: Array) -> Array:
     l_rows: list[Array] = []
     for s in range(1, p + 1):  # s = 1, 2, ..., p
         off = -s
-        if off in offsets:
+        if off in offsets and s < n:
             idx = offsets.index(off)
             d = L.data[idx]
             # d[j] = L[j+s, j]; shift right by s → l_rows[-1][i] = L[i, i-s]
@@ -1421,10 +1536,10 @@ def _backward_substitution(U: DiaMatrix, b: Array) -> Array:
     u_rows: list[Array] = []
     for s in range(1, q + 1):  # s = 1, 2, ..., q
         off = s
-        if off in offsets:
+        if off in offsets and s < n:
             idx = offsets.index(off)
             d = U.data[idx]
-            # d[i+s] = U[i, i+s]; shift left by s: d[s:] ++ zeros(s)
+            # d[i+s] = U[i, i+s]; shift left by s: d[s:n] ++ zeros(s)
             u_rows.append(jnp.concatenate([d[s:n], jnp.zeros(s, dtype=d.dtype)]))
         else:
             u_rows.append(jnp.zeros(n, dtype=U.data.dtype))
@@ -1559,6 +1674,10 @@ def diakron(A: DiaMatrix, B: DiaMatrix) -> DiaMatrix:
         for kb_idx, k_b in enumerate(B.offsets):
             b_row = B.data[kb_idx]  # shape (p,)
             K = int(k_a) * p + int(k_b)
+            # Skip diagonals entirely outside the result matrix.
+            result_n = m * p
+            if result_n <= K or -result_n >= K:
+                continue
             col_data: Array = (a_row[:, None] * b_row[None, :]).ravel()
             if K in accumulated:
                 accumulated[K] = accumulated[K] + col_data

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1123,7 +1123,9 @@ class DiaMatrix(nnx.Pytree):
         Args:
             constraints: Mapping from DOF index to pinned value, e.g.
                 ``{0: 0.0}`` or ``{0: 0.0, -1: 1.0}``.  Negative indices
-                are supported (Python-style, relative to ``n``).
+                are supported (Python-style, relative to ``n``).  Positive
+                indices must be in ``[0, n)``, otherwise :exc:`IndexError`
+                is raised.
 
         Returns:
             :class:`PinnedSystem` whose :meth:`~PinnedSystem.solve` method
@@ -1134,41 +1136,47 @@ class DiaMatrix(nnx.Pytree):
             A_sys = A.pin({0: 0.0})  # singular Fourier system
             x = A_sys.solve(b)
         """
-        import numpy as np
-
         from jaxfun.la.pinned import PinnedSystem
 
         n, m = self.shape
-        d_np = np.array(self.data)
+        data = self.data  # keep as JAX array — no device→host transfer
         offsets: list[int] = list(self.offsets)
 
         # Ensure the main diagonal is present so we can write A[i,i] = 1.
+        # The structural decision (whether to insert) uses only static ints.
         if 0 not in offsets:
             insert_pos = next(
                 (k for k, off in enumerate(offsets) if off > 0), len(offsets)
             )
             offsets.insert(insert_pos, 0)
-            d_np = np.insert(d_np, insert_pos, np.zeros(m, dtype=d_np.dtype), axis=0)
+            zero_row = jnp.zeros((1, m), dtype=data.dtype)
+            data = jnp.concatenate(
+                [data[:insert_pos], zero_row, data[insert_pos:]], axis=0
+            )
 
         main_idx = offsets.index(0)
 
-        # Normalise negative indices.
-        norm_constraints: dict[int, float] = {
-            (idx % n): val for idx, val in constraints.items()
-        }
+        # Normalise negative indices (Python-style); reject out-of-range positives.
+        norm_constraints: dict[int, float] = {}
+        for idx, val in constraints.items():
+            if idx < -n or idx >= n:
+                raise IndexError(
+                    f"Constraint index {idx} is out of range for matrix of size {n}"
+                )
+            norm_constraints[idx % n] = val
 
+        # Zero every stored entry in each pinned row, then set diagonal to 1.
+        # All indices (di, j) are Python ints — static at trace time — so
+        # .at[...].set() is fully traceable under jax.jit / jax.vmap.
         for row_idx, _val in norm_constraints.items():
-            # Zero all stored entries in this row: A[row_idx, row_idx + k].
             for di, k in enumerate(offsets):
                 j = row_idx + k
                 if 0 <= j < m:
-                    d_np[di, j] = 0.0
-            # Set diagonal entry to 1.
-            d_np[main_idx, row_idx] = 1.0
+                    data = data.at[di, j].set(0.0)
+            data = data.at[main_idx, row_idx].set(1.0)
 
         new_offsets = tuple(offsets)
-        new_data = jnp.array(d_np)
-        pinned_matrix = DiaMatrix(data=new_data, offsets=new_offsets, shape=self.shape)
+        pinned_matrix = DiaMatrix(data=data, offsets=new_offsets, shape=self.shape)
         return PinnedSystem(pinned_matrix, norm_constraints)
 
     def __repr__(self) -> str:
@@ -1667,6 +1675,8 @@ def diakron(A: DiaMatrix, B: DiaMatrix) -> DiaMatrix:
     # and result.data[K_idx, j] = A.data[ka_idx, j0] * B.data[kb_idx, j1],
     # i.e. the ravel of the outer product A.data[ka, :] ⊗ B.data[kb, :].
     result_shape = (m * p, n * p)
+    result_rows = m * p  # valid negative-offset bound: -(result_rows - 1)
+    result_cols = n * p  # valid positive-offset bound:  (result_cols - 1)
     accumulated: dict[int, Array] = {}
 
     for ka_idx, k_a in enumerate(A.offsets):
@@ -1675,8 +1685,9 @@ def diakron(A: DiaMatrix, B: DiaMatrix) -> DiaMatrix:
             b_row = B.data[kb_idx]  # shape (p,)
             K = int(k_a) * p + int(k_b)
             # Skip diagonals entirely outside the result matrix.
-            result_n = m * p
-            if result_n <= K or -result_n >= K:
+            # The result has shape (result_rows, result_cols), so valid
+            # offsets are [-(result_rows - 1), result_cols - 1].
+            if result_cols <= K or -result_rows >= K:
                 continue
             col_data: Array = (a_row[:, None] * b_row[None, :]).ravel()
             if K in accumulated:

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -122,6 +122,11 @@ class Matrix(nnx.Pytree):
                 f"lu_factor requires a square matrix, got shape {self.shape}"
             )
         lu, piv = jax.scipy.linalg.lu_factor(self.data)
+        if float(jnp.min(jnp.abs(jnp.diag(lu)))) == 0.0:
+            raise ValueError(
+                "Matrix is singular: zero pivot in LU factorisation. "
+                "Consider pinning (:meth:`Matrix.pin`) additional DOFs."
+            )
         result = LUFactors(lu=lu, piv=piv, shape=(n, n))
         object.__setattr__(self, "_lu_cache", result)
         return result

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -8,6 +8,8 @@ from flax import nnx
 
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
+    from jaxfun.la import DiaMatrix
+    from jaxfun.la.pinned import PinnedSystem
 
 Array = jax.Array
 
@@ -94,16 +96,6 @@ class Matrix(nnx.Pytree):
         y_moved = y2d.reshape((n,) + rest_shape)
         return jnp.moveaxis(y_moved, 0, axis)
 
-    @jax.jit(static_argnums=(2,))
-    def matmat(self, X: Array, axis: int = 0) -> Array:
-        """Alias for :meth:`matvec` — multiply ``A`` along ``axis`` of ``X``."""
-        return self.matvec(X, axis=axis)
-
-    @jax.jit(static_argnums=(2,))
-    def apply(self, x: Array, axis: int = 0) -> Array:
-        """Apply ``A`` along ``axis`` of ``x`` (alias for :meth:`matvec`)."""
-        return self.matvec(x, axis=axis)
-
     def lu_factor(self) -> LUFactors:
         """Compute the LU factorisation of this (square) matrix.
 
@@ -155,6 +147,10 @@ class Matrix(nnx.Pytree):
     def solve(self, b: Array, axis: int = 0) -> Array:
         """Solve ``A x = b``.
 
+        The LU factorisation is cached on the first call (via
+        :meth:`lu_factor`) so repeated solves pay the factorisation cost only
+        once.
+
         Args:
             b:    Right-hand side array.  ``b.shape[axis]`` must equal ``n``.
             axis: The axis of ``b`` along which the system is solved.  All
@@ -167,19 +163,7 @@ class Matrix(nnx.Pytree):
             A.solve(B, axis=1)  # B shape (k, n)    → (k, n)
             A.solve(T, axis=2)  # T shape (a, b, n) → (a, b, n)
         """
-        n = self.shape[0]
-
-        if b.ndim == 1:
-            return jnp.linalg.solve(self.data, b)
-
-        axis = axis % b.ndim
-        b_moved = jnp.moveaxis(b, axis, 0)  # (n, *rest)
-        rest_shape = b_moved.shape[1:]
-        batch = b_moved.size // n
-        b2d = b_moved.reshape(n, batch)  # (n, batch)
-        x2d = jnp.linalg.solve(self.data, b2d)  # (n, batch)
-        x_moved = x2d.reshape((n,) + rest_shape)
-        return jnp.moveaxis(x_moved, 0, axis)
+        return self.lu_factor().solve(b, axis=axis)
 
     @property
     def T(self) -> Matrix:
@@ -256,35 +240,109 @@ class Matrix(nnx.Pytree):
     @overload
     def __matmul__(self, other: Array) -> Array: ...
     @overload
+    def __matmul__(self, other: JAXFunction) -> Array: ...
+    @overload
     def __matmul__(self, other: Matrix) -> Matrix: ...
     @overload
-    def __matmul__(self, other: JAXFunction) -> Array: ...
-    def __matmul__(self, other: Array | Matrix | JAXFunction) -> Array | Matrix:
+    def __matmul__(self, other: DiaMatrix) -> Matrix: ...
+    def __matmul__(
+        self, other: Array | JAXFunction | Matrix | DiaMatrix
+    ) -> Array | Matrix:
         """Support ``A @ x`` (vector/array) and ``A @ B`` (Matrix)."""
         from jaxfun.galerkin import JAXFunction
-
-        if isinstance(other, Matrix):
-            n, m = self.shape
-            if m != other.shape[0]:
-                raise ValueError(
-                    f"Shape mismatch for matrix product: ({n}, {m}) @ {other.shape}"
-                )
-            return Matrix(self.data @ other.data)
+        from jaxfun.la import DiaMatrix
+        from jaxfun.utils.common import matmat
 
         if isinstance(other, JAXFunction):
-            return self @ other.array
+            return matmat(self.data, other.array)
 
-        return self.apply(other)
+        if isinstance(other, Array):
+            return matmat(self.data, other)
 
-    def __rmatmul__(self, other: Array) -> Array:
+        if isinstance(other, DiaMatrix):
+            return Matrix((other.T.matvec(self.data.T)).T)  # matvec returns dense array
+
+        assert isinstance(other, Matrix)
+        n, m = self.shape
+        if m != other.shape[0]:
+            raise ValueError(
+                f"Shape mismatch for matrix product: ({n}, {m}) @ {other.shape}"
+            )
+        return Matrix(matmat(self.data, other.data))
+
+    @overload
+    def __rmatmul__(self, other: Array) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: JAXFunction) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: Matrix) -> Matrix: ...
+    @overload
+    def __rmatmul__(self, other: DiaMatrix) -> Matrix: ...
+    def __rmatmul__(
+        self, other: Array | JAXFunction | Matrix | DiaMatrix
+    ) -> Array | Matrix:
         """Support ``x @ A`` (row-vector or 2-D array on the left)."""
-        if other.ndim == 1:
-            return self.data.T @ other
-        return other @ self.data
+        from jaxfun.galerkin import JAXFunction
+        from jaxfun.la import DiaMatrix
+        from jaxfun.utils.common import matmat
+
+        if isinstance(other, JAXFunction):
+            return matmat(other.array, self.data)
+
+        if isinstance(other, Array):
+            return matmat(other, self.data)
+
+        # NOTE: unreachable via @ when both operands are concrete DiaMatrix/Matrix
+        # instances — DiaMatrix.__matmul__ handles DiaMatrix @ Matrix, and
+        # Matrix.__matmul__ handles Matrix @ Matrix. These branches act as
+        # fallbacks for subclasses that do not override __matmul__.
+        if isinstance(other, DiaMatrix):
+            return Matrix(other.matvec(self.data))  # matvec returns dense array
+
+        assert isinstance(other, Matrix)
+        return Matrix(matmat(other.data, self.data))
 
     def astype(self, dtype: jnp.dtype) -> Matrix:
         """Return a copy with data cast to ``dtype``."""
         return Matrix(self.data.astype(dtype))
+
+    def pin(self, constraints: dict[int, float]) -> PinnedSystem:
+        """Return a :class:`PinnedSystem` with the given DOFs fixed.
+
+        For each ``(row_index, value)`` pair in *constraints* the
+        corresponding row of the dense matrix is replaced by the identity
+        row ``e_{row_index}``.
+
+        The LU factorisation of the modified matrix is cached on the returned
+        :class:`PinnedSystem` so that repeated :meth:`~PinnedSystem.solve`
+        calls are cheap.
+
+        Args:
+            constraints: Mapping from DOF index to pinned value, e.g.
+                ``{0: 0.0}`` or ``{0: 0.0, -1: 1.0}``.  Negative indices
+                are supported (Python-style, relative to ``n``).
+
+        Returns:
+            :class:`PinnedSystem` whose :meth:`~PinnedSystem.solve` method
+            modifies the RHS and solves in one call.
+
+        Example::
+
+            A_sys = A.pin({0: 0.0})
+            x = A_sys.solve(b)
+        """
+        from jaxfun.la.pinned import PinnedSystem
+
+        n, _m = self.shape
+        # Normalise negative indices.
+        norm_constraints: dict[int, float] = {
+            (idx % n): val for idx, val in constraints.items()
+        }
+        data = self.data
+        for idx in norm_constraints:
+            data = data.at[idx].set(0.0)
+            data = data.at[idx, idx].set(1.0)
+        return PinnedSystem(Matrix(data), norm_constraints)
 
     def __repr__(self) -> str:
         n, m = self.shape

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -320,7 +320,9 @@ class Matrix(nnx.Pytree):
         Args:
             constraints: Mapping from DOF index to pinned value, e.g.
                 ``{0: 0.0}`` or ``{0: 0.0, -1: 1.0}``.  Negative indices
-                are supported (Python-style, relative to ``n``).
+                are supported (Python-style, relative to ``n``).  Positive
+                indices must be in ``[0, n)``, otherwise :exc:`IndexError`
+                is raised.
 
         Returns:
             :class:`PinnedSystem` whose :meth:`~PinnedSystem.solve` method
@@ -334,10 +336,14 @@ class Matrix(nnx.Pytree):
         from jaxfun.la.pinned import PinnedSystem
 
         n, _m = self.shape
-        # Normalise negative indices.
-        norm_constraints: dict[int, float] = {
-            (idx % n): val for idx, val in constraints.items()
-        }
+        # Normalise negative indices (Python-style); reject out-of-range positives.
+        norm_constraints: dict[int, float] = {}
+        for idx, val in constraints.items():
+            if idx < -n or idx >= n:
+                raise IndexError(
+                    f"Constraint index {idx} is out of range for matrix of size {n}"
+                )
+            norm_constraints[idx % n] = val
         data = self.data
         for idx in norm_constraints:
             data = data.at[idx].set(0.0)

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import jax
 import jax.numpy as jnp
@@ -36,6 +36,8 @@ class MatrixProtocol(Protocol):
         assert isinstance(A_sparse, MatrixProtocol)
     """
 
+    data: Array
+
     @property
     def shape(self) -> tuple[int, int]:
         """``(n, m)`` shape of the matrix."""
@@ -57,14 +59,6 @@ class MatrixProtocol(Protocol):
         ``x.shape[axis]`` must equal ``m``; the output has the same shape as
         ``x`` except ``shape[axis]`` becomes ``n``.
         """
-        ...
-
-    def matmat(self, X: Array, axis: int = 0) -> Array:
-        """Alias for :meth:`matvec` treating ``X`` as a batch of column vectors."""
-        ...
-
-    def apply(self, x: Array, axis: int = 0) -> Array:
-        """Apply ``A`` along ``axis`` of ``x`` (alias for :meth:`matvec`)."""
         ...
 
     def solve(self, b: Array, axis: int = 0) -> Array:
@@ -124,13 +118,8 @@ class MatrixProtocol(Protocol):
     def __len__(self) -> int: ...
     def __add__(self, other: MatrixProtocol) -> MatrixProtocol: ...
     def __sub__(self, other: MatrixProtocol) -> MatrixProtocol: ...
-    @overload
-    def __matmul__(self, other: Array) -> Array: ...
-    @overload
-    def __matmul__(self, other: MatrixProtocol) -> MatrixProtocol: ...
-    @overload
-    def __matmul__(self, other: JAXFunction) -> Array: ...
-    def __rmatmul__(self, other: Array) -> Array: ...
+    def __matmul__(self, other: Array | JAXFunction | MatrixProtocol) -> Any: ...
+    def __rmatmul__(self, other: Array | JAXFunction | MatrixProtocol) -> Any: ...
 
 
 @runtime_checkable

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -125,6 +125,70 @@ class PinnedSystem(nnx.Pytree):
         b_mod = self.fix_rhs(b, axis=axis)
         return self.matrix.solve(b_mod, axis=axis)
 
+    # ------------------------------------------------------------------
+    # Read-only delegation to the underlying modified matrix.
+    # These give PinnedSystem the inspection half of MatrixProtocol so
+    # it can be used wherever a read-only matrix view is expected.
+    # Arithmetic methods (scale, T, __add__, …) are intentionally *not*
+    # delegated because they would silently break the constraint structure.
+    # ------------------------------------------------------------------
+
+    @property
+    def ndim(self) -> int:
+        """Always 2."""
+        return self.matrix.ndim
+
+    @property
+    def dtype(self):
+        """Element dtype of the underlying matrix."""
+        return self.matrix.dtype
+
+    @property
+    def size(self) -> int:
+        """Number of explicitly stored entries in the underlying matrix."""
+        return self.matrix.size
+
+    def matvec(self, x: Array, axis: int = 0) -> Array:
+        """Apply the *modified* (row-substituted) matrix along ``axis`` of ``x``."""
+        return self.matrix.matvec(x, axis=axis)
+
+    def lu_solve(self, b: Array, axis: int = 0) -> Array:
+        """Solve using the cached LU factors (does **not** call :meth:`fix_rhs`).
+
+        Use :meth:`solve` for the full pinned solve that also fixes the RHS.
+        """
+        return self.matrix.lu_solve(b, axis=axis)
+
+    def diagonal(self, k: int = 0) -> Array:
+        """Return the ``k``-th diagonal of the modified matrix."""
+        return self.matrix.diagonal(k)
+
+    def to_dense(self) -> Array:
+        """Return the modified matrix as a dense array."""
+        return self.matrix.to_dense()
+
+    todense = to_dense
+
+    def get_row(self, i: int | Array) -> Array:
+        """Return row ``i`` of the modified matrix."""
+        return self.matrix.get_row(i)
+
+    def get_column(self, j: int | Array) -> Array:
+        """Return column ``j`` of the modified matrix."""
+        return self.matrix.get_column(j)
+
+    def astype(self, dtype) -> PinnedSystem:
+        """Return a copy with the underlying matrix cast to ``dtype``."""
+        from jaxfun.la.pinned import PinnedSystem  # local to avoid re-import issues
+
+        return PinnedSystem(self.matrix.astype(dtype), dict(self.constraints))
+
+    def __len__(self) -> int:
+        return min(self.shape)
+
+    def __getitem__(self, key):
+        return self.matrix[key]
+
     def __repr__(self) -> str:
         pins = ", ".join(f"{k}={v}" for k, v in self.constraints)
         return f"PinnedSystem(shape={self.shape}, constraints={{{pins}}})"

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -44,7 +44,7 @@ class PinnedSystem(nnx.Pytree):
         A_sys = A.pin({0: 0.0})  # row 0 → identity, pin value 0
         A_sys.lu_factor()  # optional explicit warm-up
 
-        # Repeated solves (hot path)
+        # Repeated solves
         for b in rhs_sequence:
             x = A_sys.solve(b)  # modifies b[0] then solves
 

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -1,0 +1,130 @@
+"""Pinned (constrained) linear system.
+
+Produced by :meth:`DiaMatrix.pin` and :meth:`Matrix.pin`.  Encapsulates
+both the row-substituted matrix and the constraint values so that the RHS
+can be consistently modified and the LU factorisation reused across calls.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import jax.numpy as jnp
+from flax import nnx
+
+if TYPE_CHECKING:
+    import jax
+
+    from jaxfun.la import DiaMatrix, Matrix
+
+    Array = jax.Array
+
+
+@nnx.dataclass
+class PinnedSystem(nnx.Pytree):
+    """A linear system with pinned (constrained) degrees of freedom.
+
+    Created by calling :meth:`~jaxfun.la.DiaMatrix.pin` or
+    :meth:`~jaxfun.la.Matrix.pin` on a matrix.  The underlying matrix has
+    its pinned rows replaced by identity rows (``A[i, :] = e_i``), and the
+    LU factorisation of that modified matrix is cached on the first
+    :meth:`solve` call and reused thereafter.
+
+    Attributes:
+        matrix: The row-substituted :class:`Matrix` or :class:`DiaMatrix`.
+            Treated as a JAX pytree child so the enclosed arrays are visible
+            to :func:`jax.jit`, :func:`jax.grad`, etc.
+        constraints: Immutable tuple of ``(index, value)`` pairs recording
+            the pinned DOFs.  Stored as static pytree metadata (not traced),
+            because constraint indices and values are compile-time constants.
+
+    Usage::
+
+        # One-time setup
+        A_sys = A.pin({0: 0.0})  # row 0 → identity, pin value 0
+        A_sys.lu_factor()  # optional explicit warm-up
+
+        # Repeated solves (hot path)
+        for b in rhs_sequence:
+            x = A_sys.solve(b)  # modifies b[0] then solves
+
+    Args:
+        matrix: The row-substituted :class:`Matrix` or :class:`DiaMatrix`.
+        constraints: Mapping from DOF index to pinned value
+            (e.g. ``{0: 0.0, -1: 1.0}``).  Converted to a tuple internally.
+    """
+
+    matrix: Matrix | DiaMatrix
+    constraints: tuple[tuple[int, float], ...]
+
+    def __init__(
+        self,
+        matrix: Matrix | DiaMatrix,
+        constraints: dict[int, float],
+    ) -> None:
+        self.matrix = matrix
+        # Store as a sorted tuple so the pytree treedef is deterministic and
+        # hashable (dicts are neither).
+        self.constraints = tuple(sorted(constraints.items()))
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """``(n, n)`` shape of the underlying matrix."""
+        return self.matrix.shape
+
+    def lu_factor(self):
+        """Pre-compute and cache the LU factorisation.
+
+        Calling this explicitly before the loop avoids paying the
+        factorisation cost on the first :meth:`solve` call.
+        """
+        return self.matrix.lu_factor()
+
+    def fix_rhs(self, b: Array, axis: int = 0) -> Array:
+        """Return ``b`` with constraint values inserted at pinned positions.
+
+        For each ``(index, value)`` pair in the constraints, the slice of
+        ``b`` at position ``index`` along ``axis`` is set to ``value``.
+
+        Args:
+            b:    Right-hand side array.
+            axis: Axis of ``b`` corresponding to the DOF dimension.
+
+        Returns:
+            Modified array with the same shape as ``b``.
+
+        Examples::
+
+            # 1-D:  b[0] = 0.0
+            b_mod = sys.fix_rhs(b)
+
+            # 2-D row-major batch (k, n), axis=1:  b[:, 0] = 0.0
+            b_mod = sys.fix_rhs(b, axis=1)
+        """
+        axis = axis % b.ndim
+        b_moved = jnp.moveaxis(b, axis, 0)  # pinned axis → front
+        for idx, val in self.constraints:
+            b_moved = b_moved.at[idx].set(val)
+        return jnp.moveaxis(b_moved, 0, axis)
+
+    def solve(self, b: Array, axis: int = 0) -> Array:
+        """Modify the RHS and solve the pinned system.
+
+        Applies :meth:`fix_rhs` to ``b`` then solves using the cached LU
+        factorisation of the modified matrix.
+
+        Args:
+            b:    Right-hand side array.  ``b.shape[axis]`` must equal ``n``.
+            axis: Axis of ``b`` along which the system is solved.  All other
+                  axes are treated as independent batch dimensions.  The
+                  output has the same shape as ``b``.
+
+        Returns:
+            Solution array with the same shape as ``b``.
+        """
+        b_mod = self.fix_rhs(b, axis=axis)
+        return self.matrix.solve(b_mod, axis=axis)
+
+    def __repr__(self) -> str:
+        pins = ", ".join(f"{k}={v}" for k, v in self.constraints)
+        return f"PinnedSystem(shape={self.shape}, constraints={{{pins}}})"

--- a/src/jaxfun/utils/__init__.py
+++ b/src/jaxfun/utils/__init__.py
@@ -2,7 +2,6 @@ from .common import (
     Domain as Domain,
     diff as diff,
     diffx as diffx,
-    fromdense as fromdense,
     jacn as jacn,
     lambdify as lambdify,
     matmat as matmat,

--- a/src/jaxfun/utils/common.py
+++ b/src/jaxfun/utils/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Concatenate, NamedTuple, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, Concatenate, NamedTuple, Protocol, cast
 
 import jax
 import jax.numpy as jnp
@@ -28,7 +28,6 @@ __all__ = (
     "jacn",
     "matmat",
     "tosparse",
-    "fromdense",
     "lambdify",
 )
 
@@ -120,16 +119,8 @@ def jacn(fun: Callable[[Array], Array], k: int = 1) -> Callable[[Array], Array]:
     return jax.vmap(fun, in_axes=0, out_axes=0)
 
 
-@overload
-def matmat(a: Array, b: Array) -> Array: ...
-@overload
-def matmat(a: DiaMatrix, b: DiaMatrix) -> DiaMatrix: ...
-@overload
-def matmat(a: Array, b: DiaMatrix) -> Array: ...  # unchecked
-@overload
-def matmat(a: DiaMatrix, b: Array) -> Array: ...  # unchecked
 @jax.jit
-def matmat(a: Array | DiaMatrix, b: Array | DiaMatrix) -> Array | DiaMatrix:
+def matmat(a: Array, b: Array) -> Array:
     return a @ b
 
 
@@ -137,11 +128,6 @@ def matmat(a: Array | DiaMatrix, b: Array | DiaMatrix) -> Array | DiaMatrix:
 def eliminate_near_zeros(a: Array, tol: int = 100) -> Array:
     atol: Array = ulp(jnp.abs(a).max()) * tol
     return jnp.where(jnp.abs(a) < atol, jnp.zeros(a.shape), a)
-
-
-def fromdense(a: Array, tol: int = 100) -> DiaMatrix:
-    a0: Array = eliminate_near_zeros(a, tol=tol)
-    return DiaMatrix.from_dense(a0)
 
 
 def tosparse(a: Array, tol: int = 100) -> DiaMatrix:

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -147,9 +147,9 @@ def test_jaxfunction_2d(space: type[OrthogonalSpace], domain: Domain | None):
     uf = JAXFunction(jnp.ones((N, N)), T)
     b0 = A[0].mat @ uf.array.ravel()
     b1 = A[0].mats[0] @ uf @ A[0].mats[1].T
-    assert jnp.linalg.norm(b0 - b1.ravel()) < ulp(100)
+    assert jnp.linalg.norm(b0 - b1.ravel()) < ulp(10)
     z = inner(uf * v)
-    assert jnp.linalg.norm(z.ravel() - b0) < ulp(100)
+    assert jnp.linalg.norm(z.ravel() - b0) < ulp(10)
 
 
 def test_jaxfunction_directsum_2d(jspace: type[Jacobi.Jacobi], domain: Domain | None):
@@ -163,11 +163,11 @@ def test_jaxfunction_directsum_2d(jspace: type[Jacobi.Jacobi], domain: Domain | 
     w = JAXFunction(jnp.ones(T.num_dofs), T, name="uf")
     b0 = A[0] @ w - b
     b1 = inner(v * w)
-    assert jnp.linalg.norm(b0 - b1) < ulp(100)
+    assert jnp.linalg.norm(b0 - b1) < jnp.sqrt(ulp(1))
     C, c = inner(Div(Grad(u)) * v)
     b0 = TPMatrices(C) @ w - c
     b1 = inner(v * Div(Grad(w)))
-    assert jnp.linalg.norm(b0 - b1) < ulp(100)
+    assert jnp.linalg.norm(b0 - b1) < jnp.sqrt(ulp(1))
 
 
 def test_jaxfunction_diff_2d(space: type[OrthogonalSpace], domain: Domain | None):

--- a/tests/galerkin/test_precomputed_matrices.py
+++ b/tests/galerkin/test_precomputed_matrices.py
@@ -23,12 +23,8 @@ from jaxfun.galerkin.ChebyshevU import ChebyshevU, matrices as chebU_matrices
 from jaxfun.galerkin.Fourier import Fourier, matrices as fourier_matrices
 from jaxfun.galerkin.Legendre import Legendre, matrices as leg_matrices
 from jaxfun.galerkin.Ultraspherical import Ultraspherical, matrices as ultra_matrices
-from jaxfun.la import DiaMatrix
+from jaxfun.la import DiaMatrix, MatrixProtocol
 from jaxfun.utils.common import ulp
-
-# ---------------------------------------------------------------------------
-# Space factory helpers
-# ---------------------------------------------------------------------------
 
 
 def _cheb(N: int) -> Chebyshev:
@@ -97,8 +93,8 @@ class TestPoly5ReturnType:
         i, j = ij
         v = space_fn(8)
         M = mats((v, i), (v, j))
-        assert isinstance(M, DiaMatrix), (
-            f"expected DiaMatrix for ({i},{j}), got {type(M)}"
+        assert isinstance(M, MatrixProtocol), (
+            f"expected MatrixProtocol for ({i},{j}), got {type(M)}"
         )
 
     @pytest.mark.parametrize("ij", _POLY5_SUPPORTED)
@@ -229,31 +225,6 @@ class TestPoly5SecondDerivativeMatrix:
         assert M is not None
         assert jnp.allclose(M.get_column(0), jnp.zeros(N), atol=ulp(10))
         assert jnp.allclose(M.get_column(1), jnp.zeros(N), atol=ulp(10))
-
-
-# ---------------------------------------------------------------------------
-# Chebyshev-specific: sparsity structure of derivative matrices
-# ---------------------------------------------------------------------------
-
-
-class TestChebyshevOffsets:
-    """Chebyshev derivative matrices have characteristic offset patterns."""
-
-    def test_first_deriv_offsets_are_odd(self):
-        N = 9
-        v = _cheb(N)
-        M = cheb_matrices((v, 0), (v, 1))
-        assert M is not None
-        for off in M.offsets:
-            assert off % 2 == 1, f"expected odd offset, got {off}"
-
-    def test_second_deriv_offsets_are_even_positive(self):
-        N = 9
-        v = _cheb(N)
-        M = cheb_matrices((v, 0), (v, 2))
-        assert M is not None
-        for off in M.offsets:
-            assert off % 2 == 0 and off >= 0, f"unexpected offset {off}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -1008,6 +1008,22 @@ class TestPin:
         sys_pos = A.pin({4: 2.0})
         assert sys_neg.constraints == sys_pos.constraints
 
+    @pytest.mark.parametrize("use_matrix", [False, True])
+    def test_out_of_range_positive_raises(self, use_matrix):
+        """Positive indices >= n must raise IndexError, not silently wrap."""
+        a, A = _tridiag(5)
+        mat = a if use_matrix else A
+        with pytest.raises(IndexError, match="out of range"):
+            mat.pin({5: 0.0})
+
+    @pytest.mark.parametrize("use_matrix", [False, True])
+    def test_out_of_range_negative_raises(self, use_matrix):
+        """Indices < -n must raise IndexError."""
+        a, A = _tridiag(5)
+        mat = a if use_matrix else A
+        with pytest.raises(IndexError, match="out of range"):
+            mat.pin({-6: 0.0})
+
     def test_shape_preserved(self):
         _, A = _tridiag(7)
         sys = A.pin({0: 0.0})
@@ -1090,6 +1106,22 @@ class TestPin:
         row0 = sys.matrix.get_row(0)
         expected = jnp.zeros(5).at[0].set(1.0)
         assert jnp.allclose(row0, expected)
+
+    def test_pin_data_stays_on_device(self):
+        """pin() must not force a device→host transfer; result should be a JAX array."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert isinstance(sys.matrix.data, jax.Array)
+
+    def test_pin_callable_inside_jit(self):
+        """solve() inside jax.jit must work once the LU cache is warmed up."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        sys.lu_factor()  # warm up the LU cache outside JIT
+        b = jnp.array([0.0, 1.0, 1.0, 1.0, 1.0])
+        x_jit = jax.jit(lambda b: sys.solve(b))(b)
+        x_ref = sys.solve(b)
+        assert jnp.allclose(x_jit, x_ref, atol=ulp(100))
 
     # ------------------------------------------------------------------
     # fix_rhs
@@ -1214,3 +1246,69 @@ class TestPin:
         lu_after_second = sys.lu_factor()
         assert lu_after_first is lu_after_second
         assert jnp.allclose(x1, x2)
+
+    # ------------------------------------------------------------------
+    # Delegation / read-only MatrixProtocol surface
+    # ------------------------------------------------------------------
+
+    def test_ndim(self):
+        _, A = _tridiag(5)
+        assert A.pin({0: 0.0}).ndim == 2
+
+    def test_dtype_matches_matrix(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert sys.dtype == A.dtype
+
+    def test_size_matches_matrix(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert sys.size == sys.matrix.size
+
+    def test_matvec_delegates(self):
+        """sys.matvec(x) must equal the modified matrix's matvec."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        x = jnp.arange(5, dtype=float)
+        assert jnp.allclose(sys.matvec(x), sys.matrix.matvec(x))
+
+    def test_diagonal_delegates(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert jnp.allclose(sys.diagonal(), sys.matrix.diagonal())
+
+    def test_to_dense_delegates(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert jnp.allclose(sys.to_dense(), sys.matrix.to_dense())
+        assert jnp.allclose(sys.todense(), sys.matrix.todense())
+
+    def test_get_row_delegates(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        for i in range(5):
+            assert jnp.allclose(sys.get_row(i), sys.matrix.get_row(i))
+
+    def test_get_column_delegates(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        for j in range(5):
+            assert jnp.allclose(sys.get_column(j), sys.matrix.get_column(j))
+
+    def test_len(self):
+        _, A = _tridiag(7)
+        assert len(A.pin({0: 0.0})) == 7
+
+    def test_getitem(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        # Pinned row i=0: only diagonal entry should be 1.
+        assert float(sys[0, 0]) == pytest.approx(1.0)
+        assert float(sys[0, 1]) == pytest.approx(0.0)
+
+    def test_astype_preserves_constraints(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0, 4: 1.0})
+        sys64 = sys.astype(jnp.float64)
+        assert sys64.constraints == sys.constraints
+        assert sys64.shape == sys.shape

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -12,6 +12,8 @@ import scipy.sparse
 
 from jaxfun.la.diamatrix import DenseIndexingWarning, DiaMatrix, LUFactors, diags
 from jaxfun.la.matrix import Matrix
+from jaxfun.la.pinned import PinnedSystem
+from jaxfun.utils.common import ulp
 
 
 def _tridiag(n: int) -> tuple[Matrix, DiaMatrix]:
@@ -493,8 +495,8 @@ class TestMatvecAxis:
         rng = np.random.default_rng(7)
         X = jnp.array(rng.standard_normal((6, 5)))
         expected = a @ X
-        assert jnp.allclose(A.matvec(X, axis=0), expected, atol=1e-5)
-        assert jnp.allclose(a.matvec(X, axis=0), expected, atol=1e-5)
+        assert jnp.allclose(A.matvec(X, axis=0), expected, atol=ulp(100))
+        assert jnp.allclose(a.matvec(X, axis=0), expected, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_axis1_2d(self, mat):
@@ -503,8 +505,8 @@ class TestMatvecAxis:
         rng = np.random.default_rng(8)
         X = jnp.array(rng.standard_normal((5, 6)))  # (batch, m)
         expected = (a @ X.T).T  # (n, batch) → (batch, n)
-        assert jnp.allclose(A.matvec(X, axis=1), expected, atol=1e-5)
-        assert jnp.allclose(a.matvec(X, axis=1), expected, atol=1e-5)
+        assert jnp.allclose(A.matvec(X, axis=1), expected, atol=ulp(100))
+        assert jnp.allclose(a.matvec(X, axis=1), expected, atol=ulp(100))
 
     def test_axis_1d_ignores_axis(self):
         """For 1-D input the axis argument is irrelevant."""
@@ -521,8 +523,8 @@ class TestMatvecAxis:
         # Expected: contract axis 0 with A
         # result[i, j, k] = sum_l A[i, l] * T[l, j, k]
         expected = jnp.einsum("il,ljk->ijk", a.data, T)
-        assert jnp.allclose(A.matvec(T, axis=0), expected, atol=1e-5)
-        assert jnp.allclose(a.matvec(T, axis=0), expected, atol=1e-5)
+        assert jnp.allclose(A.matvec(T, axis=0), expected, atol=ulp(100))
+        assert jnp.allclose(a.matvec(T, axis=0), expected, atol=ulp(100))
 
     def test_axis1_3d(self):
         """matvec(T, axis=1): T shape (b0, m, b2) → (b0, n, b2)."""
@@ -530,8 +532,8 @@ class TestMatvecAxis:
         rng = np.random.default_rng(10)
         T = jnp.array(rng.standard_normal((3, 4, 2)))
         expected = jnp.einsum("il,jlk->jik", a.data, T)
-        assert jnp.allclose(A.matvec(T, axis=1), expected, atol=1e-5)
-        assert jnp.allclose(a.matvec(T, axis=1), expected, atol=1e-5)
+        assert jnp.allclose(A.matvec(T, axis=1), expected, atol=ulp(100))
+        assert jnp.allclose(a.matvec(T, axis=1), expected, atol=ulp(100))
 
     def test_axis2_3d(self):
         """matvec(T, axis=2): T shape (b0, b1, m) → (b0, b1, n)."""
@@ -539,8 +541,8 @@ class TestMatvecAxis:
         rng = np.random.default_rng(11)
         T = jnp.array(rng.standard_normal((3, 2, 4)))
         expected = jnp.einsum("il,jkl->jki", a.data, T)
-        assert jnp.allclose(A.matvec(T, axis=2), expected, atol=1e-5)
-        assert jnp.allclose(a.matvec(T, axis=2), expected, atol=1e-5)
+        assert jnp.allclose(A.matvec(T, axis=2), expected, atol=ulp(100))
+        assert jnp.allclose(a.matvec(T, axis=2), expected, atol=ulp(100))
 
     def test_negative_axis(self):
         """Negative axis should work like numpy convention."""
@@ -625,9 +627,9 @@ class TestSolve:
         x_true = jnp.arange(1, 8, dtype=float)
         b = a @ x_true
         x_hat = A.solve(b)
-        assert jnp.allclose(x_hat, x_true, atol=1e-5)
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
         # Matrix.solve should give the same answer
-        assert jnp.allclose(a.solve(b), x_true, atol=1e-5)
+        assert jnp.allclose(a.solve(b), x_true, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_solve_residual(self, mat):
@@ -635,7 +637,7 @@ class TestSolve:
         rng = np.random.default_rng(42)
         b = jnp.array(rng.standard_normal(8))
         x = A.solve(b)
-        assert float(jnp.linalg.norm(A.matvec(x) - b)) < 1e-5
+        assert float(jnp.linalg.norm(A.matvec(x) - b)) < ulp(100)
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_solve_axis1(self, mat):
@@ -646,8 +648,8 @@ class TestSolve:
         B = (a @ X_true.T).T  # (4, 6)
         X_hat = A.solve(B, axis=1)
         assert X_hat.shape == (4, 6)
-        assert jnp.allclose(X_hat, X_true, atol=1e-5)
-        assert jnp.allclose(a.solve(B, axis=1), X_true, atol=1e-5)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
+        assert jnp.allclose(a.solve(B, axis=1), X_true, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_solve_axis_matches_matvec(self, mat):
@@ -661,7 +663,7 @@ class TestSolve:
             B = A.matvec(X, axis=ax)
             X_hat = A.solve(B, axis=ax)
             assert X_hat.shape == tuple(shape)
-            assert jnp.allclose(X_hat, X, atol=1e-5), f"failed for axis={ax}"
+            assert jnp.allclose(X_hat, X, atol=ulp(100)), f"failed for axis={ax}"
 
 
 class TestLU:
@@ -711,7 +713,7 @@ class TestLU:
         lu = A.lu_factor()
         LU = cast(DiaMatrix, lu.L @ lu.U)
         PA = a.todense() if lu.perm is None else a.todense()[lu.perm, :]
-        assert jnp.allclose(LU.todense(), PA, atol=1e-5)
+        assert jnp.allclose(LU.todense(), PA, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_exact(self, mat):
@@ -720,9 +722,9 @@ class TestLU:
         b = a @ x_true
         lu = A.lu_factor()
         x_hat = lu.solve(b)
-        assert jnp.allclose(x_hat, x_true, atol=1e-5)
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
         # Matrix.lu_solve should give the same result
-        assert jnp.allclose(a.lu_solve(b), x_true, atol=1e-5)
+        assert jnp.allclose(a.lu_solve(b), x_true, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_random_rhs(self, mat):
@@ -731,7 +733,7 @@ class TestLU:
         b = jnp.array(rng.standard_normal(8))
         lu = A.lu_factor()
         x = lu.solve(b)
-        assert float(jnp.linalg.norm(A.matvec(x) - b)) < 1e-5
+        assert float(jnp.linalg.norm(A.matvec(x) - b)) < ulp(100)
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_multiple_rhs(self, mat):
@@ -743,9 +745,9 @@ class TestLU:
         lu = A.lu_factor()
         X_hat = lu.solve(B)
         assert X_hat.shape == (6, 4)
-        assert jnp.allclose(X_hat, X_true, atol=1e-5)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
         # Matrix.solve should reproduce the same result
-        assert jnp.allclose(a.solve(B), X_true, atol=1e-5)
+        assert jnp.allclose(a.solve(B), X_true, atol=ulp(100))
 
     def test_lu_nonsquare_raises(self):
         A = diags(
@@ -784,12 +786,12 @@ class TestLU:
         # L @ U == P @ A
         PA = a if lu.perm is None else a[lu.perm, :]
         H = cast(DiaMatrix, lu.L @ lu.U)
-        assert jnp.allclose(H.todense(), PA, atol=1e-5)
+        assert jnp.allclose(H.todense(), PA, atol=ulp(100))
         # Solve A x = b
         x_true = jnp.array([1.0, 2.0, 3.0])
         b = a @ x_true
         x = lu.solve(b)
-        assert jnp.allclose(x, x_true, atol=1e-5)
+        assert jnp.allclose(x, x_true, atol=ulp(100))
 
     def test_lu_perm_attribute(self):
         """perm is None when no pivoting occurred; a JAX int array when it did."""
@@ -814,8 +816,8 @@ class TestLU:
         B_T = B.T  # (batch, n)
         X_hat = lu.solve(B_T, axis=1)
         assert X_hat.shape == (4, 6)
-        assert jnp.allclose(X_hat, X_true, atol=1e-5)
-        assert jnp.allclose(a.lu_solve(B_T, axis=1), X_true, atol=1e-5)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
+        assert jnp.allclose(a.lu_solve(B_T, axis=1), X_true, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_3d_axis(self, mat):
@@ -828,10 +830,10 @@ class TestLU:
         B = A.matvec(X_true, axis=1)
         X_hat = lu.solve(B, axis=1)
         assert X_hat.shape == (3, 5, 4)
-        assert jnp.allclose(X_hat, X_true, atol=1e-5)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
         # Matrix counterpart
-        assert jnp.allclose(a.lu_solve(B, axis=1), X_true, atol=1e-5)
-        assert jnp.allclose(a.solve(B, axis=1), X_true, atol=1e-5)
+        assert jnp.allclose(a.lu_solve(B, axis=1), X_true, atol=ulp(100))
+        assert jnp.allclose(a.solve(B, axis=1), X_true, atol=ulp(100))
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_axis_matches_matvec(self, mat):
@@ -846,13 +848,15 @@ class TestLU:
             B = A.matvec(X, axis=ax)
             X_hat = lu.solve(B, axis=ax)
             assert X_hat.shape == tuple(shape)
-            assert jnp.allclose(X_hat, X, atol=1e-5), f"DiaMatrix failed for axis={ax}"
+            assert jnp.allclose(X_hat, X, atol=ulp(100)), (
+                f"DiaMatrix failed for axis={ax}"
+            )
             # Matrix counterpart: a.matvec then a.solve / a.lu_solve
             B_dense = a.matvec(X, axis=ax)
-            assert jnp.allclose(a.solve(B_dense, axis=ax), X, atol=1e-5), (
+            assert jnp.allclose(a.solve(B_dense, axis=ax), X, atol=ulp(100)), (
                 f"Matrix.solve failed for axis={ax}"
             )
-            assert jnp.allclose(a.lu_solve(B_dense, axis=ax), X, atol=1e-5), (
+            assert jnp.allclose(a.lu_solve(B_dense, axis=ax), X, atol=ulp(100)), (
                 f"Matrix.lu_solve failed for axis={ax}"
             )
 
@@ -972,3 +976,241 @@ class TestGetColumn:
         # vmap over columns produces (m, n); transpose to (n, m) for comparison
         all_cols = jax.vmap(A.get_column)(jnp.arange(5))
         assert jnp.allclose(all_cols.T, A.todense())
+
+
+class TestPin:
+    """Tests for :meth:`DiaMatrix.pin`, :meth:`Matrix.pin`, and :class:`PinnedSystem`."""  # noqa: E501
+
+    # ------------------------------------------------------------------
+    # Construction and metadata
+    # ------------------------------------------------------------------
+
+    def test_pin_returns_pinned_system_dia(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        assert isinstance(sys, PinnedSystem)
+
+    def test_pin_returns_pinned_system_matrix(self):
+        a, _ = _tridiag(5)
+        sys = a.pin({0: 0.0})
+        assert isinstance(sys, PinnedSystem)
+
+    def test_constraints_stored_as_sorted_tuple(self):
+        _, A = _tridiag(6)
+        sys = A.pin({3: 1.0, 0: 0.0})
+        # Must be a tuple of 2-tuples, sorted by index.
+        assert sys.constraints == ((0, 0.0), (3, 1.0))
+
+    def test_negative_index_normalised(self):
+        """pin({-1: v}) should be equivalent to pin({n-1: v})."""
+        _, A = _tridiag(5)
+        sys_neg = A.pin({-1: 2.0})
+        sys_pos = A.pin({4: 2.0})
+        assert sys_neg.constraints == sys_pos.constraints
+
+    def test_shape_preserved(self):
+        _, A = _tridiag(7)
+        sys = A.pin({0: 0.0})
+        assert sys.shape == (7, 7)
+
+    def test_repr(self):
+        _, A = _tridiag(4)
+        sys = A.pin({0: 0.0})
+        r = repr(sys)
+        assert "PinnedSystem" in r
+        assert "0=0.0" in r
+
+    # ------------------------------------------------------------------
+    # Pytree structure
+    # ------------------------------------------------------------------
+
+    def test_is_pytree_registered(self):
+        """PinnedSystem must be a valid JAX pytree."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        leaves, treedef = jax.tree_util.tree_flatten(sys)
+        # Only the data array inside the matrix should be a leaf.
+        assert len(leaves) == 1
+        assert isinstance(leaves[0], jax.Array)
+
+    def test_pytree_round_trip(self):
+        """Unflatten should reproduce an identical PinnedSystem."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0, 4: 1.0})
+        leaves, treedef = jax.tree_util.tree_flatten(sys)
+        sys2 = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert sys2.constraints == sys.constraints
+        assert sys2.shape == sys.shape
+
+    def test_constraints_are_static(self):
+        """Constraint indices/values must live in the treedef, not leaves."""
+        _, A = _tridiag(5)
+        sys1 = A.pin({0: 0.0})
+        sys2 = A.pin({0: 1.0})
+        _, td1 = jax.tree_util.tree_flatten(sys1)
+        _, td2 = jax.tree_util.tree_flatten(sys2)
+        # Different constraint value → different treedef.
+        assert td1 != td2
+
+    # ------------------------------------------------------------------
+    # Row substitution — modified matrix checks
+    # ------------------------------------------------------------------
+
+    def test_pinned_row_is_identity_dia(self):
+        """After pin({i: v}), row i of the modified DiaMatrix must be e_i."""
+        _, A = _tridiag(5)
+        sys = A.pin({2: 3.0})
+        assert isinstance(sys.matrix, DiaMatrix)
+        row2 = sys.matrix.get_row(2)
+        expected = jnp.zeros(5).at[2].set(1.0)
+        assert jnp.allclose(row2, expected)
+
+    def test_pinned_row_is_identity_matrix(self):
+        """After pin({i: v}), row i of the modified Matrix must be e_i."""
+        a, _ = _tridiag(5)
+        sys = a.pin({2: 3.0})
+        assert isinstance(sys.matrix, Matrix)
+        row2 = sys.matrix.get_row(2)
+        expected = jnp.zeros(5).at[2].set(1.0)
+        assert jnp.allclose(row2, expected)
+
+    def test_other_rows_unchanged_dia(self):
+        """Rows not pinned must remain identical to the original."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        for i in (1, 2, 3, 4):
+            assert jnp.allclose(sys.matrix.get_row(i), A.get_row(i))
+
+    def test_pin_adds_main_diagonal_if_missing(self):
+        """pin() must not crash when the main diagonal is not stored."""
+        # Build a matrix with only off-diagonals (no main diagonal).
+        data = jnp.ones((2, 5))
+        A_no_main = DiaMatrix(data=data, offsets=(-1, 1), shape=(5, 5))
+        sys = A_no_main.pin({0: 0.0})
+        row0 = sys.matrix.get_row(0)
+        expected = jnp.zeros(5).at[0].set(1.0)
+        assert jnp.allclose(row0, expected)
+
+    # ------------------------------------------------------------------
+    # fix_rhs
+    # ------------------------------------------------------------------
+
+    def test_fix_rhs_1d(self):
+        _, A = _tridiag(5)
+        sys = A.pin({0: 7.0, 4: -3.0})
+        b = jnp.ones(5)
+        b_mod = sys.fix_rhs(b)
+        assert float(b_mod[0]) == pytest.approx(7.0)
+        assert float(b_mod[4]) == pytest.approx(-3.0)
+        # Interior values unchanged.
+        assert jnp.allclose(b_mod[1:4], jnp.ones(3))
+
+    def test_fix_rhs_2d_axis0(self):
+        """fix_rhs on a (n, k) array with axis=0 pins rows."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 9.0})
+        B = jnp.ones((5, 3))
+        B_mod = sys.fix_rhs(B, axis=0)
+        assert jnp.allclose(B_mod[0], 9.0 * jnp.ones(3))
+        assert jnp.allclose(B_mod[1:], jnp.ones((4, 3)))
+
+    def test_fix_rhs_2d_axis1(self):
+        """fix_rhs on a (k, n) array with axis=1 pins columns."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 9.0})
+        B = jnp.ones((3, 5))
+        B_mod = sys.fix_rhs(B, axis=1)
+        assert jnp.allclose(B_mod[:, 0], 9.0 * jnp.ones(3))
+        assert jnp.allclose(B_mod[:, 1:], jnp.ones((3, 4)))
+
+    # ------------------------------------------------------------------
+    # solve — correctness
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("use_matrix", [False, True])
+    def test_solve_1d_single_pin(self, use_matrix):
+        """Solving a tridiagonal system with one DOF pinned to zero."""
+        a, A = _tridiag(5)
+        mat = a if use_matrix else A
+        sys = mat.pin({0: 0.0})
+        # Build RHS from the true solution with x[0] = 0 imposed.
+        x_true = jnp.array([0.0, 1.0, 2.0, 1.0, 0.0])
+        b = A.matvec(x_true)  # use original A for matvec, not pinned
+        x_hat = sys.solve(b)
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
+
+    @pytest.mark.parametrize("use_matrix", [False, True])
+    def test_solve_1d_two_pins(self, use_matrix):
+        """Tridiagonal with both endpoints pinned."""
+        a, A = _tridiag(5)
+        mat = a if use_matrix else A
+        sys = mat.pin({0: 0.0, -1: 0.0})
+        x_true = jnp.array([0.0, 1.0, 1.5, 1.0, 0.0])
+        b = A.matvec(x_true)
+        x_hat = sys.solve(b)
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
+
+    @pytest.mark.parametrize("use_matrix", [False, True])
+    def test_solve_dia_matches_matrix(self, use_matrix):
+        """DiaMatrix.pin and Matrix.pin must give the same answer."""
+        a, A = _tridiag(6)
+        rng = np.random.default_rng(42)
+        b = jnp.array(rng.standard_normal(6))
+        x_dia = A.pin({0: 0.0}).solve(b)
+        x_mat = a.pin({0: 0.0}).solve(b)
+        assert jnp.allclose(x_dia, x_mat, atol=ulp(100))
+
+    # ------------------------------------------------------------------
+    # solve — axis argument
+    # ------------------------------------------------------------------
+
+    def test_solve_2d_axis0(self):
+        """solve(B, axis=0): each column of B is an independent RHS."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0, 4: 0.0})
+        rng = np.random.default_rng(7)
+        k = 4
+        # Build true solutions with pinned BCs satisfied.
+        X_true = jnp.array(rng.standard_normal((5, k)))
+        X_true = X_true.at[0].set(0.0).at[4].set(0.0)
+        B = jnp.array([A.matvec(X_true[:, j]) for j in range(k)]).T  # (5, k)
+        X_hat = sys.solve(B, axis=0)
+        assert X_hat.shape == (5, k)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
+
+    def test_solve_2d_axis1(self):
+        """solve(B, axis=1): each row of B is an independent RHS."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0, 4: 0.0})
+        rng = np.random.default_rng(8)
+        k = 3
+        X_true = jnp.array(rng.standard_normal((k, 5)))
+        X_true = X_true.at[:, 0].set(0.0).at[:, 4].set(0.0)
+        B = jnp.stack([A.matvec(X_true[j]) for j in range(k)])  # (k, 5)
+        X_hat = sys.solve(B, axis=1)
+        assert X_hat.shape == (k, 5)
+        assert jnp.allclose(X_hat, X_true, atol=ulp(100))
+
+    # ------------------------------------------------------------------
+    # LU caching
+    # ------------------------------------------------------------------
+
+    def test_lu_factor_cached(self):
+        """lu_factor() called twice should return the exact same object."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        lu1 = sys.lu_factor()
+        lu2 = sys.lu_factor()
+        assert lu1 is lu2
+
+    def test_solve_reuses_lu(self):
+        """Repeated solve() calls must not recompute the LU."""
+        _, A = _tridiag(5)
+        sys = A.pin({0: 0.0})
+        b = jnp.array([0.0, 1.0, 1.0, 1.0, 0.0])
+        x1 = sys.solve(b)
+        lu_after_first = sys.lu_factor()
+        x2 = sys.solve(b)
+        lu_after_second = sys.lu_factor()
+        assert lu_after_first is lu_after_second
+        assert jnp.allclose(x1, x2)

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -224,7 +224,7 @@ class TestMatvec:
     def test_matmat_shape(self, mat):
         _, A = mat(8)
         X = jnp.ones((8, 3))
-        Y = A.matmat(X)
+        Y = A @ X
         assert Y.shape == (8, 3)
 
     @pytest.mark.parametrize("mat", allmatrices)
@@ -232,15 +232,7 @@ class TestMatvec:
         a, A = mat(6)
         rng = np.random.default_rng(1)
         X = jnp.array(rng.standard_normal((6, 3)))
-        assert jnp.allclose(A.matmat(X), a @ X, atol=1e-6)
-
-    @pytest.mark.parametrize("mat", allmatrices)
-    def test_apply_dispatches(self, mat):
-        _, A = mat(8)
-        x = jnp.ones(8)
-        X = jnp.ones((8, 2))
-        assert A.apply(x).shape == (8,)
-        assert A.apply(X).shape == (8, 2)
+        assert jnp.allclose(A @ X, a @ X, atol=1e-6)
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_matmul_vector(self, mat):
@@ -273,6 +265,37 @@ class TestMatvec:
         a, A = mat(6)
         X = jnp.eye(6)
         assert jnp.allclose(X @ A, a.todense(), atol=1e-6)
+
+    @pytest.mark.parametrize("mat", allmatrices)
+    def test_rmatmul_2d_array_x_matrix(self, mat):
+        """Array (2-D) @ Matrix → Matrix.__rmatmul__(Array) 2-D path."""
+        a, A = mat(6)
+        rng = np.random.default_rng(42)
+        X = jnp.array(rng.standard_normal((4, 6)))
+        expected = X @ a.data
+        assert jnp.allclose(X @ a, expected, atol=1e-6)
+
+    @pytest.mark.parametrize("mat", allmatrices)
+    def test_matmul_dia_x_matrix(self, mat):
+        """DiaMatrix @ Matrix → DiaMatrix.__matmul__(Matrix) path."""
+        a, A = mat(6)
+        rng = np.random.default_rng(43)
+        B = Matrix(jnp.array(rng.standard_normal((6, 4))))
+        result = A @ B
+        expected = A.todense() @ B.data
+        assert isinstance(result, Matrix)
+        assert jnp.allclose(result.data, expected, atol=1e-6)
+
+    @pytest.mark.parametrize("mat", allmatrices)
+    def test_matmul_matrix_x_dia(self, mat):
+        """Matrix @ DiaMatrix → Matrix.__matmul__(DiaMatrix) path."""
+        a, A = mat(6)
+        rng = np.random.default_rng(44)
+        B = Matrix(jnp.array(rng.standard_normal((4, 6))))
+        result = B @ A
+        expected = B.data @ A.todense()
+        assert isinstance(result, Matrix)
+        assert jnp.allclose(result.data, expected, atol=1e-6)
 
 
 class TestTranspose:
@@ -541,13 +564,6 @@ class TestMatvecAxis:
         T = jnp.ones((6, 5))  # axis 0 has size m=6
         Y = A.matvec(T, axis=0)
         assert Y.shape == (4, 5)  # axis 0 now has size n=4
-
-    def test_apply_axis(self):
-        """apply() should forward the axis argument to matvec."""
-        a, A = _tridiag(4)
-        X = jnp.ones((4, 3))
-        assert jnp.allclose(A.apply(X, axis=0), A.matvec(X, axis=0))
-        assert jnp.allclose(A.apply(X.T, axis=1), A.matvec(X.T, axis=1))
 
 
 class TestAddSub:

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -155,6 +155,38 @@ class TestDiakron:
         # offsets = {k_a*5 + k_b} for k_a in {-1,0,1}, k_b in {-1,0,1} → 9 distinct
         assert len(K.offsets) == 9
 
+    def test_rectangular_A_wide(self):
+        """Rectangular A with n > m: positive offsets up to (n*p - 1) must be kept.
+
+        The old code used result_n = m*p for both bounds, which incorrectly
+        dropped valid positive-offset diagonals when n > m.
+        """
+        # A is 2×4 (wide), B is 3×3 square → result is 6×12.
+        # Valid offsets: [-(6-1), 12-1] = [-5, 11].
+        m, n, p = 2, 4, 3
+        A_dense = jnp.array([[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0]])
+        A = DiaMatrix.from_dense(A_dense)
+        B = _diag3(p)
+        K = diakron(A, B)
+        expected = jnp.kron(A_dense, np.array(B.todense()))
+        assert K.shape == (m * p, n * p)
+        assert jnp.allclose(K.todense(), expected, ulp(100))
+
+    def test_rectangular_A_tall(self):
+        """Rectangular A with m > n: negative offsets down to -(m*p - 1) must be kept."""  # noqa: E501
+        # A is 4×2 (tall), B is 3×3 → result is 12×6.
+        # Valid offsets: [-(12-1), 6-1] = [-11, 5].
+        m, n, p = 4, 2, 3
+        A_dense = jnp.array(
+            [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32
+        )
+        A = DiaMatrix.from_dense(A_dense)
+        B = _diag3(p)
+        K = diakron(A, B)
+        expected = jnp.kron(A_dense, np.array(B.todense()))
+        assert K.shape == (m * p, n * p)
+        assert jnp.allclose(K.todense(), expected, ulp(100))
+
 
 class TestTpmatsToKron:
     def test_poisson_matches_numpy_kron(self):

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -214,8 +214,11 @@ class TestTpmatsToKron:
     def test_biharmonic_matches_numpy_kron(self):
         """Same correctness check for higher-order (biharmonic) problem."""
         import jax
+        import pytest
 
-        jax.config.update("jax_enable_x64", True)
+        if not jax.config.x64_enabled:  # ty:ignore[unresolved-attribute]
+            pytest.skip("requires float64 (run with jax_enable_x64=True)")
+
         A, _ = _biharmonic_tpmats(N=10)
         C = tpmats_to_kron(A)
 

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -82,13 +82,9 @@ def test_eliminate_near_zeros(tol: float) -> None:
 
 def test_fromdense_and_tosparse() -> None:
     a = jnp.array([[1.0, 0.0], [0.0, 2.0]])
-    dia_fromdense = common.fromdense(a)
     dia_tosparse = common.tosparse(a)
     # Check type and values
-    assert isinstance(dia_fromdense, DiaMatrix)
     assert isinstance(dia_tosparse, DiaMatrix)
-
-    assert jnp.allclose(dia_fromdense.todense(), a)
     assert jnp.allclose(dia_tosparse.todense(), a)
 
 


### PR DESCRIPTION
## Summary

Explain the motivation for this change. Link related issues or discussions.

## Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] Other (describe):

## Description of Changes

Minor changes to Matrix/DiaMatrix for enhanced performance.

The new PinnedSystem can be used to solve with constraints. Like for the poisson1D_periodic.py demo.

>>> A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)

The matrix A is singular since A[0, 0] = 0. Pin A[0, 0] = 1 and use b[0] = 0.0 by pinning:

>>> A_pin = A.pin({0: 0.0})
>>> uh = A_pin.solve(b)

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [ ] Coverage does not decrease
- [x] Git history is clean (squash/fixup before merge)
