### PR TITLE
Solvers for tensorproductmatrices

### DIFF
--- a/examples/biharmonic2D.py
+++ b/examples/biharmonic2D.py
@@ -11,7 +11,7 @@ from jaxfun.galerkin.arguments import TestFunction, TrialFunction
 from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
-from jaxfun.galerkin.tensorproductspace import TensorProduct, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
@@ -40,8 +40,9 @@ ue = T.system.expr_psi_to_base_scalar(ue)
 
 A, b = inner(Div(Grad(Div(Grad(u)))) * v - Div(Grad(Div(Grad(ue)))) * v, sparse=True)
 
-C = tpmats_to_kron(A)
-uh = C.solve(b.flatten()).reshape(b.shape)
+uh = TPMatrices(A).solve(b)
+# C = tpmats_to_kron(A)
+# uh = C.solve(b.flatten()).reshape(b.shape)
 
 N = 100
 xj = T.mesh(kind="uniform", N=(N, N))
@@ -50,7 +51,7 @@ uej = lambdify((x, y), ue)(*xj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
-    assert error < ulp(C.data.max()), error
+    assert error < ulp(100), error
     sys.exit(1)
 
 print("Error =", error)

--- a/examples/biharmonic2D.py
+++ b/examples/biharmonic2D.py
@@ -8,9 +8,9 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from jaxfun.coordinates import x, y
 from jaxfun.galerkin.arguments import TestFunction, TrialFunction
-from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
+from jaxfun.galerkin.Legendre import Legendre
 from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
@@ -31,18 +31,16 @@ bcsy = {
     "right": {"D": ue.subs(y, 1), "N": ue.diff(y, 1).subs(y, 1)},
 }
 
-Dx = FunctionSpace(M, Chebyshev, scaling=n + 1, bcs=bcsx, name="Dx", fun_str="psi")
-Dy = FunctionSpace(M, Chebyshev, scaling=n + 1, bcs=bcsy, name="Dy", fun_str="phi")
+Dx = FunctionSpace(M, Legendre, scaling=n + 1, bcs=bcsx, name="Dx", fun_str="psi")
+Dy = FunctionSpace(M, Legendre, scaling=n + 1, bcs=bcsy, name="Dy", fun_str="phi")
 T = TensorProduct(Dx, Dy, name="T")
 v = TestFunction(T, name="v")
 u = TrialFunction(T, name="u")
 ue = T.system.expr_psi_to_base_scalar(ue)
 
 A, b = inner(Div(Grad(Div(Grad(u)))) * v - Div(Grad(Div(Grad(ue)))) * v, sparse=True)
-
-uh = TPMatrices(A).solve(b)
-# C = tpmats_to_kron(A)
-# uh = C.solve(b.flatten()).reshape(b.shape)
+B = TPMatrices(A)
+uh = B.solve(b, method="kron", kron_method="rcm")
 
 N = 100
 xj = T.mesh(kind="uniform", N=(N, N))

--- a/examples/helmholtz2D.py
+++ b/examples/helmholtz2D.py
@@ -14,7 +14,7 @@ from jaxfun.galerkin.functionspace import FunctionSpace
 
 # from jaxfun.Jacobi import Jacobi as space
 from jaxfun.galerkin.inner import inner
-from jaxfun.galerkin.tensorproductspace import TensorProduct, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 
 # from jaxfun.galerkin.Legendre import Legendre as space
 from jaxfun.operators import Div, Grad
@@ -42,8 +42,8 @@ A, L = inner(
     v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True, sparse_tol=1000
 )
 
-A0 = tpmats_to_kron(A)
-un = A0.solve(L.flatten()).reshape(L.shape)
+A0 = TPMatrices(A)
+un = A0.solve(L)
 
 N = 100
 uj = T.backward(un, kind="uniform", N=(N, N))

--- a/examples/helmholtz2D.py
+++ b/examples/helmholtz2D.py
@@ -9,14 +9,14 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from jaxfun.coordinates import x, y
 from jaxfun.galerkin.arguments import TestFunction, TrialFunction
-from jaxfun.galerkin.Chebyshev import Chebyshev as space
+
+# from jaxfun.galerkin.Chebyshev import Chebyshev as space
 from jaxfun.galerkin.functionspace import FunctionSpace
 
 # from jaxfun.Jacobi import Jacobi as space
 from jaxfun.galerkin.inner import inner
+from jaxfun.galerkin.Legendre import Legendre as space
 from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
-
-# from jaxfun.galerkin.Legendre import Legendre as space
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
@@ -38,10 +38,10 @@ u = TrialFunction(T, name="u")
 # Method of manufactured solution
 ue = T.system.expr_psi_to_base_scalar(ue)
 
-A, L = inner(
-    v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True, sparse_tol=1000
-)
+A, L = inner(v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True)
 
+# C = tpmats_to_kron(A)
+# un = C.solve(L.flatten()).reshape(L.shape)
 A0 = TPMatrices(A)
 un = A0.solve(L)
 

--- a/examples/helmholtz2D.py
+++ b/examples/helmholtz2D.py
@@ -40,10 +40,8 @@ ue = T.system.expr_psi_to_base_scalar(ue)
 
 A, L = inner(v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True)
 
-# C = tpmats_to_kron(A)
-# un = C.solve(L.flatten()).reshape(L.shape)
-A0 = TPMatrices(A)
-un = A0.solve(L)
+B = TPMatrices(A)
+un = B.solve(L, method="kron", kron_method="banded")
 
 N = 100
 uj = T.backward(un, kind="uniform", N=(N, N))

--- a/examples/poisson2D.py
+++ b/examples/poisson2D.py
@@ -12,7 +12,7 @@ from jaxfun.galerkin.Chebyshev import Chebyshev as space
 # from jaxfun.galerkin.Legendre import Legendre as space
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
-from jaxfun.galerkin.tensorproductspace import TensorProduct, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
@@ -30,8 +30,7 @@ ue = (1 - x**2) * (1 - y**2)  # * sp.exp(sp.cos(sp.pi * x)) * sp.exp(sp.sin(sp.p
 # A, b = inner(-Dot(Grad(u), Grad(v)) - v * Div(Grad(ue)), sparse=False)
 A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
 
-C = tpmats_to_kron(A)
-uh = C.solve(b.flatten()).reshape(b.shape)
+uh = TPMatrices(A).solve(b)
 
 N = 100
 uj = T.backward(uh, kind="uniform", N=(N, N))

--- a/examples/poisson2D_curv.py
+++ b/examples/poisson2D_curv.py
@@ -12,7 +12,7 @@ from jaxfun.galerkin.arguments import TestFunction, TrialFunction
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.Legendre import Legendre
-from jaxfun.galerkin.tensorproductspace import TensorProduct, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
@@ -36,10 +36,10 @@ ue = (1 - r) * (sp.S.Half - r) * theta * (sp.pi / 2 - theta)
 
 # Assemble linear system of equations
 # A, b = inner(-Dot(Grad(u), Grad(v)) + v * Div(Grad(ue)), sparse=False)
-A, b = inner((v * Div(Grad(u)) - v * Div(Grad(ue))), sparse=False)
+A, b = inner((v * Div(Grad(u)) - v * Div(Grad(ue))), sparse=True)
 
-A0 = tpmats_to_kron(A)
-uh = A0.solve(b.flatten()).reshape(b.shape)
+A0 = TPMatrices(A)
+uh = A0.solve(b)
 
 rj, tj = T.mesh(kind="uniform", N=(100, 100))
 xc, yc = T.cartesian_mesh(kind="uniform", N=(100, 100))

--- a/examples/poisson2D_periodic.py
+++ b/examples/poisson2D_periodic.py
@@ -12,7 +12,7 @@ from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
-from jaxfun.galerkin.tensorproductspace import TensorProduct, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
@@ -31,11 +31,10 @@ x, y = T.system.base_scalars()
 ue = T.system.expr_psi_to_base_scalar(ue)
 
 # A, b = inner(-Dot(Grad(u), Grad(v)) - v * Div(Grad(ue)), sparse=False)
-A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=False)
+A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
 
-# Alternative scipy sparse implementation
-A0 = tpmats_to_kron(A)
-uh = A0.solve(b.flatten()).reshape(b.shape)
+A0 = TPMatrices(A)
+uh = A0.solve(b)
 
 N = 100
 uj = T.backward(uh, N=(N, N))

--- a/examples/poisson2D_periodic.py
+++ b/examples/poisson2D_periodic.py
@@ -8,10 +8,10 @@ import sympy as sp
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from jaxfun.galerkin.arguments import TestFunction, TrialFunction, x, y
-from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.inner import inner
+from jaxfun.galerkin.Legendre import Legendre
 from jaxfun.galerkin.tensorproductspace import TensorProduct, TPMatrices
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
@@ -20,7 +20,7 @@ ue = (1 - y**2) * (sp.cos(2 * x)) * sp.exp(sp.cos(sp.pi * y))
 
 M, N = 80, 20
 bcs = {"left": {"D": ue.subs(y, -1)}, "right": {"D": ue.subs(y, 1)}}
-D = FunctionSpace(M, Chebyshev, bcs, scaling=n + 1, name="D", fun_str="psi")
+D = FunctionSpace(M, Legendre, bcs, scaling=n + 1, name="D", fun_str="psi")
 F = FunctionSpace(N, Fourier, name="F", fun_str="E")
 T = TensorProduct(F, D, name="T")
 v = TestFunction(T, name="v")
@@ -43,7 +43,7 @@ uej = lambdify((x, y), ue)(*xj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
-    assert error < ulp(1000), error
+    assert error < ulp(100), error
     sys.exit(1)
 
 print("Error =", error)

--- a/src/jaxfun/galerkin/Fourier.py
+++ b/src/jaxfun/galerkin/Fourier.py
@@ -213,6 +213,22 @@ class Fourier(OrthogonalSpace):
         m = self.wavenumbers(eliminate_highest_freq=k % 2 == 1)
         return (1j * m) ** k * c
 
+    @jax.jit(static_argnums=(0, 1, 2))
+    def mesh(
+        self, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
+    ) -> Array:
+        """Return (periodic) sampling mesh in true domain.
+
+        Args:
+            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
+                MeshKind.UNIFORM).
+            N: Number of points (defaults to self.num_quad_points).
+        """
+        # Both quadrature and uniform meshes are equispaced for Fourier, so ignore kind.
+        a, b = self.domain
+        M = N if N is not None else self.num_quad_points
+        return jnp.linspace(float(a), float(b), M, endpoint=False)
+
 
 def matrices(test: tuple[Fourier, int], trial: tuple[Fourier, int]) -> DiaMatrix:
     """Return sparse operator matrix for Fourier test/trial derivatives.

--- a/src/jaxfun/galerkin/__init__.py
+++ b/src/jaxfun/galerkin/__init__.py
@@ -21,6 +21,7 @@ from .tensorproductspace import (
     DirectSumTPS as DirectSumTPS,
     TensorProduct as TensorProduct,
     TensorProductSpace as TensorProductSpace,
+    TPSolveMethod as TPSolveMethod,
     VectorTensorProductSpace as VectorTensorProductSpace,
     tpmats_to_kron as tpmats_to_kron,
 )

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -789,7 +789,7 @@ def project(ue: sp.Expr, V: TrialSpaceType) -> Array:
     v = TestFunction(V)
     if V.rank == 0:
         M, b = inner(v * (u - ue))
-        uh = M[0].solve(b.flatten()).reshape(V.num_dofs)
+        uh = M[0].solve(b)
 
     elif V.rank == 1:
         assert isinstance(ue, sp.Mul | sp.Add | JAXFunction), (
@@ -798,7 +798,6 @@ def project(ue: sp.Expr, V: TrialSpaceType) -> Array:
         assert isinstance(V, VectorTensorProductSpace)
         M, b = inner(Dot(v, (u - ue)))
         A = BlockTPMatrix(M, V, V)
-        C = A.block_array()
-        uh = C.solve(b.ravel()).reshape(b.shape)
+        uh = A.solve(b)
 
     return uh

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1923,15 +1923,19 @@ def tpmats_wavenumber_factor(
     shape = tuple(int(tpmats[0].mats[a].shape[0]) for a in range(ndim))
     n_P = shape[poly_axis]
 
+    # Determine working dtype from the polynomial-axis matrices so the solver
+    # honours float64 when JAX is configured for 64-bit precision.
+    _dtype = jnp.result_type(*[tp.mats[poly_axis].data.dtype for tp in tpmats])
+
     # Build weight matrix W[i, k] = scale_i * prod_a(diag(F_i^(a))[k_a]).
     # The flat Fourier index k varies in C-order (last Fourier axis fastest),
     # matching the transposed layout used in TPMatricesWavenumberSolver.solve.
     W_list: list[Array] = []
     for tp in tpmats:
-        w: Array = jnp.asarray(tp.scale, dtype=jnp.float32).reshape(1)
+        w: Array = jnp.asarray(tp.scale, dtype=_dtype).reshape(1)
         for a in fourier_axes:
             # Diagonal DiaMatrix: data has shape (1, n_a); data[0] is the diagonal.
-            diag_a = jnp.asarray(tp.mats[a].data[0], dtype=jnp.float32)  # (n_a,)
+            diag_a = jnp.asarray(tp.mats[a].data[0], dtype=_dtype)  # (n_a,)
             w = jnp.outer(w, diag_a).flatten()  # 1 → n_{a0} → n_{a0}*n_{a1} → …
         W_list.append(w)  # (n_F,)
 
@@ -1957,9 +1961,9 @@ def tpmats_wavenumber_factor(
         for off in poly_offsets:
             if off in mat.offsets:
                 idx = list(mat.offsets).index(off)
-                rows.append(jnp.asarray(mat.data[idx], dtype=jnp.float32))
+                rows.append(jnp.asarray(mat.data[idx], dtype=_dtype))
             else:
-                rows.append(jnp.zeros(n_P, dtype=jnp.float32))
+                rows.append(jnp.zeros(n_P, dtype=_dtype))
         P_data_rows.append(jnp.stack(rows))  # (n_diags, n_P)
 
     P_data_stack = jnp.stack(P_data_rows)  # (n_terms, n_diags, n_P)

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import itertools
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from enum import StrEnum
 from functools import partial
 from typing import TYPE_CHECKING, Any, NoReturn, TypeGuard, cast, overload
 
@@ -17,6 +18,7 @@ from scipy import sparse as scipy_sparse
 from jaxfun.coordinates import CoordSys
 from jaxfun.la import DiaMatrix, Matrix, MatrixProtocol, diakron
 from jaxfun.la.matrix import LUFactors
+from jaxfun.la.matrixprotocol import DiaMatrixSolveMethod, _CacheBox
 from jaxfun.typing import MeshKind
 
 if TYPE_CHECKING:
@@ -1082,6 +1084,27 @@ class TPLUFactors:
         return (y / jnp.asarray(self.scale)).reshape(rhs.shape)
 
 
+class TPSolveMethod(StrEnum):
+    """High-level solver selection for :meth:`TPMatrices.solve`.
+
+    Attributes:
+        AUTO: Try the factored path (:meth:`TPMatrices.lu_factor`) first;
+            fall back to explicit Kronecker assembly if it raises
+            :exc:`ValueError`.
+        LU: Force the factored path (diagonalization or wavenumber solver).
+            Propagates :exc:`ValueError` if the factor-matrix structure is
+            not suitable.
+        KRON: Force explicit Kronecker product assembly.  The assembled
+            :class:`~jaxfun.la.DiaMatrix` or :class:`~jaxfun.la.Matrix` is
+            cached; the DIA-matrix solver is selected via *kron_method* in
+            :meth:`TPMatrices.solve`.
+    """
+
+    AUTO = "auto"
+    LU = "lu"
+    KRON = "kron"
+
+
 class TPMatrices(nnx.Pytree):
     """Container for list of TPMatrix bilinear operator tensors."""
 
@@ -1112,6 +1135,42 @@ class TPMatrices(nnx.Pytree):
             jnp.array([mat._rmatmul_array(w) for mat in self.tpmats]), axis=0
         )
 
+    def tosparse(self) -> DiaMatrix:
+        sparse_box: _CacheBox[DiaMatrix] | None = getattr(self, "_sparse_cache", None)
+        if sparse_box is not None:
+            return sparse_box.value
+        kron = tpmats_to_kron(list(self.tpmats))
+        if not isinstance(kron, DiaMatrix):
+            kron = DiaMatrix.from_dense(kron.todense())
+        object.__setattr__(self, "_sparse_cache", _CacheBox(kron))
+        return kron
+
+    def todense(self) -> Array:
+        """Return the dense Kronecker product as a raw array.
+
+        The underlying :class:`~jaxfun.la.Matrix` or
+        :class:`~jaxfun.la.DiaMatrix` is cached for repeated calls.
+
+        Returns:
+            2-D :class:`~jaxfun.Array` of shape ``(N, N)`` where ``N`` is the
+            total number of degrees of freedom.
+        """
+        dense_box: _CacheBox[Matrix] | None = getattr(self, "_kron_cache", None)
+        if dense_box is not None:
+            return dense_box.value.todense()
+        sparse_box: _CacheBox[DiaMatrix] | None = getattr(self, "_sparse_cache", None)
+        if sparse_box is not None:
+            return sparse_box.value.todense()
+        kron = tpmats_to_kron(list(self.tpmats))
+        if isinstance(kron, Matrix):
+            object.__setattr__(self, "_kron_cache", _CacheBox(kron))
+            return kron.todense()
+        object.__setattr__(self, "_sparse_cache", _CacheBox(kron))
+        return kron.todense()
+
+    def to_Matrix(self) -> Matrix:
+        return Matrix(self.todense())
+
     def lu_factor(
         self,
     ) -> TPMatricesDenseLUFactors | TPMatricesLUFactors | TPMatricesWavenumberSolver:
@@ -1138,7 +1197,7 @@ class TPMatrices(nnx.Pytree):
             | None
         ) = getattr(self, "_lu_cache", None)
         if cached is not None:
-            return cached
+            return cached.value
         result: (
             TPMatricesDenseLUFactors | TPMatricesLUFactors | TPMatricesWavenumberSolver
         )
@@ -1150,27 +1209,80 @@ class TPMatrices(nnx.Pytree):
                 result = tpmats_wavenumber_factor(tpmats_list)
             except ValueError:
                 result = tpmats_lu_factor(tpmats_list)
-        object.__setattr__(self, "_lu_cache", result)
+        object.__setattr__(self, "_lu_cache", _CacheBox(result))
         return result
 
-    def solve(self, rhs: Array) -> Array:
+    def solve(
+        self,
+        rhs: Array,
+        *,
+        method: TPSolveMethod | str = TPSolveMethod.AUTO,
+        kron_method: DiaMatrixSolveMethod | str = DiaMatrixSolveMethod.AUTO,
+    ) -> Array:
         """Solve the summed tensor-product system.
 
-        Uses diagonalization (:meth:`lu_factor`) when all factor matrices on
-        each axis are simultaneously diagonalizable (e.g. 2D/3D Poisson).
-        Falls back to an explicit Kronecker product solve otherwise.  The
-        Kronecker matrix is assembled once and cached so that repeated solves
-        pay the assembly cost only on the first call; the matrix's own
-        :meth:`~jaxfun.la.Matrix.solve` caches the LU factorisation as well.
+        Args:
+            rhs: Right-hand side array.
+            method: High-level solver selection. One of:
+
+                * ``"auto"`` (default) — tries the factored path
+                  (:meth:`lu_factor`) first; falls back to explicit Kronecker
+                  product assembly if the factor-matrix structure is not
+                  suitable (e.g. not simultaneously diagonalizable).
+                * ``"lu"`` — force the factored path (diagonalization or
+                  wavenumber solver). Raises :exc:`ValueError` if the structure
+                  is not suitable.
+                * ``"kron"`` — force explicit Kronecker product assembly.
+                  The assembled matrix is cached for repeated solves.
+
+            kron_method: Solver method forwarded to
+                :meth:`~jaxfun.la.DiaMatrix.lu_solve` when the Kronecker-product
+                path is used and the assembled matrix is a
+                :class:`~jaxfun.la.DiaMatrix` (i.e. all factor matrices are
+                sparse).  One of ``"auto"``, ``"banded"``, ``"rcm"``,
+                ``"dense"``.  Ignored when the assembled matrix is a dense
+                :class:`~jaxfun.la.Matrix`.
+
+        Returns:
+            Solution array with the same shape as *rhs*.
+
+        Raises:
+            ValueError: If ``method="lu"`` but the factor-matrix structure is
+                not suitable for the factored solver.
         """
+        method = TPSolveMethod(method)
+
+        def _kron_solve(r: Array) -> Array:
+            flat = r.flatten()
+            # DiaMatrix path: shared cache with tosparse()
+            sparse_box: _CacheBox[DiaMatrix] | None = getattr(
+                self, "_sparse_cache", None
+            )
+            if sparse_box is not None:
+                return sparse_box.value.lu_solve(flat, method=kron_method).reshape(
+                    r.shape
+                )
+            # Dense Matrix path
+            dense_box: _CacheBox[Matrix] | None = getattr(self, "_kron_cache", None)
+            if dense_box is not None:
+                return dense_box.value.solve(flat).reshape(r.shape)
+            # No cache yet: compute and store
+            kron = tpmats_to_kron(list(self.tpmats))
+            if isinstance(kron, DiaMatrix):
+                object.__setattr__(self, "_sparse_cache", _CacheBox(kron))
+                return kron.lu_solve(flat, method=kron_method).reshape(r.shape)
+            object.__setattr__(self, "_kron_cache", _CacheBox(kron))
+            return kron.solve(flat).reshape(r.shape)
+
+        if method == TPSolveMethod.LU:
+            return self.lu_factor().solve(rhs)
+        if method == TPSolveMethod.KRON:
+            return _kron_solve(rhs)
+        # AUTO: try factored path, fall back to kron
         try:
             return self.lu_factor().solve(rhs)
         except ValueError:
-            cached_kron: Matrix | DiaMatrix | None = getattr(self, "_kron_cache", None)
-            if cached_kron is None:
-                cached_kron = tpmats_to_kron(list(self.tpmats))
-                object.__setattr__(self, "_kron_cache", cached_kron)
-            return cached_kron.solve(rhs.flatten()).reshape(rhs.shape)
+            return _kron_solve(rhs)
 
 
 class TensorMatrix(nnx.Pytree):  # noqa: B903
@@ -1232,11 +1344,11 @@ class BlockTPMatrix:
 
     def __init__(
         self,
-        tpmats: list[TPMatrix] | TPMatrices,
+        tpmats: list[TPMatrix],
         test_space: VectorTensorProductSpace,
         trial_space: VectorTensorProductSpace,
     ) -> None:
-        self.tpmats = tpmats.tpmats if isinstance(tpmats, TPMatrices) else tpmats
+        self.tpmats = tpmats
         self.test_space = test_space
         self.trial_space = trial_space
         self.shape = (self.test_space.dim, self.trial_space.dim)
@@ -1299,9 +1411,9 @@ class BlockTPMatrix:
                         f"got {type(mat).__name__}."
                     )
 
-        cached: DiaMatrix | None = getattr(self, "_sparse_cache", None)
+        cached: _CacheBox[DiaMatrix] | None = getattr(self, "_sparse_cache", None)
         if cached is not None:
-            return cached
+            return cached.value
 
         # Group TPMatrix objects by global_indices.
         from collections import defaultdict
@@ -1353,7 +1465,7 @@ class BlockTPMatrix:
         result = DiaMatrix(
             data=global_data, offsets=sorted_offsets, shape=(total_rows, total_cols)
         )
-        object.__setattr__(self, "_sparse_cache", result)
+        object.__setattr__(self, "_sparse_cache", _CacheBox(result))
         return result
 
     def __call__(self, u: Array | JAXFunction) -> Array:
@@ -1367,14 +1479,12 @@ class BlockTPMatrix:
         from jaxfun.galerkin import JAXFunction
 
         w = u.array if isinstance(u, JAXFunction) else u
-        rcm_cache: tuple[DiaMatrix, Array, Array] | None = getattr(
-            self, "_rcm_cache", None
-        )
-        if rcm_cache is not None:
-            A_perm, perm, inv_perm = rcm_cache
-            return A_perm.matvec(w.ravel()[perm])[inv_perm].reshape(w.shape)
-        sparse: DiaMatrix | None = getattr(self, "_sparse_cache", None)
-        if sparse is not None:
+        sparse_box: _CacheBox[DiaMatrix] | None = getattr(self, "_sparse_cache", None)
+        if sparse_box is not None:
+            sparse = sparse_box.value
+            if getattr(sparse, "_rcm_cache", None) is not None:
+                A_perm, perm, inv_perm = sparse.rcm()
+                return A_perm.matvec(w.ravel()[perm])[inv_perm].reshape(w.shape)
             return sparse.matvec(w.ravel()).reshape(w.shape)
         return self._matmul_array(w)
 
@@ -1394,16 +1504,7 @@ class BlockTPMatrix:
             isinstance(mat, DiaMatrix) for tp in self.tpmats for mat in tp.mats
         )
         if all_dia:
-            rcm_cache: tuple[DiaMatrix, Array, Array] | None = getattr(
-                self, "_rcm_cache", None
-            )
-            if rcm_cache is None:
-                _, perm, inv_perm = self.tosparse().rcm()
-                # tosparse().rcm() caches on the DiaMatrix; mirror here so
-                # __call__ can find it without re-entering tosparse().
-                rcm_cache = self.tosparse().rcm()
-                object.__setattr__(self, "_rcm_cache", rcm_cache)
-            A_perm, perm, inv_perm = rcm_cache
+            A_perm, perm, inv_perm = self.tosparse().rcm()
             x_perm = A_perm.solve(b.ravel()[perm])
             return x_perm[inv_perm].reshape(b.shape)
         M = self.to_Matrix()

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1117,7 +1117,7 @@ class TPMatrices(nnx.Pytree):
            instances, use :func:`tpmats_dense_lu_factor` (simple full Kronecker
            LU — works for any linear system).
         2. Otherwise try :func:`tpmats_wavenumber_factor` (efficient for
-           Fourier × polynomial problems).
+           Fourier x polynomial problems).
         3. Fall back to :func:`tpmats_lu_factor` (diagonalization — requires
            simultaneously diagonalizable factor matrices per axis).
 
@@ -1152,13 +1152,19 @@ class TPMatrices(nnx.Pytree):
 
         Uses diagonalization (:meth:`lu_factor`) when all factor matrices on
         each axis are simultaneously diagonalizable (e.g. 2D/3D Poisson).
-        Falls back to an explicit Kronecker product solve otherwise.
+        Falls back to an explicit Kronecker product solve otherwise.  The
+        Kronecker matrix is assembled once and cached so that repeated solves
+        pay the assembly cost only on the first call; the matrix's own
+        :meth:`~jaxfun.la.Matrix.solve` caches the LU factorisation as well.
         """
         try:
             return self.lu_factor().solve(rhs)
         except ValueError:
-            A = tpmats_to_kron(list(self.tpmats))
-            return A.solve(rhs.flatten()).reshape(rhs.shape)
+            cached_kron: Matrix | DiaMatrix | None = getattr(self, "_kron_cache", None)
+            if cached_kron is None:
+                cached_kron = tpmats_to_kron(list(self.tpmats))
+                object.__setattr__(self, "_kron_cache", cached_kron)
+            return cached_kron.solve(rhs.flatten()).reshape(rhs.shape)
 
 
 class TensorMatrix(nnx.Pytree):  # noqa: B903
@@ -1536,7 +1542,7 @@ class TPMatricesWavenumberSolver:
         )
 
         # Experimental alternative: instead of custom scan kernels, try rebuilding
-        # usining the aligned data and vmapping lu.solve directly.  This is more
+        # using the aligned data and vmapping lu.solve directly.  This is more
         # elegant, but initial tests suggest the custom scan kernels are faster
         # Keep alternative solve2 for now.
         # Rebuild LUFactors with aligned offsets (all_L_offsets / all_U_offsets)

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1030,11 +1030,6 @@ class TPMatrix(nnx.Pytree):  # noqa: B903
         Returns:
             Solution array with the same shape as ``rhs``.
 
-        Note:
-            This method is not highly useful, because TPMatrices are not often
-            solved directly by themselves. There is usually a list of them in a
-            :class:`TPMatrices`, and the summed system is then solved without
-            using this solve method.
         """
         return self.lu_factor().solve(rhs)
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1059,6 +1059,7 @@ class TPLUFactors:
         self.scale = scale
         self.shape = shape
 
+    @jax.jit(static_argnums=(0,))
     def solve(self, rhs: Array) -> Array:
         """Solve ``(scale * A0 ⊗ A1 ⊗ …) x = rhs``.
 
@@ -1440,7 +1441,7 @@ def _make_wavenumber_vmap_solve(
 
 
 class TPMatricesWavenumberSolver:
-    """Per-wavenumber solver for Fourier × polynomial tensor-product systems.
+    """Per-wavenumber solver for Fourier x polynomial tensor-product systems.
 
     Solves
 
@@ -1517,6 +1518,10 @@ class TPMatricesWavenumberSolver:
             all_L_offsets, all_U_offsets, n_P_local, self.L_data_batch.dtype
         )
 
+        # Experimental alternative: instead of custom scan kernels, try rebuilding
+        # usining the aligned data and vmapping lu.solve directly.  This is more
+        # elegant, but initial tests suggest the custom scan kernels are faster
+        # Keep alternative solve2 for now.
         # Rebuild LUFactors with aligned offsets (all_L_offsets / all_U_offsets)
         # so every element has the same pytree structure.  Then stack their
         # leaves into a single batched pytree and vmap LUFactors.solve over it.
@@ -1767,7 +1772,7 @@ def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:
 def tpmats_wavenumber_factor(
     A: list[TPMatrix] | TPMatrices,
 ) -> TPMatricesWavenumberSolver:
-    """Pre-factorize a Fourier × polynomial :class:`TPMatrices` system.
+    """Pre-factorize a Fourier x polynomial :class:`TPMatrices` system.
 
     Detects which axes are Fourier (every term has a purely diagonal
     :class:`~jaxfun.la.DiaMatrix` — ``offsets == (0,)`` — on that axis) and

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from enum import StrEnum
 from functools import partial
@@ -18,7 +19,11 @@ from scipy import sparse as scipy_sparse
 from jaxfun.coordinates import CoordSys
 from jaxfun.la import DiaMatrix, Matrix, MatrixProtocol, diakron
 from jaxfun.la.matrix import LUFactors
-from jaxfun.la.matrixprotocol import DiaMatrixSolveMethod, _CacheBox
+from jaxfun.la.matrixprotocol import (
+    DiaMatrixSolveMethod,
+    SolverNotApplicable,
+    _CacheBox,
+)
 from jaxfun.typing import MeshKind
 
 if TYPE_CHECKING:
@@ -1202,7 +1207,7 @@ class TPMatrices(nnx.Pytree):
         else:
             try:
                 result = tpmats_wavenumber_factor(tpmats_list)
-            except ValueError:
+            except SolverNotApplicable:
                 result = tpmats_lu_factor(tpmats_list)
         object.__setattr__(self, "_lu_cache", _CacheBox(result))
         return result
@@ -1276,7 +1281,7 @@ class TPMatrices(nnx.Pytree):
         # AUTO: try factored path, fall back to kron
         try:
             return self.lu_factor().solve(rhs)
-        except ValueError:
+        except SolverNotApplicable:
             return _kron_solve(rhs)
 
 
@@ -1411,8 +1416,6 @@ class BlockTPMatrix:
             return cached.value
 
         # Group TPMatrix objects by global_indices.
-        from collections import defaultdict
-
         grouped: dict[tuple[int, int], list[TPMatrix]] = defaultdict(list)
         for mat in self.tpmats:
             grouped[mat.global_indices].append(mat)
@@ -1529,9 +1532,9 @@ class TPMatricesLUFactors:
 
     def __init__(
         self,
-        eigvecs: list,
-        per_term_eigenvalues: list,
-        scales: list,
+        eigvecs: list[Array],
+        per_term_eigenvalues: list[list[Array]],
+        scales: list[complex],
         shape: tuple[int, ...],
     ) -> None:
         self.eigvecs = eigvecs  # list of (n_i, n_i) eigenvector matrices
@@ -2039,7 +2042,7 @@ def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:
                         _repr(mats_i[1]): jnp.ones_like(evals),
                     },
                 )
-            except Exception:
+            except _scipy_linalg.LinAlgError:
                 evals_np, evecs_np = _scipy_linalg.eigh(A1_np, A0_np)
                 evals = jnp.array(evals_np)
                 evecs = jnp.array(evecs_np)
@@ -2051,7 +2054,7 @@ def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:
                     },
                 )
         else:
-            raise ValueError(
+            raise SolverNotApplicable(
                 f"Axis {i} has {len(mats_i)} distinct factor matrices; "
                 "simultaneous diagonalization requires ≤ 2 distinct matrices per axis."
             )
@@ -2071,8 +2074,8 @@ def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:
     per_term_eigenvalues = [
         [axis_eigenvalues[_repr(tp.mats[i])] for i in range(ndim)] for tp in tpmats
     ]
-    scales = [tp.scale for tp in tpmats]
-    shape = tuple(int(tpmats[0].mats[i].shape[0]) for i in range(ndim))
+    scales: list[complex] = [tp.scale for tp in tpmats]
+    shape: tuple[int, ...] = tuple(int(tpmats[0].mats[i].shape[0]) for i in range(ndim))
     return TPMatricesLUFactors(
         eigvecs=eigvecs,
         per_term_eigenvalues=per_term_eigenvalues,
@@ -2135,7 +2138,7 @@ def tpmats_wavenumber_factor(
     poly_axes = [a for a in range(ndim) if not _is_diagonal_axis(a)]
 
     if len(poly_axes) != 1:
-        raise ValueError(
+        raise SolverNotApplicable(
             f"tpmats_wavenumber_factor requires exactly 1 polynomial "
             f"(non-diagonal) axis; found {len(poly_axes)}: {poly_axes}. "
             f"Use tpmats_lu_factor for fully-symmetric problems."

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1299,6 +1299,7 @@ class TPMatricesLUFactors:
         self.scales = scales
         self.shape = shape
 
+    @jax.jit(static_argnums=(0,))
     def solve(self, rhs: Array) -> Array:
         """Solve the summed tensor-product system for RHS ``rhs``.
 
@@ -1516,6 +1517,32 @@ class TPMatricesWavenumberSolver:
             all_L_offsets, all_U_offsets, n_P_local, self.L_data_batch.dtype
         )
 
+        # Rebuild LUFactors with aligned offsets (all_L_offsets / all_U_offsets)
+        # so every element has the same pytree structure.  Then stack their
+        # leaves into a single batched pytree and vmap LUFactors.solve over it.
+        from jaxfun.la.diamatrix import LUFactors as _DiaLUFactors
+
+        n = n_P_local
+        aligned_lu_list = [
+            _DiaLUFactors(
+                L=DiaMatrix(
+                    data=self.L_data_batch[k],
+                    offsets=all_L_offsets,
+                    shape=(n, n),
+                ),
+                U=DiaMatrix(
+                    data=self.U_data_batch[k],
+                    offsets=all_U_offsets,
+                    shape=(n, n),
+                ),
+                shape=(n, n),
+            )
+            for k in range(len(lu_list))
+        ]
+        self._lu_stacked = jax.tree.map(lambda *xs: jnp.stack(xs), *aligned_lu_list)
+        self._vmap_solve2 = jax.jit(jax.vmap(lambda lu, b: lu.solve(b)))
+
+    @jax.jit(static_argnums=(0,))
     def solve(self, rhs: Array) -> Array:
         """Solve the wavenumber-loop system for RHS ``rhs``.
 
@@ -1547,6 +1574,42 @@ class TPMatricesWavenumberSolver:
         sol_2d = self._vmap_solve(self.L_data_batch, self.U_data_batch, rhs_2d)
 
         # Un-permute back to the original axis order.
+        sol_perm = sol_2d.reshape(fourier_shape + (n_P,))
+        inv_perm = [0] * ndim
+        for new_pos, old_pos in enumerate(axes_order):
+            inv_perm[old_pos] = new_pos
+        return jnp.transpose(sol_perm, inv_perm)
+
+    @jax.jit(static_argnums=(0,))
+    def solve2(self, rhs: Array) -> Array:
+        """Alternative solve that vmaps :meth:`~jaxfun.la.diamatrix.LUFactors.solve`
+        directly over a batched :class:`~jaxfun.la.diamatrix.LUFactors` pytree.
+
+        All ``LUFactors`` for the wavenumber batch share the same aligned
+        ``L``/``U`` offsets and ``shape``, so their leaves can be stacked once
+        (in ``__init__``) and ``jax.vmap`` maps ``lu.solve(b)`` over the
+        leading batch axis — no custom scan kernels required.
+
+        Args:
+            rhs: Right-hand side shaped ``self.shape``.
+
+        Returns:
+            Solution with the same shape as ``rhs``.
+        """
+        shape = self.shape
+        ndim = len(shape)
+        poly_axis = self.poly_axis
+        n_P = shape[poly_axis]
+
+        fourier_axes = [a for a in range(ndim) if a != poly_axis]
+        fourier_shape = tuple(shape[a] for a in fourier_axes)
+        n_F = int(np.prod(fourier_shape)) if fourier_shape else 1
+
+        axes_order = fourier_axes + [poly_axis]
+        rhs_2d = jnp.transpose(rhs, axes_order).reshape(n_F, n_P)
+
+        sol_2d = self._vmap_solve2(self._lu_stacked, rhs_2d)
+
         sol_perm = sol_2d.reshape(fourier_shape + (n_P,))
         inv_perm = [0] * ndim
         for new_pos, old_pos in enumerate(axes_order):

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import copy
 import itertools
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import partial
-from typing import TYPE_CHECKING, NoReturn, TypeGuard, cast, overload
+from typing import TYPE_CHECKING, Any, NoReturn, TypeGuard, cast, overload
 
 import jax
 import jax.numpy as jnp
@@ -1007,9 +1007,71 @@ class TPMatrix(nnx.Pytree):  # noqa: B903
         return self._rmatmul_array(w)
 
     def solve(self, rhs: Array) -> Array:
-        """Solve linear system"""
-        A = self.mat
-        return A.solve(rhs.flatten()).reshape(rhs.shape)
+        """Solve ``(scale * A0 ⊗ A1 ⊗ …) x = rhs`` using Kronecker-factored LU.
+
+        Exploits the mixed-product property
+
+        .. math::
+
+            (A_0 \\otimes A_1 \\otimes \\cdots)^{-1}
+            = A_0^{-1} \\otimes A_1^{-1} \\otimes \\cdots
+
+        to avoid forming the full Kronecker product.  Each factor's LU is
+        computed once and cached on the factor matrix itself, so repeated
+        ``solve`` calls pay only the substitution cost.
+
+        Args:
+            rhs: Right-hand side array.  May be flat ``(n,)`` or have the
+                multidimensional shape ``(n0, n1, …)``.
+
+        Returns:
+            Solution array with the same shape as ``rhs``.
+        """
+        return self.lu_factor().solve(rhs)
+
+    def lu_factor(self) -> TPLUFactors:
+        """Pre-compute LU factors for every Kronecker factor.
+
+        Returns a :class:`TPLUFactors` whose :meth:`~TPLUFactors.solve` method
+        solves the Kronecker system without rebuilding the factorisation.
+        """
+        lu_factors = [mat.lu_factor() for mat in self.mats]
+        shape = tuple(int(m.shape[0]) for m in self.mats)
+        return TPLUFactors(lu_factors=lu_factors, scale=self.scale, shape=shape)
+
+
+class TPLUFactors:
+    """LU factorisation of a :class:`TPMatrix` (Kronecker product).
+
+    Holds the per-factor LU objects and applies them sequentially on their
+    respective axes to solve the full tensor-product system.
+
+    Attributes:
+        lu_factors: Per-axis LU factorisation objects (DiaMatrix or Matrix).
+        scale: Scalar from the parent :class:`TPMatrix`.
+        shape: Tuple of per-factor sizes ``(n0, n1, …)``.
+    """
+
+    def __init__(
+        self, lu_factors: list, scale: complex, shape: tuple[int, ...]
+    ) -> None:
+        self.lu_factors = lu_factors
+        self.scale = scale
+        self.shape = shape
+
+    def solve(self, rhs: Array) -> Array:
+        """Solve ``(scale * A0 ⊗ A1 ⊗ …) x = rhs``.
+
+        Args:
+            rhs: Right-hand side.  Flat ``(n,)`` or shaped ``(n0, n1, …)``.
+
+        Returns:
+            Solution with the same shape as ``rhs``.
+        """
+        y = rhs.reshape(self.shape)
+        for i, lu in enumerate(self.lu_factors):
+            y = lu.solve(y, axis=i)
+        return (y / jnp.asarray(self.scale)).reshape(rhs.shape)
 
 
 class TPMatrices(nnx.Pytree):
@@ -1042,10 +1104,43 @@ class TPMatrices(nnx.Pytree):
             jnp.array([mat._rmatmul_array(w) for mat in self.tpmats]), axis=0
         )
 
+    def lu_factor(self) -> TPMatricesLUFactors | TPMatricesWavenumberSolver:
+        """Pre-compute factors for repeated fast solves.
+
+        Tries :func:`tpmats_wavenumber_factor` first (efficient for Fourier ×
+        polynomial problems), then falls back to :func:`tpmats_lu_factor`
+        (diagonalization).
+
+        Returns:
+            :class:`TPMatricesWavenumberSolver` or :class:`TPMatricesLUFactors`
+            for repeated fast solves.
+        """
+        cached: TPMatricesLUFactors | TPMatricesWavenumberSolver | None = getattr(
+            self, "_lu_cache", None
+        )
+        if cached is not None:
+            return cached
+        try:
+            result: TPMatricesLUFactors | TPMatricesWavenumberSolver = (
+                tpmats_wavenumber_factor(list(self.tpmats))
+            )
+        except ValueError:
+            result = tpmats_lu_factor(list(self.tpmats))
+        object.__setattr__(self, "_lu_cache", result)
+        return result
+
     def solve(self, rhs: Array) -> Array:
-        """Solve linear system"""
-        A = tpmats_to_kron(list(self.tpmats))
-        return A.solve(rhs.flatten()).reshape(rhs.shape)
+        """Solve the summed tensor-product system.
+
+        Uses diagonalization (:meth:`lu_factor`) when all factor matrices on
+        each axis are simultaneously diagonalizable (e.g. 2D/3D Poisson).
+        Falls back to an explicit Kronecker product solve otherwise.
+        """
+        try:
+            return self.lu_factor().solve(rhs)
+        except ValueError:
+            A = tpmats_to_kron(list(self.tpmats))
+            return A.solve(rhs.flatten()).reshape(rhs.shape)
 
 
 class TensorMatrix(nnx.Pytree):  # noqa: B903
@@ -1169,6 +1264,569 @@ class BlockTPMatrix:
         """Solve M x = b using a dense factorisation of the block matrix."""
         M = self.block_array()
         return M.solve(b.ravel()).reshape(b.shape)
+
+
+class TPMatricesLUFactors:
+    """Diagonalization-based solver for a sum of tensor-product operators.
+
+    Solves
+
+    .. math::
+
+        \\sum_k s_k \\, (A_k^{(0)} \\otimes A_k^{(1)} \\otimes \\cdots)\\, x = f
+
+    by simultaneously diagonalizing the factor matrices on each axis.
+
+    Given a shared eigenbasis :math:`V` satisfying
+    :math:`V^T A V = \\Lambda` (diagonal) and :math:`V^T B V = I`, the system
+    reduces to element-wise division in the transformed space — :math:`O(n^d)`
+    work after the :math:`O(n^3)` per-axis factorisation.
+
+    For 2D Poisson (``K⊗M + M⊗K``): the denominator is
+    :math:`D_{ij} = \\lambda_i + \\lambda_j` and the back-transform is
+    :math:`U = V \\tilde{U} V^T`.
+    """
+
+    def __init__(
+        self,
+        eigvecs: list,
+        per_term_eigenvalues: list,
+        scales: list,
+        shape: tuple[int, ...],
+    ) -> None:
+        self.eigvecs = eigvecs  # list of (n_i, n_i) eigenvector matrices
+        self.per_term_eigenvalues = per_term_eigenvalues  # [term][axis] -> (n_axis,)
+        self.scales = scales
+        self.shape = shape
+
+    def solve(self, rhs: Array) -> Array:
+        """Solve the summed tensor-product system for RHS ``rhs``.
+
+        Args:
+            rhs: Right-hand side, flat ``(n,)`` or shaped ``(n0, n1, ...)``.
+
+        Returns:
+            Solution with the same shape as ``rhs``.
+        """
+        shape = self.shape
+        ndim = len(shape)
+        F = rhs.reshape(shape)
+
+        # Forward transform: apply V_i^T along each axis i.
+        # jnp.tensordot(V.T, X, axes=[[1],[i]]) contracts V^T with axis i of X,
+        # placing the result at position 0; moveaxis restores it to position i.
+        Ftilde = F
+        for i, V in enumerate(self.eigvecs):
+            Ftilde = jnp.tensordot(V.T, Ftilde, axes=[[1], [i]])
+            Ftilde = jnp.moveaxis(Ftilde, 0, i)
+
+        # Denominator: D[i0,i1,...] = sum_k s_k * Λ_k[0][i0] * Λ_k[1][i1] * ...
+        dtype = jnp.result_type(rhs.dtype, jnp.float32)
+        D = jnp.zeros(shape, dtype=dtype)
+        for evals_k, s_k in zip(self.per_term_eigenvalues, self.scales):
+            term = jnp.ones(shape, dtype=dtype)
+            for i, ev in enumerate(evals_k):
+                idx: list = [None] * ndim
+                idx[i] = slice(None)
+                term = term * ev[tuple(idx)]
+            D = D + jnp.asarray(s_k, dtype=dtype) * term
+
+        # Solve in the transformed space (element-wise division).
+        Utilde = Ftilde / D
+
+        # Back-transform: apply V_i along each axis i.
+        U = Utilde
+        for i, V in enumerate(self.eigvecs):
+            U = jnp.tensordot(V, U, axes=[[1], [i]])
+            U = jnp.moveaxis(U, 0, i)
+
+        return U.reshape(rhs.shape)
+
+
+def _make_wavenumber_vmap_solve(
+    L_offsets: tuple[int, ...],
+    U_offsets: tuple[int, ...],
+    n_P: int,
+    dtype: Any,
+) -> Callable[..., Array]:
+    """Build a ``jax.vmap``-compiled batch solver for the wavenumber loop.
+
+    Returns a function ``f(L_data_batch, U_data_batch, rhs_2d) -> sol_2d``
+    that solves each 1-D banded system ``B_k x = b_k`` using forward and
+    backward substitution compiled via :func:`jax.lax.scan`.  DIA offsets are
+    captured as static Python values in the closure so :func:`jax.vmap` only
+    traces over the array data — avoiding any pytree-metadata issues that
+    would arise from constructing :class:`~jaxfun.la.DiaMatrix` instances
+    with traced arrays.
+
+    Args:
+        L_offsets: Sub-diagonal offsets of the L factor (shared across all k).
+        U_offsets: Super-diagonal offsets of the U factor (shared across all k).
+        n_P: Length of each 1-D polynomial system.
+        dtype: JAX dtype used for zero-padding of missing diagonals.
+
+    Returns:
+        A vmapped callable ``(L_data_batch, U_data_batch, rhs_2d) -> sol_2d``
+        where each batch dimension corresponds to one Fourier wavenumber.
+    """
+    p = max((-o for o in L_offsets if o < 0), default=0)
+    q = max((o for o in U_offsets if o > 0), default=0)
+
+    # Index of each sub/super-diagonal in the data array, or None if absent.
+    l_indices: list[int | None] = [
+        L_offsets.index(-s) if -s in L_offsets else None for s in range(1, p + 1)
+    ]
+    U_main_idx: int = U_offsets.index(0)
+    u_indices: list[int | None] = [
+        U_offsets.index(s) if s in U_offsets else None for s in range(1, q + 1)
+    ]
+
+    # Reversal index for backward substitution — static since n_P is fixed.
+    rev = jnp.arange(n_P - 1, -1, -1)
+
+    def _fwd_elim(L_data: Array, b: Array) -> Array:
+        """Solve L y = b (unit lower-triangular) via forward scan."""
+        if p == 0:
+            return b
+        l_rows: list[Array] = []
+        for s, idx in enumerate(l_indices, start=1):
+            if idx is not None:
+                d = L_data[idx]
+                l_rows.append(
+                    jnp.concatenate([jnp.zeros(s, dtype=d.dtype), d[: n_P - s]])
+                )
+            else:
+                l_rows.append(jnp.zeros(n_P, dtype=dtype))
+        l_mat = jnp.stack(l_rows)  # (p, n_P); l_mat[j, i] = L[i, i-(j+1)]
+
+        def step(window: Array, xs: tuple) -> tuple[Array, Array]:
+            bi, l_i = xs  # scalar, (p,)
+            yi = bi - jnp.dot(l_i, window)
+            return jnp.concatenate([yi[None], window[:-1]]), yi
+
+        _, ys = jax.lax.scan(step, jnp.zeros(p, dtype=b.dtype), (b, l_mat.T))
+        return ys
+
+    def _bwd_sub(U_data: Array, y: Array) -> Array:
+        """Solve U x = y (upper-triangular) via backward scan."""
+        diag_d = U_data[U_main_idx]
+        if q == 0:
+            return y / diag_d
+        u_rows: list[Array] = []
+        for s, idx in enumerate(u_indices, start=1):
+            if idx is not None:
+                d = U_data[idx]
+                u_rows.append(jnp.concatenate([d[s:n_P], jnp.zeros(s, dtype=d.dtype)]))
+            else:
+                u_rows.append(jnp.zeros(n_P, dtype=dtype))
+        u_mat = jnp.stack(u_rows)  # (q, n_P)
+        y_rev, diag_rev, u_mat_rev = y[rev], diag_d[rev], u_mat[:, rev].T  # (n_P, q)
+
+        def step(window: Array, xs: tuple) -> tuple[Array, Array]:
+            yi, u_i, dii = xs  # scalar, (q,), scalar
+            xi = (yi - jnp.dot(u_i, window)) / dii
+            return jnp.concatenate([xi[None], window[:-1]]), xi
+
+        _, xs_out = jax.lax.scan(
+            step, jnp.zeros(q, dtype=y.dtype), (y_rev, u_mat_rev, diag_rev)
+        )
+        return xs_out[rev]
+
+    def _solve_one(L_data: Array, U_data: Array, b: Array) -> Array:
+        return _bwd_sub(U_data, _fwd_elim(L_data, b))
+
+    return jax.jit(jax.vmap(_solve_one))
+
+
+class TPMatricesWavenumberSolver:
+    """Per-wavenumber solver for Fourier × polynomial tensor-product systems.
+
+    Solves
+
+    .. math::
+
+        \\sum_i s_i \\bigl(A_i^{(0)} \\otimes \\cdots\\bigr)\\, x = f
+
+    where all axes except one are *Fourier* (every per-axis matrix is diagonal)
+    and exactly one axis is *polynomial* (banded but not purely diagonal).
+
+    For each combination of Fourier wavenumber indices the 1-D polynomial
+    problem
+
+    .. math::
+
+        B_k\\, \\hat{u}_k = \\hat{f}_k, \\quad
+        B_k = \\sum_i s_i \\Bigl(\\prod_{a \\in \\text{Fourier}}
+        F_i^{(a)}[k_a]\\Bigr)\\, P_i
+
+    is assembled using banded :class:`~jaxfun.la.DiaMatrix` arithmetic and
+    pre-factorised with :meth:`~jaxfun.la.DiaMatrix.lu_factor` (result
+    cached on each matrix).
+
+    Args:
+        poly_axis: Index of the polynomial axis in the full tensor.
+        B_matrices: Per-wavenumber :class:`~jaxfun.la.DiaMatrix` objects,
+            length ``n_F`` (product of all Fourier-axis sizes), each
+            carrying a warm :meth:`~jaxfun.la.DiaMatrix.lu_factor` cache.
+        shape: Full solution shape ``(n_0, n_1, ...)``.
+    """
+
+    def __init__(
+        self,
+        poly_axis: int,
+        B_matrices: list,
+        shape: tuple[int, ...],
+    ) -> None:
+        self.poly_axis = poly_axis
+        self.B_matrices = B_matrices
+        self.shape = shape
+        # Pre-stack L and U data for vmapped solving.
+        # lu_factor prunes structurally-zero diagonals per-wavenumber, so
+        # different B_k may yield L/U with different offsets.  Compute the
+        # union of offsets and pad missing diagonals with zeros so all rows
+        # have the same shape before stacking.
+        lu_list = [B.lu_factor() for B in B_matrices]
+        n_P_local = B_matrices[0].shape[0]
+
+        all_L_offsets: tuple[int, ...] = tuple(
+            sorted({off for lu in lu_list for off in lu.L.offsets})
+        )
+        all_U_offsets: tuple[int, ...] = tuple(
+            sorted({off for lu in lu_list for off in lu.U.offsets})
+        )
+
+        def _align_data(dia_mat: DiaMatrix, target_offsets: tuple[int, ...]) -> Array:
+            rows: list[Array] = []
+            for off in target_offsets:
+                if off in dia_mat.offsets:
+                    rows.append(dia_mat.data[list(dia_mat.offsets).index(off)])
+                else:
+                    rows.append(jnp.zeros(n_P_local, dtype=dia_mat.data.dtype))
+            return jnp.stack(rows)
+
+        self.L_data_batch: Array = jnp.stack(
+            [_align_data(lu.L, all_L_offsets) for lu in lu_list]
+        )
+        self.U_data_batch: Array = jnp.stack(
+            [_align_data(lu.U, all_U_offsets) for lu in lu_list]
+        )
+        self.L_offsets: tuple[int, ...] = all_L_offsets
+        self.U_offsets: tuple[int, ...] = all_U_offsets
+        self._vmap_solve = _make_wavenumber_vmap_solve(
+            all_L_offsets, all_U_offsets, n_P_local, self.L_data_batch.dtype
+        )
+
+    def solve(self, rhs: Array) -> Array:
+        """Solve the wavenumber-loop system for RHS ``rhs``.
+
+        All per-wavenumber 1-D banded polynomial solves are executed in a
+        single :func:`jax.vmap` call over the stacked ``L`` / ``U`` factor
+        data arrays.  The scan kernels are compiled once on the first call
+        and reused for subsequent solves.
+
+        Args:
+            rhs: Right-hand side shaped ``self.shape``.
+
+        Returns:
+            Solution with the same shape as ``rhs``.
+        """
+        shape = self.shape
+        ndim = len(shape)
+        poly_axis = self.poly_axis
+        n_P = shape[poly_axis]
+
+        fourier_axes = [a for a in range(ndim) if a != poly_axis]
+        fourier_shape = tuple(shape[a] for a in fourier_axes)
+        n_F = int(np.prod(fourier_shape)) if fourier_shape else 1
+
+        # Permute so all Fourier axes come first, polynomial axis last, then
+        # flatten to (n_F, n_P) for vectorised solving.
+        axes_order = fourier_axes + [poly_axis]
+        rhs_2d = jnp.transpose(rhs, axes_order).reshape(n_F, n_P)
+
+        sol_2d = self._vmap_solve(self.L_data_batch, self.U_data_batch, rhs_2d)
+
+        # Un-permute back to the original axis order.
+        sol_perm = sol_2d.reshape(fourier_shape + (n_P,))
+        inv_perm = [0] * ndim
+        for new_pos, old_pos in enumerate(axes_order):
+            inv_perm[old_pos] = new_pos
+        return jnp.transpose(sol_perm, inv_perm)
+
+
+def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:
+    """Compute diagonalization-based LU factors for a sum of :class:`TPMatrix`.
+
+    Simultaneously diagonalizes the factor matrices on each axis so that the
+    full Kronecker-sum system reduces to element-wise division in the
+    transformed space.
+
+    **Algorithm** (2D, generalises to any number of dims):
+
+    Given a list of TPMatrices representing :math:`\\sum_k s_k A_k \\otimes B_k`,
+    find :math:`V` such that :math:`V^T A V = \\Lambda_A` and
+    :math:`V^T B V = I` (generalized eigenproblem :math:`A v = \\lambda B v`).
+    Then:
+
+    .. math::
+
+        \\tilde{F} = V^T F V, \\quad
+        D_{ij} = \\textstyle\\sum_k s_k \\lambda_k^{(0)}{}_i \\lambda_k^{(1)}{}_j,
+        \\quad U = V (\\tilde{F} / D) V^T.
+
+    **Requirement**: all factor matrices on each axis must be simultaneously
+    diagonalizable — true whenever each axis has at most 2 distinct matrices
+    that form a symmetric-definite pair (e.g. stiffness K and mass M from the
+    same 1D function space).  Axes that share the same unordered matrix pair
+    automatically reuse the same eigenvectors.
+
+    Args:
+        A: Single :class:`TPMatrix` or list of :class:`TPMatrix` objects (as
+            returned by :func:`~jaxfun.galerkin.inner.inner`).
+
+    Returns:
+        :class:`TPMatricesLUFactors` whose :meth:`~TPMatricesLUFactors.solve`
+        method solves the system without re-factorising.
+
+    Raises:
+        ValueError: if any axis has more than 2 distinct factor matrices.
+    """
+    if isinstance(A, TPMatrix):
+        A = [A]
+    tpmats = list(A)
+    ndim = tpmats[0].dims
+
+    # --- value-based deduplication of factor matrices ----------------------
+    # Matrices that are numerically equal but have different Python ids (e.g.
+    # M from K⊗M and M from the M⊗M term in a Helmholtz problem) are treated
+    # as the same matrix.  All ids are mapped to a single representative id.
+    _mat_by_id: dict[int, object] = {}
+    _dense_by_id: dict[int, Array] = {}
+    for tp in tpmats:
+        for mat in tp.mats:
+            mid = id(mat)
+            if mid not in _mat_by_id:
+                _mat_by_id[mid] = mat
+                _dense_by_id[mid] = mat.todense()
+
+    _seen_repr: list[int] = []  # canonical ids in first-seen order
+    _id_to_repr: dict[int, int] = {}
+    for mid in _mat_by_id:
+        for rid in _seen_repr:
+            if _dense_by_id[mid].shape == _dense_by_id[rid].shape and jnp.allclose(
+                _dense_by_id[mid], _dense_by_id[rid], rtol=1e-5, atol=1e-8
+            ):
+                _id_to_repr[mid] = rid
+                break
+        else:
+            _id_to_repr[mid] = mid
+            _seen_repr.append(mid)
+
+    def _repr(mat) -> int:
+        return _id_to_repr[id(mat)]
+
+    # --- per-axis pair → (eigvecs, {repr_id: eigenvalues}) ----------------
+    # Axes that share the same unordered pair of matrices reuse eigenvectors.
+    pair_cache: dict[frozenset, tuple[Array, dict[int, Array]]] = {}
+
+    for i in range(ndim):
+        mats_i = list(
+            {_repr(tp.mats[i]): _mat_by_id[_repr(tp.mats[i])] for tp in tpmats}.values()
+        )
+        pair_key = frozenset(_repr(m) for m in mats_i)
+        if pair_key in pair_cache:
+            continue
+        if len(mats_i) == 1:
+            A_dense = cast(MatrixProtocol, mats_i[0]).todense()
+            evals, evecs = jnp.linalg.eigh(A_dense)
+            pair_cache[pair_key] = (evecs, {_repr(mats_i[0]): evals})
+        elif len(mats_i) == 2:
+            import numpy as _np
+            import scipy.linalg as _scipy_linalg
+
+            A0_np = _np.array(cast(MatrixProtocol, mats_i[0]).todense())
+            A1_np = _np.array(cast(MatrixProtocol, mats_i[1]).todense())
+            # Generalized eigenproblem: try A0 v = λ A1 v (A1 must be PD).
+            # If that fails (A1 not PD), swap to A1 v = λ A0 v.
+            try:
+                evals_np, evecs_np = _scipy_linalg.eigh(A0_np, A1_np)
+                evals = jnp.array(evals_np)
+                evecs = jnp.array(evecs_np)
+                pair_cache[pair_key] = (
+                    evecs,
+                    {
+                        _repr(mats_i[0]): evals,
+                        _repr(mats_i[1]): jnp.ones_like(evals),
+                    },
+                )
+            except Exception:
+                evals_np, evecs_np = _scipy_linalg.eigh(A1_np, A0_np)
+                evals = jnp.array(evals_np)
+                evecs = jnp.array(evecs_np)
+                pair_cache[pair_key] = (
+                    evecs,
+                    {
+                        _repr(mats_i[1]): evals,
+                        _repr(mats_i[0]): jnp.ones_like(evals),
+                    },
+                )
+        else:
+            raise ValueError(
+                f"Axis {i} has {len(mats_i)} distinct factor matrices; "
+                "simultaneous diagonalization requires ≤ 2 distinct matrices per axis."
+            )
+
+    # Build per-axis eigenvector list and global repr_id→eigenvalues map.
+    eigvecs: list[Array] = []
+    axis_eigenvalues: dict[int, Array] = {}
+    for i in range(ndim):
+        mats_i = list(
+            {_repr(tp.mats[i]): _mat_by_id[_repr(tp.mats[i])] for tp in tpmats}.values()
+        )
+        pair_key = frozenset(_repr(m) for m in mats_i)
+        evecs, evals_map = pair_cache[pair_key]
+        eigvecs.append(evecs)
+        axis_eigenvalues.update(evals_map)
+
+    per_term_eigenvalues = [
+        [axis_eigenvalues[_repr(tp.mats[i])] for i in range(ndim)] for tp in tpmats
+    ]
+    scales = [tp.scale for tp in tpmats]
+    shape = tuple(int(tpmats[0].mats[i].shape[0]) for i in range(ndim))
+    return TPMatricesLUFactors(
+        eigvecs=eigvecs,
+        per_term_eigenvalues=per_term_eigenvalues,
+        scales=scales,
+        shape=shape,
+    )
+
+
+def tpmats_wavenumber_factor(
+    A: list[TPMatrix] | TPMatrices,
+) -> TPMatricesWavenumberSolver:
+    """Pre-factorize a Fourier × polynomial :class:`TPMatrices` system.
+
+    Detects which axes are Fourier (every term has a purely diagonal
+    :class:`~jaxfun.la.DiaMatrix` — ``offsets == (0,)`` — on that axis) and
+    which is the polynomial axis (banded but not purely diagonal).
+
+    For each Fourier wavenumber index ``k`` assembles the 1-D banded
+    polynomial system
+
+    .. math::
+
+        B_k = \\sum_i s_i \\Bigl(\\prod_{a \\in \\text{Fourier}}
+        F_i^{(a)}[k_a]\\Bigr)\\, P_i
+
+    as a :class:`~jaxfun.la.DiaMatrix` (preserving the banded sparsity
+    pattern of the polynomial matrices) and warms its
+    :meth:`~jaxfun.la.DiaMatrix.lu_factor` cache.
+
+    Args:
+        A: :class:`list` of :class:`TPMatrix` (as returned by
+            :func:`~jaxfun.galerkin.inner.inner`) or a
+            :class:`TPMatrices` instance.
+
+    Returns:
+        :class:`TPMatricesWavenumberSolver` for repeated fast solves.
+
+    Raises:
+        TypeError: If ``A`` is not a ``list[TPMatrix]`` or
+            :class:`TPMatrices`.
+        ValueError: If the structure does not have exactly one non-diagonal
+            (polynomial) axis, e.g. for fully symmetric problems where
+            :func:`tpmats_lu_factor` should be used instead.
+    """
+    if isinstance(A, TPMatrices):
+        tpmats: list[TPMatrix] = list(A.tpmats)
+    elif isinstance(A, list):
+        tpmats = A
+    else:
+        raise TypeError(
+            f"tpmats_wavenumber_factor expects a list[TPMatrix] or TPMatrices, "
+            f"got {type(A).__name__!r}."
+        )
+    ndim: int = tpmats[0].dims
+
+    def _is_diagonal_axis(axis: int) -> bool:
+        return all(set(cast(DiaMatrix, tp.mats[axis]).offsets) == {0} for tp in tpmats)
+
+    fourier_axes = [a for a in range(ndim) if _is_diagonal_axis(a)]
+    poly_axes = [a for a in range(ndim) if not _is_diagonal_axis(a)]
+
+    if len(poly_axes) != 1:
+        raise ValueError(
+            f"tpmats_wavenumber_factor requires exactly 1 polynomial "
+            f"(non-diagonal) axis; found {len(poly_axes)}: {poly_axes}. "
+            f"Use tpmats_lu_factor for fully-symmetric problems."
+        )
+
+    poly_axis = poly_axes[0]
+    shape = tuple(int(tpmats[0].mats[a].shape[0]) for a in range(ndim))
+    n_P = shape[poly_axis]
+
+    # Build weight matrix W[i, k] = scale_i * prod_a(diag(F_i^(a))[k_a]).
+    # The flat Fourier index k varies in C-order (last Fourier axis fastest),
+    # matching the transposed layout used in TPMatricesWavenumberSolver.solve.
+    W_list: list[Array] = []
+    for tp in tpmats:
+        w: Array = jnp.asarray(tp.scale, dtype=jnp.float32).reshape(1)
+        for a in fourier_axes:
+            # Diagonal DiaMatrix: data has shape (1, n_a); data[0] is the diagonal.
+            diag_a = jnp.asarray(tp.mats[a].data[0], dtype=jnp.float32)  # (n_a,)
+            w = jnp.outer(w, diag_a).flatten()  # 1 → n_{a0} → n_{a0}*n_{a1} → …
+        W_list.append(w)  # (n_F,)
+
+    W = jnp.stack(W_list)  # (n_terms, n_F)
+
+    # Union of offsets across all polynomial matrices, in sorted order.
+    poly_offsets: tuple[int, ...] = tuple(
+        sorted(
+            {
+                int(off)
+                for tp in tpmats
+                for off in cast(DiaMatrix, tp.mats[poly_axis]).offsets
+            }
+        )
+    )
+
+    # Stack polynomial DIA data aligned to poly_offsets.
+    # P_data_stack[i, d, :] = data of term i for offset poly_offsets[d].
+    P_data_rows: list[Array] = []
+    for tp in tpmats:
+        mat = cast(DiaMatrix, tp.mats[poly_axis])
+        rows: list[Array] = []
+        for off in poly_offsets:
+            if off in mat.offsets:
+                idx = list(mat.offsets).index(off)
+                rows.append(jnp.asarray(mat.data[idx], dtype=jnp.float32))
+            else:
+                rows.append(jnp.zeros(n_P, dtype=jnp.float32))
+        P_data_rows.append(jnp.stack(rows))  # (n_diags, n_P)
+
+    P_data_stack = jnp.stack(P_data_rows)  # (n_terms, n_diags, n_P)
+
+    # Assemble per-wavenumber DIA data:
+    # B_data_batch[k, d, :] = sum_i W[i,k] * P_data_stack[i, d, :].
+    B_data_batch = jnp.einsum("tf,tdp->fdp", W, P_data_stack)  # (n_F, n_diags, n_P)
+    n_F = B_data_batch.shape[0]
+
+    # Build per-wavenumber DiaMatrix objects and warm their lu_factor caches.
+    B_matrices: list[DiaMatrix] = []
+    for k in range(n_F):
+        B_k = DiaMatrix(
+            data=B_data_batch[k],
+            offsets=poly_offsets,
+            shape=(n_P, n_P),
+        )
+        B_k.lu_factor()  # warms the cache stored on B_k
+        B_matrices.append(B_k)
+
+    return TPMatricesWavenumberSolver(
+        poly_axis=poly_axis,
+        B_matrices=B_matrices,
+        shape=shape,
+    )
 
 
 def tpmats_to_kron(A: TPMatrix | list[TPMatrix], tol: int = 100) -> Matrix | DiaMatrix:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -16,6 +16,7 @@ from scipy import sparse as scipy_sparse
 
 from jaxfun.coordinates import CoordSys
 from jaxfun.la import DiaMatrix, Matrix, MatrixProtocol, diakron
+from jaxfun.la.matrix import LUFactors
 from jaxfun.typing import MeshKind
 
 if TYPE_CHECKING:
@@ -1105,28 +1106,44 @@ class TPMatrices(nnx.Pytree):
             jnp.array([mat._rmatmul_array(w) for mat in self.tpmats]), axis=0
         )
 
-    def lu_factor(self) -> TPMatricesLUFactors | TPMatricesWavenumberSolver:
+    def lu_factor(
+        self,
+    ) -> TPMatricesDenseLUFactors | TPMatricesLUFactors | TPMatricesWavenumberSolver:
         """Pre-compute factors for repeated fast solves.
 
-        Tries :func:`tpmats_wavenumber_factor` first (efficient for Fourier ×
-        polynomial problems), then falls back to :func:`tpmats_lu_factor`
-        (diagonalization).
+        Dispatch order:
+
+        1. If all per-axis factor matrices are dense :class:`~jaxfun.la.Matrix`
+           instances, use :func:`tpmats_dense_lu_factor` (simple full Kronecker
+           LU — works for any linear system).
+        2. Otherwise try :func:`tpmats_wavenumber_factor` (efficient for
+           Fourier × polynomial problems).
+        3. Fall back to :func:`tpmats_lu_factor` (diagonalization — requires
+           simultaneously diagonalizable factor matrices per axis).
 
         Returns:
-            :class:`TPMatricesWavenumberSolver` or :class:`TPMatricesLUFactors`
-            for repeated fast solves.
+            :class:`TPMatricesDenseLUFactors`, :class:`TPMatricesWavenumberSolver`,
+            or :class:`TPMatricesLUFactors` for repeated fast solves.
         """
-        cached: TPMatricesLUFactors | TPMatricesWavenumberSolver | None = getattr(
-            self, "_lu_cache", None
-        )
+        cached: (
+            TPMatricesDenseLUFactors
+            | TPMatricesLUFactors
+            | TPMatricesWavenumberSolver
+            | None
+        ) = getattr(self, "_lu_cache", None)
         if cached is not None:
             return cached
-        try:
-            result: TPMatricesLUFactors | TPMatricesWavenumberSolver = (
-                tpmats_wavenumber_factor(list(self.tpmats))
-            )
-        except ValueError:
-            result = tpmats_lu_factor(list(self.tpmats))
+        result: (
+            TPMatricesDenseLUFactors | TPMatricesLUFactors | TPMatricesWavenumberSolver
+        )
+        tpmats_list = list(self.tpmats)
+        if all(isinstance(mat, Matrix) for tp in tpmats_list for mat in tp.mats):
+            result = tpmats_dense_lu_factor(tpmats_list)
+        else:
+            try:
+                result = tpmats_wavenumber_factor(tpmats_list)
+            except ValueError:
+                result = tpmats_lu_factor(tpmats_list)
         object.__setattr__(self, "_lu_cache", result)
         return result
 
@@ -1620,6 +1637,79 @@ class TPMatricesWavenumberSolver:
         for new_pos, old_pos in enumerate(axes_order):
             inv_perm[old_pos] = new_pos
         return jnp.transpose(sol_perm, inv_perm)
+
+
+class TPMatricesDenseLUFactors:
+    """Dense Kronecker-product LU solver for a sum of :class:`TPMatrix`.
+
+    Assembles the full (dense) Kronecker product ``sum_k s_k A_k^(0) ⊗ …``
+    into a single :class:`~jaxfun.la.Matrix`, LU-factorizes it once, and
+    solves by a single triangular-substitution call.
+
+    This is the appropriate solver when all per-axis factor matrices are
+    dense :class:`~jaxfun.la.Matrix` instances.  It imposes no structural
+    requirement on the system (unlike the diagonalization-based
+    :class:`TPMatricesLUFactors` which requires simultaneously diagonalizable
+    factor matrices).
+
+    Attributes:
+        lu: Pre-computed :class:`~jaxfun.la.matrix.LUFactors` of the full
+            assembled Kronecker product.
+        shape: Per-axis sizes ``(n0, n1, …)``.
+    """
+
+    def __init__(self, lu: LUFactors, shape: tuple[int, ...]) -> None:
+        self.lu = lu
+        self.shape = shape
+
+    @jax.jit(static_argnums=(0,))
+    def solve(self, rhs: Array) -> Array:
+        """Solve the summed tensor-product system for RHS ``rhs``.
+
+        Args:
+            rhs: Right-hand side, flat ``(n,)`` or shaped ``(n0, n1, …)``.
+
+        Returns:
+            Solution with the same shape as ``rhs``.
+        """
+        return self.lu.solve(rhs.ravel()).reshape(rhs.shape)
+
+
+def tpmats_dense_lu_factor(
+    A: TPMatrix | list[TPMatrix],
+) -> TPMatricesDenseLUFactors:
+    """Assemble and LU-factorize the dense Kronecker product of a :class:`TPMatrices`.
+
+    Sums all Kronecker-product terms into a single dense
+    :class:`~jaxfun.la.Matrix` and computes its LU factorisation.  This is
+    the simplest solver and is appropriate when all per-axis factor matrices
+    are dense :class:`~jaxfun.la.Matrix` instances.
+
+    Args:
+        A: Single :class:`TPMatrix` or list thereof (as returned by
+           :func:`~jaxfun.galerkin.inner.inner`).
+
+    Returns:
+        :class:`TPMatricesDenseLUFactors` whose :meth:`~TPMatricesDenseLUFactors.solve`
+        method solves the system without re-factorising.
+
+    Raises:
+        TypeError: if any factor matrix is not a :class:`~jaxfun.la.Matrix`.
+    """
+    if isinstance(A, TPMatrix):
+        A = [A]
+    tpmats = list(A)
+    for tp in tpmats:
+        for mat in tp.mats:
+            if not isinstance(mat, Matrix):
+                raise TypeError(
+                    f"tpmats_dense_lu_factor requires all factor matrices to be "
+                    f"Matrix (dense); got {type(mat).__name__}."
+                )
+    mat = tpmats_to_kron(tpmats)
+    assert isinstance(mat, Matrix)
+    shape = tuple(int(tpmats[0].mats[i].shape[0]) for i in range(tpmats[0].dims))
+    return TPMatricesDenseLUFactors(lu=mat.lu_factor(), shape=shape)
 
 
 def tpmats_lu_factor(A: TPMatrix | list[TPMatrix]) -> TPMatricesLUFactors:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -1027,6 +1027,12 @@ class TPMatrix(nnx.Pytree):  # noqa: B903
 
         Returns:
             Solution array with the same shape as ``rhs``.
+
+        Note:
+            This method is not highly useful, because TPMatrices are not often
+            solved directly by themselves. There is usually a list of them in a
+            :class:`TPMatrices`, and the summed system is then solved without
+            using this solve method.
         """
         return self.lu_factor().solve(rhs)
 
@@ -1226,11 +1232,11 @@ class BlockTPMatrix:
 
     def __init__(
         self,
-        tpmats: list[TPMatrix],
+        tpmats: list[TPMatrix] | TPMatrices,
         test_space: VectorTensorProductSpace,
         trial_space: VectorTensorProductSpace,
     ) -> None:
-        self.tpmats = tpmats
+        self.tpmats = tpmats.tpmats if isinstance(tpmats, TPMatrices) else tpmats
         self.test_space = test_space
         self.trial_space = trial_space
         self.shape = (self.test_space.dim, self.trial_space.dim)
@@ -1249,15 +1255,6 @@ class BlockTPMatrix:
             out = out.at[indices[0]].add(mat @ w[indices[1]])
         return out
 
-    @jax.jit(static_argnums=0)
-    def mat(self) -> Array:
-        """Return explicit block matrix (dense)."""
-        out = jnp.zeros(self.shape)
-        for m in self.tpmats:
-            indices = m.global_indices
-            out = out.at[self.slice(indices)].add(m.mat)
-        return out
-
     def slice(self, indices: tuple[int, ...]) -> tuple[slice, ...]:  # ty:ignore[invalid-type-form]
         """Return slice object for block matrix indices."""
         N = self.test_block_sizes
@@ -1267,26 +1264,149 @@ class BlockTPMatrix:
             slice(jnp.sum(M[: indices[1]]), jnp.sum(M[: indices[1] + 1])),
         )
 
-    def block_array(self) -> Matrix:
-        """Return dense block matrix assembled from Kronecker products."""
+    def todense(self) -> Array:
+        """Return dense array."""
         out = jnp.zeros(self.shape)
         for m in self.tpmats:
             indices = m.global_indices
             block = m.mat
             dense = block.todense()
             out = out.at[self.slice(indices)].add(dense)
-        return Matrix(out)
+        return out
+
+    def to_Matrix(self) -> Matrix:
+        """Return dense matrix object."""
+        return Matrix(self.todense())
+
+    def tosparse(self) -> DiaMatrix:
+        """Assemble global :class:`~jaxfun.la.DiaMatrix` from DiaMatrix-factor blocks.
+
+        The assembled matrix is cached on the instance so repeated calls are
+        free.
+
+        Returns:
+            :class:`~jaxfun.la.DiaMatrix` of shape ``(total_rows, total_cols)``.
+
+        Raises:
+            TypeError: if any factor matrix is not a
+                :class:`~jaxfun.la.DiaMatrix`.
+        """
+        for tp in self.tpmats:
+            for mat in tp.mats:
+                if not isinstance(mat, DiaMatrix):
+                    raise TypeError(
+                        f"tosparse requires all factor matrices to be DiaMatrix; "
+                        f"got {type(mat).__name__}."
+                    )
+
+        cached: DiaMatrix | None = getattr(self, "_sparse_cache", None)
+        if cached is not None:
+            return cached
+
+        # Group TPMatrix objects by global_indices.
+        from collections import defaultdict
+
+        grouped: dict[tuple[int, int], list[TPMatrix]] = defaultdict(list)
+        for mat in self.tpmats:
+            grouped[mat.global_indices].append(mat)
+
+        test_block_sizes = [int(s) for s in self.test_block_sizes]
+        trial_block_sizes = [int(s) for s in self.trial_block_sizes]
+        test_starts = [sum(test_block_sizes[:i]) for i in range(len(test_block_sizes))]
+        trial_starts = [
+            sum(trial_block_sizes[:i]) for i in range(len(trial_block_sizes))
+        ]
+        total_rows = sum(test_block_sizes)
+        total_cols = sum(trial_block_sizes)
+
+        # Build per-block DiaMatrix and collect all global diagonal offsets.
+        block_dias: dict[tuple[int, int], DiaMatrix] = {}
+        global_offsets: set[int] = set()
+        for (bi, bj), mats in grouped.items():
+            block_dia = tpmats_to_kron(mats)
+            if not isinstance(block_dia, DiaMatrix):
+                raise TypeError(
+                    f"tpmats_to_kron returned {type(block_dia).__name__} for block "
+                    f"({bi},{bj}); expected DiaMatrix."
+                )
+            block_dias[(bi, bj)] = block_dia
+            shift = trial_starts[bj] - test_starts[bi]
+            for k in block_dia.offsets:
+                global_offsets.add(int(k) + shift)
+
+        sorted_offsets = tuple(sorted(global_offsets))
+        offset_to_idx = {k: i for i, k in enumerate(sorted_offsets)}
+
+        # Allocate global DIA data array and scatter each block's diagonals.
+        dtype = jnp.result_type(*[d.data.dtype for d in block_dias.values()])
+        global_data = jnp.zeros((len(sorted_offsets), total_cols), dtype=dtype)
+        for (bi, bj), block_dia in block_dias.items():
+            col_start = trial_starts[bj]
+            shift = col_start - test_starts[bi]
+            n_cols_block = trial_block_sizes[bj]
+            for d_b, k_b in enumerate(block_dia.offsets):
+                d_g = offset_to_idx[int(k_b) + shift]
+                global_data = global_data.at[
+                    d_g, col_start : col_start + n_cols_block
+                ].add(block_dia.data[d_b])
+
+        result = DiaMatrix(
+            data=global_data, offsets=sorted_offsets, shape=(total_rows, total_cols)
+        )
+        object.__setattr__(self, "_sparse_cache", result)
+        return result
 
     def __call__(self, u: Array | JAXFunction) -> Array:
-        """Apply block matrix to coefficient array u."""
+        """Apply block matrix to coefficient array u.
+
+        Uses the RCM-permuted :class:`~jaxfun.la.DiaMatrix` for a single
+        global matvec when the sparse cache has been populated (e.g. after
+        :meth:`solve` or an explicit :meth:`tosparse` call); otherwise falls
+        back to the per-block path.
+        """
         from jaxfun.galerkin import JAXFunction
 
         w = u.array if isinstance(u, JAXFunction) else u
+        rcm_cache: tuple[DiaMatrix, Array, Array] | None = getattr(
+            self, "_rcm_cache", None
+        )
+        if rcm_cache is not None:
+            A_perm, perm, inv_perm = rcm_cache
+            return A_perm.matvec(w.ravel()[perm])[inv_perm].reshape(w.shape)
+        sparse: DiaMatrix | None = getattr(self, "_sparse_cache", None)
+        if sparse is not None:
+            return sparse.matvec(w.ravel()).reshape(w.shape)
         return self._matmul_array(w)
 
     def solve(self, b: Array) -> Array:
-        """Solve M x = b using a dense factorisation of the block matrix."""
-        M = self.block_array()
+        """Solve ``M x = b``.
+
+        When all factor matrices are :class:`~jaxfun.la.DiaMatrix` instances,
+        assembles the global sparse matrix via :meth:`tosparse`, applies the
+        reverse Cuthill-McKee permutation to minimise bandwidth, and solves
+        with the banded LU.  The permuted matrix and permutation vectors are
+        cached so repeated solves are cheap.
+
+        Falls back to a dense factorisation when any factor is a
+        :class:`~jaxfun.la.Matrix`.
+        """
+        all_dia = all(
+            isinstance(mat, DiaMatrix) for tp in self.tpmats for mat in tp.mats
+        )
+        if all_dia:
+            rcm_cache: tuple[DiaMatrix, Array, Array] | None = getattr(
+                self, "_rcm_cache", None
+            )
+            if rcm_cache is None:
+                _, perm, inv_perm = self.tosparse().rcm()
+                # tosparse().rcm() caches on the DiaMatrix; mirror here so
+                # __call__ can find it without re-entering tosparse().
+                rcm_cache = self.tosparse().rcm()
+                object.__setattr__(self, "_rcm_cache", rcm_cache)
+            A_perm, perm, inv_perm = rcm_cache
+            x_perm = A_perm.solve(b.ravel()[perm])
+            return x_perm[inv_perm].reshape(b.shape)
+        M = self.to_Matrix()
         return M.solve(b.ravel()).reshape(b.shape)
 
 

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -309,6 +309,16 @@ class DiaMatrix(nnx.Pytree):
 
         return Matrix(self.todense())
 
+    def to_scipy(self):
+        """Return a ``scipy.sparse.dia_matrix`` equivalent of this matrix."""
+        import numpy as np
+        from scipy.sparse import dia_matrix
+
+        return dia_matrix(
+            (np.asarray(self.data), np.array(self.offsets, dtype=np.int32)),
+            shape=self.shape,
+        )
+
     def lu_factor(self, *, pivot: bool = False) -> LUFactors:
         """Compute a banded LU factorisation of this (square) matrix.
 
@@ -516,17 +526,19 @@ class DiaMatrix(nnx.Pytree):
 
         Uses the banded LU factorisation (:meth:`lu_factor`) when the
         bandwidth is narrow enough that the JIT-compiled kernel compiles
-        quickly.  Falls back to ``jnp.linalg.solve`` on the dense matrix when
-        the product ``p * (q + 1)`` (number of unrolled loop iterations in the
-        LU kernel) exceeds ``dense_threshold``, avoiding multi-minute XLA
-        compile times for wide-banded matrices.
+        quickly.  When the product ``p * (q + 1)`` exceeds ``dense_threshold``,
+        first attempts to reduce bandwidth via :meth:`rcm`; if the permuted
+        matrix fits within the threshold the banded solve is applied on the
+        permuted system.  Only if RCM cannot reduce the bandwidth enough does
+        the method fall back to ``jnp.linalg.solve`` on the dense matrix,
+        avoiding multi-minute XLA compile times for wide-banded matrices.
 
         Args:
             b: Right-hand side array.
             axis: Axis of ``b`` along which the system is solved.
             pivot: Passed to :meth:`lu_factor` (banded path only).
             dense_threshold: Maximum bandwidth ``p * (q + 1)`` before
-                switching to a dense solver. Default 100.
+                trying RCM / switching to a dense solver. Default 100.
 
         Returns:
             Solution array with the same shape as ``b``.
@@ -544,10 +556,40 @@ class DiaMatrix(nnx.Pytree):
         if _box is not None and pivot in _box.value:
             return _box.value[pivot].solve(b, axis=axis)
 
+        # If the RCM-path factorisation is cached, use it directly.
+        _rcm_box: _CacheBox[dict[bool, tuple[LUFactors, Array, Array]]] | None = (
+            getattr(self, "_rcm_solve_cache", None)
+        )
+        if _rcm_box is not None and pivot in _rcm_box.value:
+            lu_perm, perm, inv_perm = _rcm_box.value[pivot]
+            ax = axis % b.ndim
+            return jnp.take(
+                lu_perm.solve(jnp.take(b, perm, axis=ax), axis=ax), inv_perm, axis=ax
+            )
+
         if p * (q + 1) > dense_threshold:
-            # Dense path: XLA compiles jnp.linalg.solve in milliseconds.
-            # Cache the dense LUFactors so repeated calls pay only the
-            # forward/back substitution cost (same as the banded path).
+            # Try RCM reordering first: may reduce bandwidth enough for the
+            # banded LU kernel, avoiding both the dense-solve cost and the
+            # dense-matrix allocation.
+            A_perm, perm, inv_perm = self.rcm()
+            offsets_p = A_perm.offsets
+            p_p = max((-k for k in offsets_p if k < 0), default=0)
+            q_p = max((k for k in offsets_p if k > 0), default=0)
+            if p_p * (q_p + 1) <= dense_threshold:
+                # Permute b along the solve axis, solve, un-permute.
+                lu_perm = A_perm.lu_factor(pivot=pivot)
+                # Cache so future calls short-circuit above.
+                _rcm_box = getattr(self, "_rcm_solve_cache", None)
+                if _rcm_box is None:
+                    _rcm_box = _CacheBox({})
+                    object.__setattr__(self, "_rcm_solve_cache", _rcm_box)
+                _rcm_box.value[pivot] = (lu_perm, perm, inv_perm)
+                ax = axis % b.ndim
+                b_perm = jnp.take(b, perm, axis=ax)
+                x_perm = lu_perm.solve(b_perm, axis=ax)
+                return jnp.take(x_perm, inv_perm, axis=ax)
+
+            # Bandwidth still too large after RCM: fall back to dense.
             from jaxfun.la.matrix import Matrix  # local import avoids circular
 
             _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
@@ -1219,6 +1261,191 @@ class DiaMatrix(nnx.Pytree):
             f"DiaMatrix(shape=({n}, {m}), dtype={self.dtype}, "
             f"n_diags={nd}, nnz={self.nnz}, offsets={self.offsets})"
         )
+
+    def rcm(self) -> tuple[DiaMatrix, Array, Array]:
+        """Apply the reverse Cuthill-McKee algorithm to reduce bandwidth.
+
+        Computes a symmetric row/column permutation ``perm`` using the
+        Scipy :func:`_rcm_scipy` implementation and returns the permuted
+        matrix ``A[perm][:, perm]`` together with the forward and inverse
+        permutation arrays.
+
+        The result is a setup-time host operation (not JIT'd) and is cached
+        on the instance via :class:`_CacheBox`.
+
+        Returns:
+            ``(A_perm, perm, inv_perm)`` where
+
+            * ``A_perm`` — :class:`DiaMatrix` with reduced bandwidth.
+            * ``perm`` — 1-D int array: ``A_perm[i, j] = A[perm[i], perm[j]]``.
+            * ``inv_perm`` — 1-D int array satisfying
+              ``inv_perm[perm[i]] == i``, used to un-permute the solution.
+
+        Example::
+
+            A_perm, perm, inv_perm = A.rcm()
+            x_perm = A_perm.solve(b[perm])
+            x = x_perm[inv_perm]
+        """
+        _box: _CacheBox[tuple[DiaMatrix, Array, Array]] | None = getattr(
+            self, "_rcm_cache", None
+        )
+        if _box is not None:
+            return _box.value
+
+        n, m = self.shape
+        perm = _rcm_scipy(self.data, self.offsets, self.shape)
+        new_data, new_offsets = _permute_dia(self.data, self.offsets, (n, m), perm)
+
+        A_perm = DiaMatrix(
+            data=new_data,
+            offsets=new_offsets,
+            shape=(n, n),
+        )
+        inv_perm = jnp.argsort(perm).astype(jnp.int32)
+        result = (A_perm, perm, inv_perm)
+        object.__setattr__(self, "_rcm_cache", _CacheBox(result))
+        return result
+
+
+@jax.jit(static_argnums=(1, 2, 3))
+def _permute_dia_kernel(
+    data: Array,
+    offsets: tuple[int, ...],
+    shape: tuple[int, int],
+    new_offsets: tuple[int, ...],
+    perm: Array,
+) -> Array:
+    """JIT-compiled scatter kernel for :func:`_permute_dia`.
+
+    Takes the output offset set as a static argument so the output shape
+    ``(len(new_offsets), m)`` is known at compile time.  An extra scratch
+    row (index ``len(new_offsets)``) absorbs writes for structural zeros
+    whose new diagonal is not in *new_offsets*.
+
+    Args:
+        data: Column-aligned DIA data of shape ``(n_diags, n_cols)``.
+        offsets: Static diagonal offsets of *data*.
+        shape: Static ``(n, m)`` matrix shape.
+        new_offsets: Static sorted diagonal offsets of the output matrix.
+        perm: Permutation array of length ``n``.
+
+    Returns:
+        New DIA data array of shape ``(len(new_offsets), m)``.
+    """
+    n, m = shape
+    n_new = len(new_offsets)
+    inv_perm = jnp.argsort(perm).astype(jnp.int32)
+
+    # Build lookup: offset value → row index in new_data.
+    # Offsets range from -(n-1) to (n-1); shift so index 0 = offset -(n-1).
+    # Entries absent from new_offsets map to n_new (scratch row).
+    shift = n - 1
+    lookup = jnp.full(2 * n - 1, jnp.int32(n_new), dtype=jnp.int32)
+    for ri, nk in enumerate(new_offsets):
+        lookup = lookup.at[nk + shift].set(jnp.int32(ri))
+
+    # Allocate output with one extra scratch row.
+    new_data = jnp.zeros((n_new + 1, m), dtype=data.dtype)
+
+    for ki, k in enumerate(offsets):
+        col_start = max(0, k)
+        length = min(m - col_start, n - max(0, -k))
+        if length <= 0:
+            continue
+        col_idx = jnp.arange(col_start, col_start + length, dtype=jnp.int32)
+        new_cs = inv_perm[col_idx]
+        new_rs = inv_perm[col_idx - jnp.int32(k)]
+        row_indices = lookup[new_cs - new_rs + shift]
+        new_data = new_data.at[row_indices, new_cs].set(
+            data[ki, col_start : col_start + length]
+        )
+
+    return new_data[:n_new]
+
+
+def _permute_dia(
+    data: Array,
+    offsets: tuple[int, ...],
+    shape: tuple[int, int],
+    perm: Array,
+) -> tuple[Array, tuple[int, ...]]:
+    """Symmetrically permute a DIA matrix.
+
+    Computes ``A_perm[i, j] = A[perm[i], perm[j]]`` and returns the result in
+    column-aligned DIA format.
+
+    The output diagonal set is determined at Python level using NumPy on the
+    concrete arrays (since ``perm`` is always materialised at setup time), then
+    passed as a static argument to the JIT-compiled :func:`_permute_dia_kernel`
+    which performs the actual gather/scatter.
+
+    Args:
+        data: Column-aligned DIA data array of shape ``(n_diags, n_cols)``.
+        offsets: Diagonal offsets corresponding to rows of *data*.
+        shape: ``(n_rows, n_cols)`` of the original matrix.
+        perm: Permutation array of length ``n``.
+
+    Returns:
+        ``(new_data, new_offsets)`` in column-aligned DIA format with the same
+        dtype as *data*.
+    """
+    import numpy as np
+
+    n, m = shape
+    perm_np = np.asarray(perm)
+    inv_perm_np = np.argsort(perm_np)
+    data_np = np.asarray(data)
+
+    # Determine new_offsets from concrete values — pure NumPy, no JIT needed.
+    new_ks: set[int] = set()
+    for ki, k in enumerate(offsets):
+        col_start = max(0, k)
+        length = min(m - col_start, n - max(0, -k))
+        if length <= 0:
+            continue
+        col_idx = np.arange(col_start, col_start + length)
+        row_idx = col_idx - k
+        nz = data_np[ki, col_start : col_start + length] != 0
+        if not nz.any():
+            continue
+        new_cs = inv_perm_np[col_idx[nz]]
+        new_rs = inv_perm_np[row_idx[nz]]
+        new_ks.update(map(int, new_cs - new_rs))
+
+    if not new_ks:
+        return jnp.zeros((0, m), dtype=data.dtype), ()
+
+    new_offsets = tuple(sorted(new_ks))
+    new_data = _permute_dia_kernel(data, offsets, shape, new_offsets, perm)
+    return new_data, new_offsets
+
+
+def _rcm_scipy(
+    data: Array,
+    offsets: tuple[int, ...],
+    shape: tuple[int, int],
+) -> Array:
+    """Compute the RCM permutation via :func:`scipy.sparse.csgraph.reverse_cuthill_mckee`.
+
+    Args:
+        data: Column-aligned DIA data array.
+        offsets: Diagonal offsets.
+        shape: ``(n, m)`` matrix shape.
+
+    Returns:
+        1-D ``int32`` JAX array ``perm`` of length ``n``.
+    """  # noqa: E501
+    import numpy as np
+    import scipy.sparse as sp_sparse
+    from scipy.sparse.csgraph import reverse_cuthill_mckee
+
+    n, m = shape
+    sp_dia = sp_sparse.dia_matrix(
+        (np.asarray(data), list(offsets)), shape=(n, m)
+    ).tocsr()
+    perm_np = reverse_cuthill_mckee(sp_dia, symmetric_mode=False).astype(np.int32)
+    return jnp.array(perm_np)
 
 
 @jax.jit(static_argnums=(2, 3, 4))

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -7,7 +7,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
-from jaxfun.la.matrixprotocol import _CacheBox
+from jaxfun.la.matrixprotocol import DiaMatrixSolveMethod, _CacheBox
 
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
@@ -520,91 +520,152 @@ class DiaMatrix(nnx.Pytree):
         axis: int = 0,
         *,
         pivot: bool = False,
-        dense_threshold: int = 100,
+        method: DiaMatrixSolveMethod | str = DiaMatrixSolveMethod.AUTO,
+        auto_threshold: int = 100,
     ) -> Array:
         """Solve ``A x = b``.
 
-        Uses the banded LU factorisation (:meth:`lu_factor`) when the
-        bandwidth is narrow enough that the JIT-compiled kernel compiles
-        quickly.  When the product ``p * (q + 1)`` exceeds ``dense_threshold``,
-        first attempts to reduce bandwidth via :meth:`rcm`; if the permuted
-        matrix fits within the threshold the banded solve is applied on the
-        permuted system.  Only if RCM cannot reduce the bandwidth enough does
-        the method fall back to ``jnp.linalg.solve`` on the dense matrix,
-        avoiding multi-minute XLA compile times for wide-banded matrices.
+        Three solver paths are available, selected via *method*:
+
+        * ``"banded"`` — banded LU factorisation (:meth:`lu_factor`).  Fast
+          when the matrix bandwidth ``p * (q + 1)`` is small, but XLA compile
+          time grows with bandwidth.
+        * ``"rcm"`` — apply reverse Cuthill-McKee reordering (:meth:`rcm`),
+          then banded LU on the permuted system.  Useful when the original
+          bandwidth is large but RCM can reduce it.
+        * ``"dense"`` — ``jnp.linalg.solve`` on the dense matrix.  Suitable
+          for small or nearly full matrices where the banded structure offers
+          no advantage.
+        * ``"auto"`` (default) — heuristic that checks cached factorisations
+          first, then chooses ``"banded"`` when ``p * (q + 1) <= auto_threshold``,
+          ``"rcm"`` when RCM reduces the bandwidth to ``<= auto_threshold``, and
+          ``"dense"`` otherwise.
 
         Args:
             b: Right-hand side array.
             axis: Axis of ``b`` along which the system is solved.
-            pivot: Passed to :meth:`lu_factor` (banded path only).
-            dense_threshold: Maximum bandwidth ``p * (q + 1)`` before
-                trying RCM / switching to a dense solver. Default 100.
+            pivot: Passed to :meth:`lu_factor` (banded and RCM paths only).
+            method: One of ``"auto"``, ``"banded"``, ``"rcm"``, or
+                ``"dense"``.  Default ``"auto"``.
+            auto_threshold: Threshold for the ``"auto"`` method, trading off
+                banded/RCM solvers against dense.  The banded solver is usually
+                faster for small bandwidth, but compile time grows with bandwidth.
+                RCM can reduce bandwidth and enable the banded solver, but adds
+                overhead and is not guaranteed to help.  Default is 100.
 
         Returns:
             Solution array with the same shape as ``b``.
-        """
-        offsets = self.offsets
-        p = max((-k for k in offsets if k < 0), default=0)
-        q = max((k for k in offsets if k > 0), default=0)
 
-        # If the banded LU is already cached (e.g. from a prior lu_factor()
-        # call), use it regardless of bandwidth — the expensive compilation
-        # already happened.
+        Raises:
+            ValueError: If *method* is not one of the recognised values.
+        """
+        _METHODS = {"auto", "banded", "rcm", "dense"}
+        if method not in _METHODS:
+            raise ValueError(
+                f"method must be one of {sorted(_METHODS)!r}, got {method!r}"
+            )
+        method = DiaMatrixSolveMethod(method)
+
+        # ------------------------------------------------------------------
+        # "banded" path (and cache hit for banded)
+        # ------------------------------------------------------------------
         _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
             self, "_lu_cache", None
         )
-        if _box is not None and pivot in _box.value:
-            return _box.value[pivot].solve(b, axis=axis)
+        if method == DiaMatrixSolveMethod.BANDED or (
+            method == DiaMatrixSolveMethod.AUTO
+            and _box is not None
+            and pivot in _box.value
+        ):
+            return self.lu_factor(pivot=pivot).solve(b, axis=axis)
 
-        # If the RCM-path factorisation is cached, use it directly.
+        # ------------------------------------------------------------------
+        # "rcm" path (and cache hit for rcm)
+        # ------------------------------------------------------------------
         _rcm_box: _CacheBox[dict[bool, tuple[LUFactors, Array, Array]]] | None = (
             getattr(self, "_rcm_solve_cache", None)
         )
-        if _rcm_box is not None and pivot in _rcm_box.value:
+        if method == DiaMatrixSolveMethod.RCM or (
+            method == DiaMatrixSolveMethod.AUTO
+            and _rcm_box is not None
+            and pivot in _rcm_box.value
+        ):
+            if _rcm_box is None or pivot not in _rcm_box.value:
+                A_perm, perm, inv_perm = self.rcm()
+                lu_perm = A_perm.lu_factor(pivot=pivot)
+                if _rcm_box is None:
+                    _rcm_box = _CacheBox({})
+                    object.__setattr__(self, "_rcm_solve_cache", _rcm_box)
+                _rcm_box.value[pivot] = (lu_perm, perm, inv_perm)
             lu_perm, perm, inv_perm = _rcm_box.value[pivot]
             ax = axis % b.ndim
             return jnp.take(
                 lu_perm.solve(jnp.take(b, perm, axis=ax), axis=ax), inv_perm, axis=ax
             )
 
-        if p * (q + 1) > dense_threshold:
-            # Try RCM reordering first: may reduce bandwidth enough for the
-            # banded LU kernel, avoiding both the dense-solve cost and the
-            # dense-matrix allocation.
-            A_perm, perm, inv_perm = self.rcm()
-            offsets_p = A_perm.offsets
-            p_p = max((-k for k in offsets_p if k < 0), default=0)
-            q_p = max((k for k in offsets_p if k > 0), default=0)
-            if p_p * (q_p + 1) <= dense_threshold:
-                # Permute b along the solve axis, solve, un-permute.
-                lu_perm = A_perm.lu_factor(pivot=pivot)
-                # Cache so future calls short-circuit above.
-                _rcm_box = getattr(self, "_rcm_solve_cache", None)
-                if _rcm_box is None:
-                    _rcm_box = _CacheBox({})
-                    object.__setattr__(self, "_rcm_solve_cache", _rcm_box)
-                _rcm_box.value[pivot] = (lu_perm, perm, inv_perm)
-                ax = axis % b.ndim
-                b_perm = jnp.take(b, perm, axis=ax)
-                x_perm = lu_perm.solve(b_perm, axis=ax)
-                return jnp.take(x_perm, inv_perm, axis=ax)
-
-            # Bandwidth still too large after RCM: fall back to dense.
+        # ------------------------------------------------------------------
+        # "dense" path (and cache hit for dense)
+        # ------------------------------------------------------------------
+        if method == DiaMatrixSolveMethod.DENSE:
             from jaxfun.la.matrix import Matrix  # local import avoids circular
 
-            _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
-                self, "_lu_cache", None
-            )
             if _box is None:
                 _box = _CacheBox({})
                 object.__setattr__(self, "_lu_cache", _box)
-            cache: dict[bool | str, LUFactors] = _box.value
             _dense_key = "_dense"
-            if _dense_key not in cache:
-                cache[_dense_key] = Matrix(self.todense()).lu_factor()  # type: ignore[index]
-            return cache[_dense_key].solve(b, axis=axis)
+            if _dense_key not in _box.value:
+                _box.value[_dense_key] = Matrix(self.todense()).lu_factor()  # type: ignore[index]
+            return _box.value[_dense_key].solve(b, axis=axis)
 
-        return self.lu_factor(pivot=pivot).solve(b, axis=axis)
+        # ------------------------------------------------------------------
+        # "auto": choose based on bandwidth
+        # ------------------------------------------------------------------
+        offsets = self.offsets
+        p = max((-k for k in offsets if k < 0), default=0)
+        q = max((k for k in offsets if k > 0), default=0)
+
+        if p * (q + 1) <= auto_threshold:
+            return self.lu_factor(pivot=pivot).solve(b, axis=axis)
+
+        # Try RCM: may reduce bandwidth enough for banded LU.
+        A_perm, perm, inv_perm = self.rcm()
+        offsets_p = A_perm.offsets
+        p_p = max((-k for k in offsets_p if k < 0), default=0)
+        q_p = max((k for k in offsets_p if k > 0), default=0)
+        if p_p * (q_p + 1) > p * (q + 1):
+            # RCM made it worse: skip it and go straight to dense.
+            warnings.warn(
+                f"DiaMatrix.lu_solve(method='auto'): RCM reordering increased bandwidth "  # noqa: E501
+                f"from p*(q+1)={p * (q + 1)} to p'*(q'+1)={p_p * (q_p + 1)}. ",
+                stacklevel=2,
+            )
+
+        elif p_p * (q_p + 1) <= auto_threshold:
+            lu_perm = A_perm.lu_factor(pivot=pivot)
+            if _rcm_box is None:
+                _rcm_box = _CacheBox({})
+                object.__setattr__(self, "_rcm_solve_cache", _rcm_box)
+            _rcm_box.value[pivot] = (lu_perm, perm, inv_perm)
+            ax = axis % b.ndim
+            return jnp.take(
+                lu_perm.solve(jnp.take(b, perm, axis=ax), axis=ax), inv_perm, axis=ax
+            )
+
+            # Bandwidth still too large after RCM: fall back to dense.
+            warnings.warn(
+                f"DiaMatrix.lu_solve(method='auto'): bandwidth p*(q+1)={p_p * (q_p + 1)} "  # noqa: E501
+                f"exceeds threshold {auto_threshold} even after RCM reordering. ",
+                stacklevel=2,
+            )
+
+        warnings.warn(
+            "Falling back to dense solver. Consider using a larger auto_threshold "
+            "or method='dense' to suppress this warning.",
+            stacklevel=2,
+        )
+        return self.lu_solve(
+            b, axis=axis, pivot=pivot, method=DiaMatrixSolveMethod.DENSE
+        )
 
     solve = lu_solve
 

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1356,6 +1356,8 @@ class DiaMatrix(nnx.Pytree):
             return _box.value
 
         n, m = self.shape
+        if n != m:
+            raise ValueError("RCM permutation is only defined for square matrices.")
         perm = _rcm_scipy(self.data, self.offsets, self.shape)
         new_data, new_offsets = _permute_dia(self.data, self.offsets, (n, m), perm)
 

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -651,7 +651,8 @@ class DiaMatrix(nnx.Pytree):
                 lu_perm.solve(jnp.take(b, perm, axis=ax), axis=ax), inv_perm, axis=ax
             )
 
-            # Bandwidth still too large after RCM: fall back to dense.
+        else:
+            # RCM reduced bandwidth but it still exceeds the threshold.
             warnings.warn(
                 f"DiaMatrix.lu_solve(method='auto'): bandwidth p*(q+1)={p_p * (q_p + 1)} "  # noqa: E501
                 f"exceeds threshold {auto_threshold} even after RCM reordering. ",

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -7,6 +7,8 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
+from jaxfun.la.matrixprotocol import _CacheBox
+
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
     from jaxfun.la import Matrix, MatrixProtocol
@@ -50,32 +52,6 @@ def _warn_dense_indexing() -> None:
         DenseIndexingWarning,
         stacklevel=3,
     )
-
-
-class _CacheBox[T]:
-    """Thin wrapper that provides identity-based equality and hashing.
-
-    Flax NNX captures all instance ``__dict__`` entries as pytree aux_data
-    (metadata).  Metadata is compared by equality on every JIT cache lookup.
-    Storing a :class:`DiaMatrix` or a :class:`LUFactors` containing JAX arrays
-    directly would trigger array equality checks and crash.  Wrapping the
-    cached value in ``_CacheBox`` makes the comparison use ``is`` (identity),
-    so the same cached object always compares equal to itself.
-    """
-
-    __slots__ = ("value",)
-
-    def __init__(self, value: T) -> None:
-        self.value = value
-
-    def __eq__(self, other: object) -> bool:
-        return type(other) is _CacheBox and self.value is other.value
-
-    def __hash__(self) -> int:
-        return id(self.value)
-
-    def __repr__(self) -> str:
-        return f"_CacheBox({self.value!r})"
 
 
 @nnx.dataclass
@@ -366,11 +342,13 @@ class DiaMatrix(nnx.Pytree):
             ValueError: if the matrix is not square or the system is singular.
         """
         # --- lazy cache -------------------------------------------------
-        _box: _CacheBox[dict[bool, LUFactors]] | None = getattr(self, "_lu_cache", None)
+        _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
+            self, "_lu_cache", None
+        )
         if _box is None:
             _box = _CacheBox({})
             object.__setattr__(self, "_lu_cache", _box)
-        cache: dict[bool, LUFactors] = _box.value
+        cache: dict[bool | str, LUFactors] = _box.value
         if pivot in cache:
             return cache[pivot]
 
@@ -560,7 +538,9 @@ class DiaMatrix(nnx.Pytree):
         # If the banded LU is already cached (e.g. from a prior lu_factor()
         # call), use it regardless of bandwidth — the expensive compilation
         # already happened.
-        _box: _CacheBox[dict[bool, LUFactors]] | None = getattr(self, "_lu_cache", None)
+        _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
+            self, "_lu_cache", None
+        )
         if _box is not None and pivot in _box.value:
             return _box.value[pivot].solve(b, axis=axis)
 
@@ -570,17 +550,17 @@ class DiaMatrix(nnx.Pytree):
             # forward/back substitution cost (same as the banded path).
             from jaxfun.la.matrix import Matrix  # local import avoids circular
 
-            _box: _CacheBox[dict[bool, LUFactors]] | None = getattr(
+            _box: _CacheBox[dict[bool | str, LUFactors]] | None = getattr(
                 self, "_lu_cache", None
             )
             if _box is None:
                 _box = _CacheBox({})
                 object.__setattr__(self, "_lu_cache", _box)
-            cache: dict[bool, LUFactors] = _box.value
+            cache: dict[bool | str, LUFactors] = _box.value
             _dense_key = "_dense"
             if _dense_key not in cache:
                 cache[_dense_key] = Matrix(self.todense()).lu_factor()  # type: ignore[index]
-            return cache[_dense_key].solve(b, axis=axis)  # type: ignore[index]
+            return cache[_dense_key].solve(b, axis=axis)
 
         return self.lu_factor(pivot=pivot).solve(b, axis=axis)
 

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1146,7 +1146,26 @@ class DiaMatrix(nnx.Pytree):
     def dtype(self) -> jnp.dtype:
         return self.data.dtype
 
-    def pin(self, constraints: dict[int, float]) -> PinnedSystem:
+    def pin(
+        self, constraints: dict[int, float] | tuple[tuple[int, float], ...]
+    ) -> PinnedSystem:
+        """Return a :class:`PinnedSystem` with the given DOFs fixed."""
+        from jaxfun.la.pinned import PinnedSystem
+
+        if isinstance(constraints, dict):
+            constraints = tuple(sorted(constraints.items()))
+        norm_constraints, new_offsets, data = self._pin(constraints)
+        pinned_matrix = DiaMatrix(
+            data=data, offsets=tuple(int(i) for i in new_offsets), shape=self.shape
+        )
+        return PinnedSystem(
+            pinned_matrix, tuple((int(i), float(j)) for i, j in norm_constraints)
+        )
+
+    @jax.jit(static_argnums=(1,))
+    def _pin(
+        self, constraints: tuple[tuple[int, float], ...]
+    ) -> tuple[list[tuple[int, float]], list[int], Array]:
         """Return a :class:`PinnedSystem` with the given DOFs fixed.
 
         For each ``(row_index, value)`` pair in *constraints* the corresponding
@@ -1174,8 +1193,6 @@ class DiaMatrix(nnx.Pytree):
             A_sys = A.pin({0: 0.0})  # singular Fourier system
             x = A_sys.solve(b)
         """
-        from jaxfun.la.pinned import PinnedSystem
-
         n, m = self.shape
         data = self.data  # keep as JAX array — no device→host transfer
         offsets: list[int] = list(self.offsets)
@@ -1195,27 +1212,25 @@ class DiaMatrix(nnx.Pytree):
         main_idx = offsets.index(0)
 
         # Normalise negative indices (Python-style); reject out-of-range positives.
-        norm_constraints: dict[int, float] = {}
-        for idx, val in constraints.items():
+        norm_constraints: list[tuple[int, float]] = []
+        for idx, val in constraints:
             if idx < -n or idx >= n:
                 raise IndexError(
                     f"Constraint index {idx} is out of range for matrix of size {n}"
                 )
-            norm_constraints[idx % n] = val
+            norm_constraints.append((idx % n, float(val)))
 
         # Zero every stored entry in each pinned row, then set diagonal to 1.
         # All indices (di, j) are Python ints — static at trace time — so
         # .at[...].set() is fully traceable under jax.jit / jax.vmap.
-        for row_idx, _val in norm_constraints.items():
+        for row_idx, _val in norm_constraints:
             for di, k in enumerate(offsets):
                 j = row_idx + k
                 if 0 <= j < m:
                     data = data.at[di, j].set(0.0)
             data = data.at[main_idx, row_idx].set(1.0)
 
-        new_offsets = tuple(offsets)
-        pinned_matrix = DiaMatrix(data=data, offsets=new_offsets, shape=self.shape)
-        return PinnedSystem(pinned_matrix, norm_constraints)
+        return norm_constraints, offsets, data
 
     def __repr__(self) -> str:
         n, m = self.shape
@@ -1263,7 +1278,7 @@ def _merge_jit_kernel(
     return jnp.stack(rows)  # (n_out, m)
 
 
-class LUFactors:
+class LUFactors(nnx.Pytree):
     """Result of :meth:`DiaMatrix.lu_factor`.
 
     Holds the unit-lower-triangular factor ``L`` and the upper-triangular
@@ -1283,13 +1298,14 @@ class LUFactors:
         shape: tuple[int, int],
         perm: Array | None = None,
     ):
-        self.L = L
-        self.U = U
+        self.L = nnx.data(L)
+        self.U = nnx.data(U)
         self.shape = shape
         # perm[i] = original row index that was placed at row i after pivoting.
         # None means the identity permutation (no row swaps occurred).
         self.perm = perm
 
+    @jax.jit(static_argnums=(2,))
     def solve(self, b: Array, axis: int = 0) -> Array:
         """Solve ``A x = b`` using forward then backward substitution.
 

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -411,10 +411,16 @@ class DiaMatrix(nnx.Pytree):
                     "enabling pivoting for this matrix."
                 )
 
+            _lu_tol = (
+                float(jnp.finfo(self.data.dtype).eps)
+                * float(jnp.max(jnp.abs(band_lu)))
+                * n
+            )
+
             l_offsets = tuple(
                 off
                 for off in range(-p, 1)
-                if off == 0 or bool(jnp.any(band_lu[center + off] != 0))
+                if off == 0 or float(jnp.max(jnp.abs(band_lu[center + off]))) > _lu_tol
             )
             l_data_rows: list[Array] = []
             for off in l_offsets:
@@ -424,9 +430,13 @@ class DiaMatrix(nnx.Pytree):
                     l_data_rows.append(band_lu[center + off].astype(self.data.dtype))
             L = DiaMatrix(data=jnp.stack(l_data_rows), offsets=l_offsets, shape=(n, n))
 
-            u_offsets = tuple(range(0, q + 1))
+            u_offsets = tuple(
+                off
+                for off in range(0, q + 1)
+                if off == 0 or float(jnp.max(jnp.abs(band_lu[center + off]))) > _lu_tol
+            )
             u_data_rows = [
-                band_lu[center + u].astype(self.data.dtype) for u in range(q + 1)
+                band_lu[center + u].astype(self.data.dtype) for u in u_offsets
             ]
             U = DiaMatrix(data=jnp.stack(u_data_rows), offsets=u_offsets, shape=(n, n))
 
@@ -472,11 +482,17 @@ class DiaMatrix(nnx.Pytree):
 
         # ---------- extract L -------------------------------------------
         # band_lu[center - t, :] is already the column-aligned DIA row for
-        # offset -t (L[i, i-t] = band_lu[center-t, i-t]).  Skip all-zero rows.
+        # offset -t (L[i, i-t] = band_lu[center-t, i-t]).  Skip near-zero rows
+        # using a relative tolerance (floating-point residuals from elimination
+        # can leave structurally-zero diagonals with tiny non-zero entries).
+        _lu_tol = (
+            float(jnp.finfo(self.data.dtype).eps) * float(jnp.max(jnp.abs(band_lu))) * n
+        )
+
         l_offsets = tuple(
             off
             for off in range(-2 * p, 1)
-            if off == 0 or bool(jnp.any(band_lu[center + off] != 0))
+            if off == 0 or float(jnp.max(jnp.abs(band_lu[center + off]))) > _lu_tol
         )
         l_data_rows: list[Array] = []
         for off in l_offsets:
@@ -492,10 +508,12 @@ class DiaMatrix(nnx.Pytree):
 
         # ---------- extract U -------------------------------------------
         # band_lu[center + u, :] is the column-aligned DIA row for offset +u.
-        u_offsets = tuple(range(0, q_eff + 1))
-        u_data_rows = [
-            band_lu[center + u].astype(self.data.dtype) for u in range(q_eff + 1)
-        ]
+        u_offsets = tuple(
+            off
+            for off in range(0, q_eff + 1)
+            if off == 0 or float(jnp.max(jnp.abs(band_lu[center + off]))) > _lu_tol
+        )
+        u_data_rows = [band_lu[center + u].astype(self.data.dtype) for u in u_offsets]
         U = DiaMatrix(
             data=jnp.stack(u_data_rows),
             offsets=u_offsets,
@@ -539,18 +557,30 @@ class DiaMatrix(nnx.Pytree):
         p = max((-k for k in offsets if k < 0), default=0)
         q = max((k for k in offsets if k > 0), default=0)
 
+        # If the banded LU is already cached (e.g. from a prior lu_factor()
+        # call), use it regardless of bandwidth — the expensive compilation
+        # already happened.
+        _box: _CacheBox[dict[bool, LUFactors]] | None = getattr(self, "_lu_cache", None)
+        if _box is not None and pivot in _box.value:
+            return _box.value[pivot].solve(b, axis=axis)
+
         if p * (q + 1) > dense_threshold:
             # Dense path: XLA compiles jnp.linalg.solve in milliseconds.
-            n = self.shape[0]
-            axis = axis % b.ndim
-            if b.ndim == 1:
-                return jnp.linalg.solve(self.todense(), b)
-            b_moved = jnp.moveaxis(b, axis, 0)  # (n, *rest)
-            rest_shape = b_moved.shape[1:]
-            batch = b_moved.size // n
-            b2d = b_moved.reshape(n, batch)  # (n, batch)
-            x2d = jnp.linalg.solve(self.todense(), b2d)  # (n, batch)
-            return jnp.moveaxis(x2d.reshape((n,) + rest_shape), 0, axis)
+            # Cache the dense LUFactors so repeated calls pay only the
+            # forward/back substitution cost (same as the banded path).
+            from jaxfun.la.matrix import Matrix  # local import avoids circular
+
+            _box: _CacheBox[dict[bool, LUFactors]] | None = getattr(
+                self, "_lu_cache", None
+            )
+            if _box is None:
+                _box = _CacheBox({})
+                object.__setattr__(self, "_lu_cache", _box)
+            cache: dict[bool, LUFactors] = _box.value
+            _dense_key = "_dense"
+            if _dense_key not in cache:
+                cache[_dense_key] = Matrix(self.todense()).lu_factor()  # type: ignore[index]
+            return cache[_dense_key].solve(b, axis=axis)  # type: ignore[index]
 
         return self.lu_factor(pivot=pivot).solve(b, axis=axis)
 

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -311,7 +311,23 @@ class Matrix(nnx.Pytree):
         """Return a copy with data cast to ``dtype``."""
         return Matrix(self.data.astype(dtype))
 
-    def pin(self, constraints: dict[int, float]) -> PinnedSystem:
+    def pin(
+        self, constraints: dict[int, float] | tuple[tuple[int, float], ...]
+    ) -> PinnedSystem:
+        """Return a :class:`PinnedSystem` with the given DOFs fixed."""
+        from jaxfun.la.pinned import PinnedSystem
+
+        if isinstance(constraints, dict):
+            constraints = tuple(sorted(constraints.items()))
+        norm_constraints, data = self._pin(constraints)
+        return PinnedSystem(
+            Matrix(data), tuple((int(i), float(j)) for i, j in norm_constraints)
+        )
+
+    @jax.jit(static_argnums=(1,))
+    def _pin(
+        self, constraints: tuple[tuple[int, float], ...]
+    ) -> tuple[list[tuple[int, float]], Array]:
         """Return a :class:`PinnedSystem` with the given DOFs fixed.
 
         For each ``(row_index, value)`` pair in *constraints* the
@@ -338,29 +354,28 @@ class Matrix(nnx.Pytree):
             A_sys = A.pin({0: 0.0})
             x = A_sys.solve(b)
         """
-        from jaxfun.la.pinned import PinnedSystem
-
         n, _m = self.shape
         # Normalise negative indices (Python-style); reject out-of-range positives.
-        norm_constraints: dict[int, float] = {}
-        for idx, val in constraints.items():
+        norm_constraints: list[tuple[int, float]] = []
+        for idx, val in constraints:
             if idx < -n or idx >= n:
                 raise IndexError(
                     f"Constraint index {idx} is out of range for matrix of size {n}"
                 )
-            norm_constraints[idx % n] = val
+            norm_constraints.append((idx % n, float(val)))
         data = self.data
-        for idx in norm_constraints:
+        for idx, _ in norm_constraints:
             data = data.at[idx].set(0.0)
             data = data.at[idx, idx].set(1.0)
-        return PinnedSystem(Matrix(data), norm_constraints)
+
+        return norm_constraints, data
 
     def __repr__(self) -> str:
         n, m = self.shape
         return f"Matrix(shape=({n}, {m}), dtype={self.dtype})"
 
 
-class LUFactors:
+class LUFactors(nnx.Pytree):
     """Result of :meth:`Matrix.lu_factor`.
 
     Holds the packed LU decomposition as returned by
@@ -383,6 +398,7 @@ class LUFactors:
         self.piv = piv  # (n,) int32 pivot indices
         self.shape = shape
 
+    @jax.jit(static_argnums=(2,))
     def solve(self, b: Array, axis: int = 0) -> Array:
         """Solve ``A x = b`` using the stored LU factorisation.
 

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -6,6 +6,8 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
+from jaxfun.la.matrixprotocol import _CacheBox
+
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
     from jaxfun.la import DiaMatrix
@@ -23,11 +25,12 @@ class Matrix(nnx.Pytree):
 
     Attributes:
         data: The underlying ``(n, m)`` JAX array.
-        _lu_cache: Private ``LUFactors | None`` populated on the first call to
-            :meth:`lu_factor`.  Subsequent calls return the cached object at
-            no extra cost.  Stored via ``object.__setattr__`` so it is
-            invisible to JAX's pytree machinery and does not affect JIT
-            tracing or compilation.
+        _lu_cache: Private :class:`~jaxfun.la.matrixprotocol._CacheBox` wrapping
+            a ``LUFactors``, populated on the first call to :meth:`lu_factor`.
+            Subsequent calls return the cached object at no extra cost.  Stored
+            via ``object.__setattr__`` and wrapped in ``_CacheBox`` so it is
+            invisible to JAX's pytree machinery and compares by identity (not
+            by array equality) on every JIT cache lookup.
 
     Example::
 
@@ -113,9 +116,9 @@ class Matrix(nnx.Pytree):
         Raises:
             ValueError: if the matrix is not square.
         """
-        cached: LUFactors | None = getattr(self, "_lu_cache", None)
-        if cached is not None:
-            return cached
+        _box: _CacheBox[LUFactors] | None = getattr(self, "_lu_cache", None)
+        if _box is not None:
+            return _box.value
         n, m = self.shape
         if n != m:
             raise ValueError(
@@ -128,7 +131,7 @@ class Matrix(nnx.Pytree):
                 "Consider pinning (:meth:`Matrix.pin`) additional DOFs."
             )
         result = LUFactors(lu=lu, piv=piv, shape=(n, n))
-        object.__setattr__(self, "_lu_cache", result)
+        object.__setattr__(self, "_lu_cache", _CacheBox(result))
         return result
 
     def lu_solve(self, b: Array, axis: int = 0) -> Array:

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -19,6 +19,17 @@ class DiaMatrixSolveMethod(StrEnum):
     DENSE = "dense"
 
 
+class SolverNotApplicable(Exception):
+    """Raised when a solver strategy cannot be applied to the given matrix structure.
+
+    Used by :func:`~jaxfun.galerkin.tensorproductspace.tpmats_lu_factor` and
+    :func:`~jaxfun.galerkin.tensorproductspace.tpmats_wavenumber_factor` to
+    signal that the factor-matrix structure is incompatible with the requested
+    solver.  Caught by :meth:`~jaxfun.galerkin.TPMatrices.lu_factor` and
+    :meth:`~jaxfun.galerkin.TPMatrices.solve` when selecting a fallback.
+    """
+
+
 class _CacheBox[T]:
     """Thin wrapper that provides identity-based equality and hashing.
 

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -11,6 +11,33 @@ if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
 
 
+class _CacheBox[T]:
+    """Thin wrapper that provides identity-based equality and hashing.
+
+    Flax NNX captures all instance ``__dict__`` entries as pytree aux_data
+    (metadata).  Metadata is compared by equality on every JIT cache lookup.
+    Storing a :class:`~jaxfun.la.DiaMatrix` or a :class:`LUFactors`
+    containing JAX arrays directly would trigger array equality checks and
+    crash.  Wrapping the cached value in ``_CacheBox`` makes the comparison
+    use ``is`` (identity), so the same cached object always compares equal to
+    itself.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        return type(other) is _CacheBox and self.value is other.value
+
+    def __hash__(self) -> int:
+        return id(self.value)
+
+    def __repr__(self) -> str:
+        return f"_CacheBox({self.value!r})"
+
+
 @runtime_checkable
 class MatrixProtocol(Protocol):
     """Structural interface shared by all matrix types in ``jaxfun.la``.

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import jax
@@ -9,6 +10,13 @@ Array = jax.Array
 
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
+
+
+class DiaMatrixSolveMethod(StrEnum):
+    AUTO = "auto"
+    BANDED = "banded"
+    RCM = "rcm"
+    DENSE = "dense"
 
 
 class _CacheBox[T]:

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -51,8 +51,7 @@ class PinnedSystem(nnx.Pytree):
 
     Args:
         matrix: The row-substituted :class:`Matrix` or :class:`DiaMatrix`.
-        constraints: Mapping from DOF index to pinned value
-            (e.g. ``{0: 0.0, -1: 1.0}``).  Converted to a tuple internally.
+        constraints: tuple of ``(index, value)`` pairs recording the pinned DOFs.
     """
 
     matrix: Matrix | DiaMatrix
@@ -190,5 +189,5 @@ class PinnedSystem(nnx.Pytree):
         return self.matrix[key]
 
     def __repr__(self) -> str:
-        pins = ", ".join(f"{k}={v}" for k, v in self.constraints)
+        pins = ", ".join(f"{k}: {v}" for k, v in self.constraints)
         return f"PinnedSystem(shape={self.shape}, constraints={{{pins}}})"

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import jax
 import jax.numpy as jnp
 from flax import nnx
 
@@ -60,12 +61,10 @@ class PinnedSystem(nnx.Pytree):
     def __init__(
         self,
         matrix: Matrix | DiaMatrix,
-        constraints: dict[int, float],
+        constraints: tuple[tuple[int, float], ...],
     ) -> None:
-        self.matrix = matrix
-        # Store as a sorted tuple so the pytree treedef is deterministic and
-        # hashable (dicts are neither).
-        self.constraints = tuple(sorted(constraints.items()))
+        self.matrix = nnx.data(matrix)
+        self.constraints = nnx.static(constraints)
 
     @property
     def shape(self) -> tuple[int, int]:
@@ -80,6 +79,7 @@ class PinnedSystem(nnx.Pytree):
         """
         return self.matrix.lu_factor()
 
+    @jax.jit(static_argnums=(2,))
     def fix_rhs(self, b: Array, axis: int = 0) -> Array:
         """Return ``b`` with constraint values inserted at pinned positions.
 
@@ -181,7 +181,7 @@ class PinnedSystem(nnx.Pytree):
         """Return a copy with the underlying matrix cast to ``dtype``."""
         from jaxfun.la.pinned import PinnedSystem  # local to avoid re-import issues
 
-        return PinnedSystem(self.matrix.astype(dtype), dict(self.constraints))
+        return PinnedSystem(self.matrix.astype(dtype), self.constraints)
 
     def __len__(self) -> int:
         return min(self.shape)

--- a/src/jaxfun/operators.py
+++ b/src/jaxfun/operators.py
@@ -21,7 +21,7 @@ from sympy.core.basic import Basic
 from sympy.core.function import Derivative as sympy_Derivative, diff as df
 from sympy.printing.latex import LatexPrinter
 from sympy.printing.pretty.stringpict import prettyForm
-from sympy.vector import Dot as sympy_Dot, VectorAdd, VectorMul, VectorZero
+from sympy.vector import VectorAdd, VectorMul, VectorZero
 from sympy.vector.basisdependent import BasisDependent, BasisDependentZero
 from sympy.vector.dyadic import Dyadic, DyadicAdd, DyadicMul, DyadicZero
 from sympy.vector.operators import Curl as sympy_Curl, Divergence, Gradient
@@ -677,7 +677,7 @@ class Curl(sympy_Curl):
         return curl(self._expr.doit(**hints))
 
 
-class Dot(sympy_Dot):
+class Dot(Expr):
     """Unevaluated dot product wrapper delegating to custom dot().
 
     Args:
@@ -1072,15 +1072,5 @@ sp.vector.vector.cross = cross  # ty:ignore[possibly-missing-submodule]
 sp.vector.operators.gradient = gradient  # ty:ignore[possibly-missing-submodule]
 sp.vector.operators.curl = curl  # ty:ignore[possibly-missing-submodule]
 sp.vector.operators.divergence = divergence  # ty:ignore[possibly-missing-submodule]
-sp.vector.vector.Cross = Cross  # ty:ignore[possibly-missing-submodule]
-sp.vector.vector.Dot = Dot  # ty:ignore[possibly-missing-submodule]
-sp.vector.operators.Curl = Curl  # ty:ignore[possibly-missing-submodule]
-sp.vector.operators.Gradient = Grad  # ty:ignore[possibly-missing-submodule]
-sp.vector.operators.Divergence = Div  # ty:ignore[possibly-missing-submodule]
-sp.vector.Cross = Cross  # ty:ignore[possibly-missing-submodule]
-sp.vector.Dot = Dot  # ty:ignore[possibly-missing-submodule]
-sp.vector.Curl = Curl  # ty:ignore[possibly-missing-submodule]
-sp.vector.Gradient = Grad  # ty:ignore[possibly-missing-submodule]
-sp.vector.Divergence = Div  # ty:ignore[possibly-missing-submodule]
 sp.vector.basisdependent.BasisDependent.diff = covariant_diff  # ty:ignore[possibly-missing-submodule]
 sp.vector.Dyadic.is_Dyadic = True  # ty:ignore[possibly-missing-submodule]

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -21,6 +21,7 @@ from sympy.vector import (
 from typing_extensions import TypedDict
 
 from jaxfun.la import MatrixProtocol
+from jaxfun.la.matrixprotocol import DiaMatrixSolveMethod as DiaMatrixSolveMethod
 
 if TYPE_CHECKING:
     from jaxfun.coordinates import BaseDyadic, BaseScalar, BaseVector

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -21,7 +21,10 @@ from sympy.vector import (
 from typing_extensions import TypedDict
 
 from jaxfun.la import MatrixProtocol
-from jaxfun.la.matrixprotocol import DiaMatrixSolveMethod as DiaMatrixSolveMethod
+from jaxfun.la.matrixprotocol import (
+    DiaMatrixSolveMethod as DiaMatrixSolveMethod,
+    SolverNotApplicable as SolverNotApplicable,
+)
 
 if TYPE_CHECKING:
     from jaxfun.coordinates import BaseDyadic, BaseScalar, BaseVector

--- a/tests/galerkin/test_tensorproductspace.py
+++ b/tests/galerkin/test_tensorproductspace.py
@@ -156,3 +156,20 @@ def test_inner_returns_matrix_and_vector_with_bcs():
     # A is dense matrix, b vector
     assert A.shape[0] == A.shape[1]
     assert b.shape[0] == A.shape[0]
+
+
+def test_vectortensorproductspace_project():
+    N: int = 8
+
+    C = Chebyshev.Chebyshev(N)
+    T = TensorProduct(C, C)
+    V = VectorTensorProductSpace(T, name="V")
+    x, y = T.system.base_scalars()
+    i, j = T.system.base_vectors()
+
+    u = JAXFunction(y * i + x * j, V)
+
+    ua = V.backward(u.array)
+    xi, yj = T.mesh()
+    assert jnp.linalg.norm(ua[0] - yj) < ulp(1000)
+    assert jnp.linalg.norm(ua[1] - xi) < ulp(1000)

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -218,13 +218,12 @@ def test_tpmatrices_solve_fourier_poly2d_l2(poly):
 
 
 # ---------------------------------------------------------------------------
-# 3D: Fourier×Fourier×Legendre
+# 3D: Fourier x Fourier x Legendre
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow
 def test_tpmatrices_solve_fourier_fourier_legendre_3d():
-    """3D wavenumber solver: Fourier×Fourier×Legendre Poisson."""
+    """3D wavenumber solver: Fourier x Fourier x Legendre Poisson."""
     N = 8
     F0 = FunctionSpace(N, Fourier)
     F1 = FunctionSpace(N, Fourier)

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -116,7 +116,7 @@ def test_tpmats_wavenumber_factor_solve_agrees_with_kron(poly):
     ref = tpmats_to_kron(A).solve(b.flatten()).reshape(b.shape)
     uh = wn.solve(b)
     assert uh.shape == b.shape
-    assert float(jnp.max(jnp.abs(uh - ref))) < jnp.sqrt(ulp(10))
+    assert float(jnp.max(jnp.abs(uh - ref))) < ulp(10)
 
 
 @POLY_SPACES

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import numpy as np
 import pytest
 import sympy as sp
 
@@ -9,10 +10,12 @@ from jaxfun.galerkin import (
     TensorProduct,
     TestFunction,
     TrialFunction,
+    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.tensorproductspace import (
+    BlockTPMatrix,
     TPLUFactors,
     TPMatrices,
     TPMatricesDenseLUFactors,
@@ -24,7 +27,8 @@ from jaxfun.galerkin.tensorproductspace import (
     tpmats_to_kron,
     tpmats_wavenumber_factor,
 )
-from jaxfun.operators import Div, Grad
+from jaxfun.la.diamatrix import DiaMatrix
+from jaxfun.operators import Div, Dot, Grad
 from jaxfun.utils.common import lambdify, ulp
 
 # ---------------------------------------------------------------------------
@@ -329,3 +333,79 @@ def test_tpmatrices_solve_fourier_fourier_legendre_3d():
     uej = lambdify((x, y, z), ue)(*xj)
     l2 = float(jnp.linalg.norm(uj - uej)) / M
     assert l2 < jnp.sqrt(ulp(1000)), f"3D L2 error {l2:.2e} too large"
+
+
+# ---------------------------------------------------------------------------
+# BlockTPMatrix
+# ---------------------------------------------------------------------------
+
+BCS_VEC = {"left": {"D": 0}, "right": {"D": 0}}
+
+
+def _vector_block_system(N: int, poly):
+    """Two-component vector mass system in 2D.
+
+    Uses inner(Dot(v, u)) to assemble a block-diagonal mass matrix
+    (two decoupled identical blocks).  Returns (A, b, x_true) where b is
+    a manufactured RHS consistent with the dense system.
+    """
+    F0 = FunctionSpace(N, poly, BCS_VEC)
+    F1 = FunctionSpace(N, poly, BCS_VEC)
+    T = TensorProduct(F0, F1)
+    V = VectorTensorProductSpace(T, name="V")
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    M = inner(Dot(v, u), sparse=True)
+    A = BlockTPMatrix(M, V, V)
+    rng = np.random.default_rng(0)
+    x_true = jnp.array(rng.standard_normal(A.shape[1]), dtype=jnp.float32)
+    b = A.to_Matrix().matvec(x_true)
+    return A, b, x_true
+
+
+@POLY_SPACES
+def test_blocktpmatrix_tosparse_returns_diamatrix(poly):
+    A, b, _ = _vector_block_system(8, poly)
+    sparse = A.tosparse()
+    assert isinstance(sparse, DiaMatrix)
+    assert sparse.shape == A.shape
+
+
+@POLY_SPACES
+def test_blocktpmatrix_solve_sparse_matches_dense(poly):
+    A, b, x_true = _vector_block_system(8, poly)
+    # Dense reference
+    x_dense = A.to_Matrix().solve(b.ravel()).reshape(b.shape)
+    # Sparse / RCM path
+    x_sparse = A.solve(b)
+    assert x_sparse.shape == b.shape
+    assert jnp.allclose(x_sparse.ravel(), x_dense.ravel(), atol=ulp(1000))
+
+
+@POLY_SPACES
+def test_blocktpmatrix_rcm_reduces_bandwidth(poly):
+    A, _, _ = _vector_block_system(8, poly)
+    sparse = A.tosparse()
+    A_perm, _, _ = sparse.rcm()
+    bw_before = max(abs(k) for k in sparse.offsets)
+    bw_after = max(abs(k) for k in A_perm.offsets)
+    assert bw_after <= bw_before
+
+
+@POLY_SPACES
+def test_blocktpmatrix_call_matches_dense_matvec(poly):
+    A, b, x_true = _vector_block_system(8, poly)
+    # Warm the RCM cache via solve
+    _ = A.solve(b)
+    y_block = A(x_true)
+    y_dense = A.to_Matrix().matvec(x_true.ravel()).reshape(x_true.shape)
+    assert jnp.allclose(y_block.ravel(), y_dense.ravel(), atol=ulp(1000))
+
+
+@POLY_SPACES
+def test_blocktpmatrix_solve_cached_rcm(poly):
+    """Second solve reuses cached RCM without reassembly."""
+    A, b, _ = _vector_block_system(8, poly)
+    x1 = A.solve(b)
+    x2 = A.solve(b)
+    assert jnp.allclose(x1.ravel(), x2.ravel(), atol=ulp(10))

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -13,9 +13,11 @@ from jaxfun.galerkin import (
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.tensorproductspace import (
+    TPLUFactors,
     TPMatrices,
     TPMatricesLUFactors,
     TPMatricesWavenumberSolver,
+    TPMatrix,
     tpmats_lu_factor,
     tpmats_to_kron,
     tpmats_wavenumber_factor,
@@ -152,6 +154,30 @@ def test_wavenumber_solver_solve2_agrees_with_solve():
     _, A, b, _ = _poisson_fourier_poly_2d(16, Legendre.Legendre)
     wn = tpmats_wavenumber_factor(A)
     assert float(jnp.max(jnp.abs(wn.solve(b) - wn.solve2(b)))) < float(ulp(100))
+
+
+# ---------------------------------------------------------------------------
+# TPMatrix.solve / TPLUFactors  (single Kronecker-product term)
+# ---------------------------------------------------------------------------
+
+
+@POLY_SPACES
+def test_tpmatrix_lu_factor_returns_tplufactors(poly):
+    """TPMatrix.lu_factor() returns a TPLUFactors instance."""
+    _, A, _, _ = _poisson_poly2d(8, poly)
+    assert isinstance(A[0], TPMatrix)
+    lu = A[0].lu_factor()
+    assert isinstance(lu, TPLUFactors)
+
+
+@POLY_SPACES
+def test_tpmatrix_solve_single_term(poly):
+    """TPMatrix.solve solves a single-term Kronecker system correctly."""
+    T, A, b, ue = _poisson_poly2d(16, poly)
+    # Use the first (and for a pure Laplacian, dominant) term directly
+    tp = A[0]
+    rhs = tp(tp.lu_factor().solve(b))  # round-trip: A*(A^{-1}*b) ≈ b
+    assert float(jnp.max(jnp.abs(rhs - b))) < float(ulp(100))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -116,7 +116,7 @@ def test_tpmats_wavenumber_factor_solve_agrees_with_kron(poly):
     ref = tpmats_to_kron(A).solve(b.flatten()).reshape(b.shape)
     uh = wn.solve(b)
     assert uh.shape == b.shape
-    assert float(jnp.max(jnp.abs(uh - ref))) < float(ulp(100))
+    assert float(jnp.max(jnp.abs(uh - ref))) < jnp.sqrt(ulp(10))
 
 
 @POLY_SPACES
@@ -130,7 +130,7 @@ def test_tpmats_wavenumber_factor_solve_fourier_poly_l2(poly):
     xj = T.mesh(N=(N, N), broadcast=True)
     uej = lambdify((x, y), ue)(*xj)
     l2 = float(jnp.linalg.norm(uj - uej)) / N
-    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+    assert l2 < jnp.sqrt(ulp(10)), f"L2 error {l2:.2e} too large"
 
 
 def test_tpmats_wavenumber_factor_accepts_tpmatrices():
@@ -296,7 +296,7 @@ def test_tpmatrices_solve_fourier_poly2d_l2(poly):
     xj = T.mesh(N=(N, N), broadcast=True)
     uej = lambdify((x, y), ue)(*xj)
     l2 = float(jnp.linalg.norm(uj - uej)) / N
-    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+    assert l2 < jnp.sqrt(ulp(10)), f"L2 error {l2:.2e} too large"
 
 
 # ---------------------------------------------------------------------------
@@ -328,4 +328,4 @@ def test_tpmatrices_solve_fourier_fourier_legendre_3d():
     xj = T.mesh(N=(M, M, M), broadcast=True)
     uej = lambdify((x, y, z), ue)(*xj)
     l2 = float(jnp.linalg.norm(uj - uej)) / M
-    assert l2 < float(ulp(100)), f"3D L2 error {l2:.2e} too large"
+    assert l2 < jnp.sqrt(ulp(1000)), f"3D L2 error {l2:.2e} too large"

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -1,0 +1,250 @@
+import jax.numpy as jnp
+import pytest
+import sympy as sp
+
+from jaxfun.galerkin import (
+    Chebyshev,
+    FunctionSpace,
+    Legendre,
+    TensorProduct,
+    TestFunction,
+    TrialFunction,
+)
+from jaxfun.galerkin.Fourier import Fourier
+from jaxfun.galerkin.inner import inner
+from jaxfun.galerkin.tensorproductspace import (
+    TPMatrices,
+    TPMatricesLUFactors,
+    TPMatricesWavenumberSolver,
+    tpmats_lu_factor,
+    tpmats_to_kron,
+    tpmats_wavenumber_factor,
+)
+from jaxfun.operators import Div, Grad
+from jaxfun.utils.common import lambdify, ulp
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BCS = {"left": {"D": 0}, "right": {"D": 0}}
+
+POLY_SPACES = pytest.mark.parametrize(
+    "poly",
+    [Legendre.Legendre, Chebyshev.Chebyshev],
+    ids=["legendre", "chebyshev"],
+)
+
+
+def _poisson_poly2d(N: int, poly):
+    """Return (T, A, b, ue) for poly x poly Poisson with manufactured solution."""
+    F0 = FunctionSpace(N, poly, BCS)
+    F1 = FunctionSpace(N, poly, BCS)
+    T = TensorProduct(F0, F1)
+    v, u = TestFunction(T), TrialFunction(T)
+    x, y = T.system.base_scalars()
+    ue = (1 - x**2) * (1 - y**2)
+    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
+    return T, A, b, ue
+
+
+def _poisson_fourier_poly_2d(N: int, poly):
+    """Return (T, A, b, ue) for Fourier x poly Poisson with manufactured solution."""
+    F = FunctionSpace(N, Fourier)
+    D = FunctionSpace(N, poly, BCS)
+    T = TensorProduct(F, D)
+    v, u = TestFunction(T), TrialFunction(T)
+    x, y = T.system.base_scalars()
+    ue = sp.cos(2 * x) * (1 - y**2)
+    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
+    return T, A, b, ue
+
+
+# ---------------------------------------------------------------------------
+# tpmats_lu_factor (diagonalization path)
+# ---------------------------------------------------------------------------
+
+
+def test_tpmats_lu_factor_returns_correct_type():
+    _, A, b, _ = _poisson_poly2d(8, Legendre.Legendre)
+    lu = tpmats_lu_factor(A)
+    assert isinstance(lu, TPMatricesLUFactors)
+
+
+@POLY_SPACES
+def test_tpmats_lu_factor_solve_poly2d(poly):
+    T, A, b, ue = _poisson_poly2d(16, poly)
+    lu = tpmats_lu_factor(A)
+    assert isinstance(lu, TPMatricesLUFactors)
+    uh = lu.solve(b)
+    assert uh.shape == b.shape
+    x, y = T.system.base_scalars()
+    N = 40
+    uj = T.backward(uh, N=(N, N))
+    xj = T.mesh(N=(N, N), broadcast=True)
+    uej = lambdify((x, y), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / N
+    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+
+
+def test_tpmats_lu_factor_accepts_tpmatrix_single():
+    """tpmats_lu_factor accepts a single TPMatrix as well as a list."""
+    _, A, b, _ = _poisson_poly2d(8, Legendre.Legendre)
+    lu = tpmats_lu_factor([A[0]])
+    assert isinstance(lu, TPMatricesLUFactors)
+
+
+# ---------------------------------------------------------------------------
+# tpmats_wavenumber_factor
+# ---------------------------------------------------------------------------
+
+
+def test_tpmats_wavenumber_factor_returns_correct_type():
+    _, A, _, _ = _poisson_fourier_poly_2d(8, Legendre.Legendre)
+    wn = tpmats_wavenumber_factor(A)
+    assert isinstance(wn, TPMatricesWavenumberSolver)
+
+
+@POLY_SPACES
+def test_tpmats_wavenumber_factor_solve_agrees_with_kron(poly):
+    _, A, b, _ = _poisson_fourier_poly_2d(16, poly)
+    wn = tpmats_wavenumber_factor(A)
+    ref = tpmats_to_kron(A).solve(b.flatten()).reshape(b.shape)
+    uh = wn.solve(b)
+    assert uh.shape == b.shape
+    assert float(jnp.max(jnp.abs(uh - ref))) < float(ulp(100))
+
+
+@POLY_SPACES
+def test_tpmats_wavenumber_factor_solve_fourier_poly_l2(poly):
+    T, A, b, ue = _poisson_fourier_poly_2d(16, poly)
+    wn = tpmats_wavenumber_factor(A)
+    uh = wn.solve(b)
+    x, y = T.system.base_scalars()
+    N = 40
+    uj = T.backward(uh, N=(N, N))
+    xj = T.mesh(N=(N, N), broadcast=True)
+    uej = lambdify((x, y), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / N
+    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+
+
+def test_tpmats_wavenumber_factor_accepts_tpmatrices():
+    """tpmats_wavenumber_factor accepts a TPMatrices object as well as a list."""
+    _, A, b, _ = _poisson_fourier_poly_2d(8, Legendre.Legendre)
+    wn = tpmats_wavenumber_factor(TPMatrices(A))
+    assert isinstance(wn, TPMatricesWavenumberSolver)
+    uh = wn.solve(b)
+    assert uh.shape == b.shape
+
+
+def test_tpmats_wavenumber_factor_type_error():
+    with pytest.raises(TypeError):
+        tpmats_wavenumber_factor("not a valid input")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# TPMatricesWavenumberSolver.solve2
+# ---------------------------------------------------------------------------
+
+
+def test_wavenumber_solver_solve2_agrees_with_solve():
+    _, A, b, _ = _poisson_fourier_poly_2d(16, Legendre.Legendre)
+    wn = tpmats_wavenumber_factor(A)
+    assert float(jnp.max(jnp.abs(wn.solve(b) - wn.solve2(b)))) < float(ulp(100))
+
+
+# ---------------------------------------------------------------------------
+# TPMatrices.solve auto-dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_tpmatrices_solve_dispatches_wavenumber_for_fourier():
+    """TPMatrices.solve should dispatch to TPMatricesWavenumberSolver for Fourier x poly."""  # noqa: E501
+    _, A, b, _ = _poisson_fourier_poly_2d(12, Legendre.Legendre)
+    mats = TPMatrices(A)
+    lu = mats.lu_factor()
+    assert isinstance(lu, TPMatricesWavenumberSolver)
+    uh = mats.solve(b)
+    assert uh.shape == b.shape
+
+
+@POLY_SPACES
+def test_tpmatrices_solve_dispatches_lu_for_poly(poly):
+    """TPMatrices.solve should dispatch to TPMatricesLUFactors for all-polynomial."""
+    _, A, b, _ = _poisson_poly2d(12, poly)
+    mats = TPMatrices(A)
+    lu = mats.lu_factor()
+    assert isinstance(lu, TPMatricesLUFactors)
+    uh = mats.solve(b)
+    assert uh.shape == b.shape
+
+
+def test_tpmatrices_lu_factor_caching():
+    """lu_factor called twice returns the same cached object."""
+    _, A, _, _ = _poisson_fourier_poly_2d(8, Legendre.Legendre)
+    mats = TPMatrices(A)
+    lu1 = mats.lu_factor()
+    lu2 = mats.lu_factor()
+    assert lu1 is lu2
+
+
+@POLY_SPACES
+def test_tpmatrices_solve_poly2d_l2(poly):
+    T, A, b, ue = _poisson_poly2d(16, poly)
+    uh = TPMatrices(A).solve(b)
+    assert uh.shape == b.shape
+    x, y = T.system.base_scalars()
+    N = 40
+    uj = T.backward(uh, N=(N, N))
+    xj = T.mesh(N=(N, N), broadcast=True)
+    uej = lambdify((x, y), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / N
+    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+
+
+@POLY_SPACES
+def test_tpmatrices_solve_fourier_poly2d_l2(poly):
+    T, A, b, ue = _poisson_fourier_poly_2d(16, poly)
+    uh = TPMatrices(A).solve(b)
+    assert uh.shape == b.shape
+    x, y = T.system.base_scalars()
+    N = 40
+    uj = T.backward(uh, N=(N, N))
+    xj = T.mesh(N=(N, N), broadcast=True)
+    uej = lambdify((x, y), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / N
+    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+
+
+# ---------------------------------------------------------------------------
+# 3D: Fourier×Fourier×Legendre
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_tpmatrices_solve_fourier_fourier_legendre_3d():
+    """3D wavenumber solver: Fourier×Fourier×Legendre Poisson."""
+    N = 8
+    F0 = FunctionSpace(N, Fourier)
+    F1 = FunctionSpace(N, Fourier)
+    D = FunctionSpace(N, Legendre.Legendre, BCS)
+    T = TensorProduct(F0, F1, D)
+    v, u = TestFunction(T), TrialFunction(T)
+    x, y, z = T.system.base_scalars()
+    ue = sp.cos(2 * x) * sp.cos(2 * y) * (1 - z**2)
+    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
+
+    mats = TPMatrices(A)
+    lu = mats.lu_factor()
+    assert isinstance(lu, TPMatricesWavenumberSolver)
+
+    uh = mats.solve(b)
+    assert uh.shape == b.shape
+
+    M = 20
+    uj = T.backward(uh, N=(M, M, M))
+    xj = T.mesh(N=(M, M, M), broadcast=True)
+    uej = lambdify((x, y, z), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / M
+    assert l2 < float(ulp(100)), f"3D L2 error {l2:.2e} too large"

--- a/tests/galerkin/test_tpmatrices_solvers.py
+++ b/tests/galerkin/test_tpmatrices_solvers.py
@@ -15,9 +15,11 @@ from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.tensorproductspace import (
     TPLUFactors,
     TPMatrices,
+    TPMatricesDenseLUFactors,
     TPMatricesLUFactors,
     TPMatricesWavenumberSolver,
     TPMatrix,
+    tpmats_dense_lu_factor,
     tpmats_lu_factor,
     tpmats_to_kron,
     tpmats_wavenumber_factor,
@@ -38,7 +40,7 @@ POLY_SPACES = pytest.mark.parametrize(
 )
 
 
-def _poisson_poly2d(N: int, poly):
+def _poisson_poly2d(N: int, poly, sparse: bool = True):
     """Return (T, A, b, ue) for poly x poly Poisson with manufactured solution."""
     F0 = FunctionSpace(N, poly, BCS)
     F1 = FunctionSpace(N, poly, BCS)
@@ -46,11 +48,11 @@ def _poisson_poly2d(N: int, poly):
     v, u = TestFunction(T), TrialFunction(T)
     x, y = T.system.base_scalars()
     ue = (1 - x**2) * (1 - y**2)
-    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
+    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=sparse)
     return T, A, b, ue
 
 
-def _poisson_fourier_poly_2d(N: int, poly):
+def _poisson_fourier_poly_2d(N: int, poly, sparse: bool = True):
     """Return (T, A, b, ue) for Fourier x poly Poisson with manufactured solution."""
     F = FunctionSpace(N, Fourier)
     D = FunctionSpace(N, poly, BCS)
@@ -58,7 +60,7 @@ def _poisson_fourier_poly_2d(N: int, poly):
     v, u = TestFunction(T), TrialFunction(T)
     x, y = T.system.base_scalars()
     ue = sp.cos(2 * x) * (1 - y**2)
-    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
+    A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=sparse)
     return T, A, b, ue
 
 
@@ -154,6 +156,60 @@ def test_wavenumber_solver_solve2_agrees_with_solve():
     _, A, b, _ = _poisson_fourier_poly_2d(16, Legendre.Legendre)
     wn = tpmats_wavenumber_factor(A)
     assert float(jnp.max(jnp.abs(wn.solve(b) - wn.solve2(b)))) < float(ulp(100))
+
+
+# ---------------------------------------------------------------------------
+# tpmats_dense_lu_factor / TPMatricesDenseLUFactors
+# ---------------------------------------------------------------------------
+
+
+@POLY_SPACES
+def test_tpmats_dense_lu_factor_returns_correct_type(poly):
+    _, A, _, _ = _poisson_poly2d(8, poly, sparse=False)
+    lu = tpmats_dense_lu_factor(A)
+    assert isinstance(lu, TPMatricesDenseLUFactors)
+
+
+@POLY_SPACES
+def test_tpmats_dense_lu_factor_solve_poly2d(poly):
+    T, A, b, ue = _poisson_poly2d(16, poly, sparse=False)
+    lu = tpmats_dense_lu_factor(A)
+    uh = lu.solve(b)
+    assert uh.shape == b.shape
+    x, y = T.system.base_scalars()
+    N = 40
+    uj = T.backward(uh, N=(N, N))
+    xj = T.mesh(N=(N, N), broadcast=True)
+    uej = lambdify((x, y), ue)(*xj)
+    l2 = float(jnp.linalg.norm(uj - uej)) / N
+    assert l2 < float(ulp(100)), f"L2 error {l2:.2e} too large"
+
+
+@POLY_SPACES
+def test_tpmatrices_solve_dispatches_dense_for_matrix(poly):
+    """TPMatrices.lu_factor() dispatches to TPMatricesDenseLUFactors for dense matrices."""  # noqa: E501
+    _, A, b, _ = _poisson_poly2d(12, poly, sparse=False)
+    mats = TPMatrices(A)
+    lu = mats.lu_factor()
+    assert isinstance(lu, TPMatricesDenseLUFactors)
+    uh = mats.solve(b)
+    assert uh.shape == b.shape
+
+
+@POLY_SPACES
+def test_tpmats_dense_agrees_with_sparse(poly):
+    """Dense and sparse solvers produce the same solution."""
+    _, A_sp, b_sp, _ = _poisson_poly2d(16, poly, sparse=True)
+    _, A_de, b_de, _ = _poisson_poly2d(16, poly, sparse=False)
+    uh_sp = tpmats_lu_factor(A_sp).solve(b_sp)
+    uh_de = tpmats_dense_lu_factor(A_de).solve(b_de)
+    assert float(jnp.max(jnp.abs(uh_sp - uh_de))) < float(ulp(100))
+
+
+def test_tpmats_dense_lu_factor_type_error():
+    _, A, _, _ = _poisson_poly2d(8, Legendre.Legendre, sparse=True)
+    with pytest.raises(TypeError):
+        tpmats_dense_lu_factor(A)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -391,7 +391,7 @@ class TestScalarArithmetic:
 
 
 def _indexing_matrix() -> tuple[jax.Array, DiaMatrix]:
-    dense = jnp.arange(1, 21, dtype=jnp.float32).reshape(4, 5)
+    dense = jnp.arange(1, 21, dtype=float).reshape(4, 5)
     return dense, DiaMatrix.from_dense(dense)
 
 
@@ -884,7 +884,7 @@ class TestGetRow:
 
     def test_unstored_diagonal_is_zero(self):
         # Only main diagonal stored; every row should be a one-hot vector.
-        A = diags([jnp.arange(1, 5, dtype=jnp.float32)], offsets=(0,))
+        A = diags([jnp.arange(1, 5, dtype=float)], offsets=(0,))
         for i in range(4):
             row = A.get_row(i)
             expected = jnp.zeros(4).at[i].set(float(i + 1))
@@ -942,7 +942,7 @@ class TestGetColumn:
 
     def test_unstored_diagonal_is_zero(self):
         # Only main diagonal stored; every column should be a one-hot vector.
-        A = diags([jnp.arange(1, 5, dtype=jnp.float32)], offsets=(0,))
+        A = diags([jnp.arange(1, 5, dtype=float)], offsets=(0,))
         for j in range(4):
             col = A.get_column(j)
             expected = jnp.zeros(4).at[j].set(float(j + 1))
@@ -1335,7 +1335,7 @@ class TestRCM:
         for i in range(n - half):
             dense[i, i + half] = -1.0
             dense[i + half, i] = -1.0
-        A = DiaMatrix.from_dense(jnp.array(dense, dtype=jnp.float32))
+        A = DiaMatrix.from_dense(jnp.array(dense, dtype=float))
         A_perm, _, _ = A.rcm()
         bw_before = max(abs(k) for k in A.offsets)
         bw_after = max(abs(k) for k in A_perm.offsets)
@@ -1382,12 +1382,12 @@ class TestRCM:
         for i in range(n - half):
             dense[i, i + half] = -0.5
             dense[i + half, i] = -0.5
-        A = DiaMatrix.from_dense(jnp.array(dense, dtype=jnp.float32))
+        A = DiaMatrix.from_dense(jnp.array(dense, dtype=float))
         bw = max(abs(k) for k in A.offsets)
         # Confirm bandwidth is non-trivial so the rcm path is meaningful
         assert bw > 1
 
-        x_true = jnp.arange(1.0, n + 1.0, dtype=jnp.float32)
+        x_true = jnp.arange(1.0, n + 1.0, dtype=float)
         b = A.matvec(x_true)
         x_hat = A.lu_solve(b, method="rcm")
         assert jnp.allclose(x_hat, x_true, atol=ulp(1000))
@@ -1404,7 +1404,7 @@ class TestRCM:
         # Interleave permutation: [0,4,1,5,2,6,3,7] inflates bandwidth to ~4.
         perm_bad = np.array([0, 4, 1, 5, 2, 6, 3, 7])
         dense_bad = np.array(A0.todense())[perm_bad][:, perm_bad]
-        A = DiaMatrix.from_dense(jnp.array(dense_bad, dtype=jnp.float32))
+        A = DiaMatrix.from_dense(jnp.array(dense_bad, dtype=float))
         # Confirm bandwidth exceeds threshold so the wide path is entered.
         p = max((-k for k in A.offsets if k < 0), default=0)
         q = max((k for k in A.offsets if k > 0), default=0)

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -1038,7 +1038,7 @@ class TestPin:
         sys = A.pin({0: 0.0})
         r = repr(sys)
         assert "PinnedSystem" in r
-        assert "0=0.0" in r
+        assert "0: 0.0" in r
 
     # ------------------------------------------------------------------
     # Pytree structure

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -1316,3 +1316,129 @@ class TestPin:
         sys64 = sys.astype(jnp.float64)
         assert sys64.constraints == sys.constraints
         assert sys64.shape == sys.shape
+
+
+class TestRCM:
+    """Tests for DiaMatrix.rcm() — reverse Cuthill-McKee reordering."""
+
+    def test_returns_correct_types(self):
+        _, A = _pentadiag(8)
+        A_perm, perm, inv_perm = A.rcm()
+        assert isinstance(A_perm, DiaMatrix)
+        assert perm.dtype == jnp.int32
+        assert inv_perm.dtype == jnp.int32
+        assert perm.shape == (8,)
+        assert inv_perm.shape == (8,)
+
+    def test_perm_is_valid_permutation(self):
+        _, A = _pentadiag(8)
+        _, perm, inv_perm = A.rcm()
+        # perm must contain every index exactly once
+        assert jnp.allclose(jnp.sort(perm), jnp.arange(8))
+        # inv_perm is the inverse: inv_perm[perm[i]] == i
+        assert jnp.allclose(inv_perm[perm], jnp.arange(8))
+
+    def test_dense_roundtrip(self):
+        """A_perm.todense() should equal A.todense()[perm][:, perm]."""
+        _, A = _pentadiag(8)
+        A_perm, perm, inv_perm = A.rcm()
+        dense_A = np.array(A.todense())
+        perm_np = np.array(perm)
+        expected = jnp.array(dense_A[perm_np][:, perm_np])
+        assert jnp.allclose(A_perm.todense(), expected, atol=ulp(100))
+
+    def test_reduces_bandwidth_on_large_offset_matrix(self):
+        """A matrix with artificially large bandwidth should shrink after RCM."""
+        n = 16
+        # Build a matrix with off-diagonal entries at offset ±(n//2)
+        dense = np.diag(4 * np.ones(n))
+        half = n // 2
+        for i in range(n - half):
+            dense[i, i + half] = -1.0
+            dense[i + half, i] = -1.0
+        A = DiaMatrix.from_dense(jnp.array(dense, dtype=jnp.float32))
+        A_perm, _, _ = A.rcm()
+        bw_before = max(abs(k) for k in A.offsets)
+        bw_after = max(abs(k) for k in A_perm.offsets)
+        assert bw_after <= bw_before
+
+    def test_permuted_solve_matches_original(self):
+        _, A = _pentadiag(8)
+        A_perm, perm, inv_perm = A.rcm()
+        x_true = jnp.arange(1.0, 9.0)
+        b = A.matvec(x_true)
+        # Solve via RCM: A_perm x_perm = b[perm], then x = x_perm[inv_perm]
+        x_hat = A_perm.solve(b[perm])[inv_perm]
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
+
+    def test_tridiag_permuted_solve(self):
+        _, A = _tridiag(10)
+        A_perm, perm, inv_perm = A.rcm()
+        x_true = jnp.ones(10) * 3.0
+        b = A.matvec(x_true)
+        x_hat = A_perm.solve(b[perm])[inv_perm]
+        assert jnp.allclose(x_hat, x_true, atol=ulp(100))
+
+    def test_cached_returns_same_objects(self):
+        _, A = _tridiag(6)
+        result1 = A.rcm()
+        result2 = A.rcm()
+        # All three tuple elements must be the exact same objects
+        assert result1[0] is result2[0]
+        assert result1[1] is result2[1]
+        assert result1[2] is result2[2]
+
+    def test_lu_solve_uses_rcm_for_wide_bandwidth(self):
+        """lu_solve with wide bandwidth should take the RCM path, not dense."""
+        n = 24
+        # Build a block-diagonal-like matrix with a large offset that RCM
+        # can compress: two n/2 tridiagonal blocks connected by off-diagonals
+        # at offset ±(n//2).  Bandwidth = n//2 → p*(q+1) = (n//2)²  >> 100.
+        dense = np.diag(4 * np.ones(n))
+        half = n // 2
+        for i in range(n - 1):
+            dense[i, i + 1] = -1.0
+            dense[i + 1, i] = -1.0
+        # Remove direct neighbors and add inter-block coupling at ±half
+        for i in range(n - half):
+            dense[i, i + half] = -0.5
+            dense[i + half, i] = -0.5
+        A = DiaMatrix.from_dense(jnp.array(dense, dtype=jnp.float32))
+        bw = max(abs(k) for k in A.offsets)
+        # Confirm bandwidth exceeds default dense_threshold
+        assert bw > 10
+
+        x_true = jnp.arange(1.0, n + 1.0, dtype=jnp.float32)
+        b = A.matvec(x_true)
+        x_hat = A.lu_solve(b, dense_threshold=10)
+        assert jnp.allclose(x_hat, x_true, atol=ulp(1000))
+
+    def test_lu_solve_rcm_path_cached(self):
+        """Second lu_solve via the RCM path must populate _rcm_solve_cache.
+
+        Build a tridiagonal that has been deliberately badly ordered (every
+        other node swapped) to inflate bandwidth.  RCM can collapse it back to
+        a narrow matrix, so the RCM path — not the dense fallback — is used.
+        """
+        n = 8
+        _, A0 = _tridiag(n)
+        # Interleave permutation: [0,4,1,5,2,6,3,7] inflates bandwidth to ~4.
+        perm_bad = np.array([0, 4, 1, 5, 2, 6, 3, 7])
+        dense_bad = np.array(A0.todense())[perm_bad][:, perm_bad]
+        A = DiaMatrix.from_dense(jnp.array(dense_bad, dtype=jnp.float32))
+        # Confirm bandwidth exceeds threshold so the wide path is entered.
+        p = max((-k for k in A.offsets if k < 0), default=0)
+        q = max((k for k in A.offsets if k > 0), default=0)
+        assert p * (q + 1) > 10
+
+        x_true = jnp.arange(1.0, n + 1.0)
+        b = A.matvec(x_true)
+        # First call — should take RCM path and populate _rcm_solve_cache.
+        x1 = A.lu_solve(b, dense_threshold=10)
+        assert hasattr(A, "_rcm_solve_cache"), (
+            "_rcm_solve_cache not set after first call"
+        )
+        # Second call — should hit the cache and return the same result.
+        x2 = A.lu_solve(b, dense_threshold=10)
+        assert jnp.allclose(x1, x2, atol=ulp(10))
+        assert jnp.allclose(x1, x_true, atol=ulp(100))

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -232,8 +232,7 @@ class TestMatvec:
     @pytest.mark.parametrize("mat", allmatrices)
     def test_matmat_vs_dense(self, mat):
         a, A = mat(6)
-        rng = np.random.default_rng(1)
-        X = jnp.array(rng.standard_normal((6, 3)))
+        X = jax.random.normal(jax.random.PRNGKey(1), shape=(6, 3))
         assert jnp.allclose(A @ X, a @ X, atol=1e-6)
 
     @pytest.mark.parametrize("mat", allmatrices)
@@ -272,8 +271,7 @@ class TestMatvec:
     def test_rmatmul_2d_array_x_matrix(self, mat):
         """Array (2-D) @ Matrix → Matrix.__rmatmul__(Array) 2-D path."""
         a, A = mat(6)
-        rng = np.random.default_rng(42)
-        X = jnp.array(rng.standard_normal((4, 6)))
+        X = jax.random.normal(jax.random.PRNGKey(42), shape=(4, 6))
         expected = X @ a.data
         assert jnp.allclose(X @ a, expected, atol=1e-6)
 
@@ -281,8 +279,7 @@ class TestMatvec:
     def test_matmul_dia_x_matrix(self, mat):
         """DiaMatrix @ Matrix → DiaMatrix.__matmul__(Matrix) path."""
         a, A = mat(6)
-        rng = np.random.default_rng(43)
-        B = Matrix(jnp.array(rng.standard_normal((6, 4))))
+        B = Matrix(jax.random.normal(jax.random.PRNGKey(43), shape=(6, 4)))
         result = A @ B
         expected = A.todense() @ B.data
         assert isinstance(result, Matrix)
@@ -292,8 +289,7 @@ class TestMatvec:
     def test_matmul_matrix_x_dia(self, mat):
         """Matrix @ DiaMatrix → Matrix.__matmul__(DiaMatrix) path."""
         a, A = mat(6)
-        rng = np.random.default_rng(44)
-        B = Matrix(jnp.array(rng.standard_normal((4, 6))))
+        B = Matrix(jax.random.normal(jax.random.PRNGKey(44), shape=(4, 6)))
         result = B @ A
         expected = B.data @ A.todense()
         assert isinstance(result, Matrix)
@@ -492,8 +488,7 @@ class TestMatvecAxis:
     def test_axis0_2d_equals_matmat(self, mat):
         """matvec(X, axis=0) should equal the classic A @ X product."""
         a, A = mat(6)
-        rng = np.random.default_rng(7)
-        X = jnp.array(rng.standard_normal((6, 5)))
+        X = jax.random.normal(jax.random.PRNGKey(7), shape=(6, 5))
         expected = a @ X
         assert jnp.allclose(A.matvec(X, axis=0), expected, atol=ulp(100))
         assert jnp.allclose(a.matvec(X, axis=0), expected, atol=ulp(100))
@@ -502,8 +497,7 @@ class TestMatvecAxis:
     def test_axis1_2d(self, mat):
         """matvec(X, axis=1) contracts along columns: each row of X gets multiplied."""
         a, A = mat(6)
-        rng = np.random.default_rng(8)
-        X = jnp.array(rng.standard_normal((5, 6)))  # (batch, m)
+        X = jax.random.normal(jax.random.PRNGKey(8), shape=(5, 6))  # (batch, m)
         expected = (a @ X.T).T  # (n, batch) → (batch, n)
         assert jnp.allclose(A.matvec(X, axis=1), expected, atol=ulp(100))
         assert jnp.allclose(a.matvec(X, axis=1), expected, atol=ulp(100))
@@ -518,8 +512,7 @@ class TestMatvecAxis:
     def test_axis0_3d(self):
         """matvec(T, axis=0): T shape (m, b1, b2) → (n, b1, b2)."""
         a, A = _tridiag(4)
-        rng = np.random.default_rng(9)
-        T = jnp.array(rng.standard_normal((4, 3, 2)))
+        T = jax.random.normal(jax.random.PRNGKey(9), shape=(4, 3, 2))
         # Expected: contract axis 0 with A
         # result[i, j, k] = sum_l A[i, l] * T[l, j, k]
         expected = jnp.einsum("il,ljk->ijk", a.data, T)
@@ -529,8 +522,7 @@ class TestMatvecAxis:
     def test_axis1_3d(self):
         """matvec(T, axis=1): T shape (b0, m, b2) → (b0, n, b2)."""
         a, A = _tridiag(4)
-        rng = np.random.default_rng(10)
-        T = jnp.array(rng.standard_normal((3, 4, 2)))
+        T = jax.random.normal(jax.random.PRNGKey(10), shape=(3, 4, 2))
         expected = jnp.einsum("il,jlk->jik", a.data, T)
         assert jnp.allclose(A.matvec(T, axis=1), expected, atol=ulp(100))
         assert jnp.allclose(a.matvec(T, axis=1), expected, atol=ulp(100))
@@ -538,8 +530,7 @@ class TestMatvecAxis:
     def test_axis2_3d(self):
         """matvec(T, axis=2): T shape (b0, b1, m) → (b0, b1, n)."""
         a, A = _tridiag(4)
-        rng = np.random.default_rng(11)
-        T = jnp.array(rng.standard_normal((3, 2, 4)))
+        T = jax.random.normal(jax.random.PRNGKey(11), shape=(3, 2, 4))
         expected = jnp.einsum("il,jkl->jki", a.data, T)
         assert jnp.allclose(A.matvec(T, axis=2), expected, atol=ulp(100))
         assert jnp.allclose(a.matvec(T, axis=2), expected, atol=ulp(100))
@@ -547,8 +538,7 @@ class TestMatvecAxis:
     def test_negative_axis(self):
         """Negative axis should work like numpy convention."""
         a, A = _tridiag(4)
-        rng = np.random.default_rng(12)
-        T = jnp.array(rng.standard_normal((3, 2, 4)))
+        T = jax.random.normal(jax.random.PRNGKey(12), shape=(3, 2, 4))
         assert jnp.allclose(A.matvec(T, axis=-1), A.matvec(T, axis=2), atol=1e-6)
 
     def test_output_shape_axis0(self):
@@ -634,8 +624,7 @@ class TestSolve:
     @pytest.mark.parametrize("mat", allmatrices)
     def test_solve_residual(self, mat):
         a, A = mat(8)
-        rng = np.random.default_rng(42)
-        b = jnp.array(rng.standard_normal(8))
+        b = jax.random.normal(jax.random.PRNGKey(42), shape=(8,))
         x = A.solve(b)
         assert float(jnp.linalg.norm(A.matvec(x) - b)) < ulp(100)
 
@@ -643,8 +632,7 @@ class TestSolve:
     def test_solve_axis1(self, mat):
         """A.solve(B, axis=1): each row of B is a separate RHS."""
         a, A = mat(6)
-        rng = np.random.default_rng(55)
-        X_true = jnp.array(rng.standard_normal((4, 6)))
+        X_true = jax.random.normal(jax.random.PRNGKey(55), shape=(4, 6))
         B = (a @ X_true.T).T  # (4, 6)
         X_hat = A.solve(B, axis=1)
         assert X_hat.shape == (4, 6)
@@ -655,11 +643,10 @@ class TestSolve:
     def test_solve_axis_matches_matvec(self, mat):
         """A.solve(A.matvec(X, axis=k), axis=k) == X for k in 0,1,2."""
         a, A = mat(7)
-        rng = np.random.default_rng(66)
         for ax in (0, 1, 2):
             shape = [3, 7, 4]
             shape[ax] = 7
-            X = jnp.array(rng.standard_normal(shape))
+            X = jax.random.normal(jax.random.PRNGKey(66), shape=tuple(shape))
             B = A.matvec(X, axis=ax)
             X_hat = A.solve(B, axis=ax)
             assert X_hat.shape == tuple(shape)
@@ -733,8 +720,7 @@ class TestLU:
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_solve_random_rhs(self, mat):
         a, A = mat(8)
-        rng = np.random.default_rng(99)
-        b = jnp.array(rng.standard_normal(8))
+        b = jax.random.normal(jax.random.PRNGKey(99), shape=(8,))
         lu = A.lu_factor()
         x = lu.solve(b)
         assert float(jnp.linalg.norm(A.matvec(x) - b)) < ulp(100)
@@ -743,8 +729,7 @@ class TestLU:
     def test_lu_solve_multiple_rhs(self, mat):
         """solve() should work for 2-D right-hand sides (n, k)."""
         a, A = mat(6)
-        rng = np.random.default_rng(7)
-        X_true = jnp.array(rng.standard_normal((6, 4)))
+        X_true = jax.random.normal(jax.random.PRNGKey(7), shape=(6, 4))
         B = a @ X_true
         lu = A.lu_factor()
         X_hat = lu.solve(B)
@@ -814,8 +799,7 @@ class TestLU:
         """solve(B, axis=1) solves each row of B as a separate RHS."""
         a, A = mat(6)
         lu = A.lu_factor()
-        rng = np.random.default_rng(11)
-        X_true = jnp.array(rng.standard_normal((4, 6)))  # (batch, n)
+        X_true = jax.random.normal(jax.random.PRNGKey(11), shape=(4, 6))  # (batch, n)
         B = a @ X_true.T  # (n, batch)
         B_T = B.T  # (batch, n)
         X_hat = lu.solve(B_T, axis=1)
@@ -828,8 +812,7 @@ class TestLU:
         """solve on a 3-D array along a non-zero axis."""
         a, A = mat(5)
         lu = A.lu_factor()
-        rng = np.random.default_rng(22)
-        X_true = jnp.array(rng.standard_normal((3, 5, 4)))  # (a, n, b)
+        X_true = jax.random.normal(jax.random.PRNGKey(22), shape=(3, 5, 4))  # (a, n, b)
         # Build RHS: apply A along axis 1
         B = A.matvec(X_true, axis=1)
         X_hat = lu.solve(B, axis=1)
@@ -844,11 +827,10 @@ class TestLU:
         """lu.solve(A.matvec(X, axis=k), axis=k) == X for any axis."""
         a, A = mat(5)
         lu = A.lu_factor()
-        rng = np.random.default_rng(33)
         for ax in (0, 1, 2):
             shape = [3, 5, 4]
             shape[ax] = 5
-            X = jnp.array(rng.standard_normal(shape))
+            X = jax.random.normal(jax.random.PRNGKey(33), shape=tuple(shape))
             B = A.matvec(X, axis=ax)
             X_hat = lu.solve(B, axis=ax)
             assert X_hat.shape == tuple(shape)
@@ -1190,8 +1172,7 @@ class TestPin:
     def test_solve_dia_matches_matrix(self, use_matrix):
         """DiaMatrix.pin and Matrix.pin must give the same answer."""
         a, A = _tridiag(6)
-        rng = np.random.default_rng(42)
-        b = jnp.array(rng.standard_normal(6))
+        b = jax.random.normal(jax.random.PRNGKey(42), shape=(6,))
         x_dia = A.pin({0: 0.0}).solve(b)
         x_mat = a.pin({0: 0.0}).solve(b)
         assert jnp.allclose(x_dia, x_mat, atol=ulp(100))
@@ -1204,10 +1185,9 @@ class TestPin:
         """solve(B, axis=0): each column of B is an independent RHS."""
         _, A = _tridiag(5)
         sys = A.pin({0: 0.0, 4: 0.0})
-        rng = np.random.default_rng(7)
         k = 4
         # Build true solutions with pinned BCs satisfied.
-        X_true = jnp.array(rng.standard_normal((5, k)))
+        X_true = jax.random.normal(jax.random.PRNGKey(7), shape=(5, k))
         X_true = X_true.at[0].set(0.0).at[4].set(0.0)
         B = jnp.array([A.matvec(X_true[:, j]) for j in range(k)]).T  # (5, k)
         X_hat = sys.solve(B, axis=0)
@@ -1218,9 +1198,8 @@ class TestPin:
         """solve(B, axis=1): each row of B is an independent RHS."""
         _, A = _tridiag(5)
         sys = A.pin({0: 0.0, 4: 0.0})
-        rng = np.random.default_rng(8)
         k = 3
-        X_true = jnp.array(rng.standard_normal((k, 5)))
+        X_true = jax.random.normal(jax.random.PRNGKey(8), shape=(k, 5))
         X_true = X_true.at[:, 0].set(0.0).at[:, 4].set(0.0)
         B = jnp.stack([A.matvec(X_true[j]) for j in range(k)])  # (k, 5)
         X_hat = sys.solve(B, axis=1)
@@ -1405,12 +1384,12 @@ class TestRCM:
             dense[i + half, i] = -0.5
         A = DiaMatrix.from_dense(jnp.array(dense, dtype=jnp.float32))
         bw = max(abs(k) for k in A.offsets)
-        # Confirm bandwidth exceeds default dense_threshold
-        assert bw > 10
+        # Confirm bandwidth is non-trivial so the rcm path is meaningful
+        assert bw > 1
 
         x_true = jnp.arange(1.0, n + 1.0, dtype=jnp.float32)
         b = A.matvec(x_true)
-        x_hat = A.lu_solve(b, dense_threshold=10)
+        x_hat = A.lu_solve(b, method="rcm")
         assert jnp.allclose(x_hat, x_true, atol=ulp(1000))
 
     def test_lu_solve_rcm_path_cached(self):
@@ -1434,11 +1413,11 @@ class TestRCM:
         x_true = jnp.arange(1.0, n + 1.0)
         b = A.matvec(x_true)
         # First call — should take RCM path and populate _rcm_solve_cache.
-        x1 = A.lu_solve(b, dense_threshold=10)
+        x1 = A.lu_solve(b, method="rcm")
         assert hasattr(A, "_rcm_solve_cache"), (
             "_rcm_solve_cache not set after first call"
         )
         # Second call — should hit the cache and return the same result.
-        x2 = A.lu_solve(b, dense_threshold=10)
+        x2 = A.lu_solve(b, method="rcm")
         assert jnp.allclose(x1, x2, atol=ulp(10))
         assert jnp.allclose(x1, x_true, atol=ulp(100))

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -701,10 +701,14 @@ class TestLU:
         assert set(lu.L.offsets) == {-2, -1, 0}
 
     def test_lu_U_offsets(self):
-        """For a tridiagonal (no pivoting), U has offsets (0, 1)."""
+        """Structurally-zero diagonals are pruned from U after factorisation.
+
+        _pentadiagO has only even offsets (-4,-2,0,2,4).  No fill-in occurs on
+        odd diagonals, so U should contain only offsets {0, 2, 4}.
+        """
         _, A = _pentadiagO(5)
         lu = A.lu_factor()
-        assert set(lu.U.offsets) == {0, 1, 2, 3, 4}
+        assert set(lu.U.offsets) == {0, 2, 4}
 
     @pytest.mark.parametrize("mat", allmatrices)
     def test_lu_product_equals_original(self, mat):

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -389,7 +389,7 @@ def _make_tpmatrix_2d(
 ) -> tuple[TPMatrix, np.ndarray]:
     """Return a TPMatrix(A0, A1) and the corresponding dense Kronecker product."""
     a0 = jax.random.normal(jax.random.PRNGKey(7), shape=(m0, n0))
-    a1 = jax.random.normal(jax.random.PRNGKey(7), shape=(m1, n1))
+    a1 = jax.random.normal(jax.random.PRNGKey(8), shape=(m1, n1))
     tp = TPMatrix(
         [Matrix(a0), Matrix(a1)],  # ty:ignore[invalid-argument-type]
         scale,

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import cast
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -288,21 +289,20 @@ class TestKronSolve:
         assert jnp.allclose(x_lu, x_dense, atol=ulp(100))
 
     def test_poisson_dense_fallback(self):
-        """Forcing the dense-fallback path (dense_threshold=0) must give same answer."""
+        """Forcing the dense-fallback path must give same answer as banded path."""
         A, b = _poisson_tpmats(N=8)
         C = cast(DiaMatrix, tpmats_to_kron(A))
         b_flat = b.flatten()
-        x_banded = C.solve(b_flat, dense_threshold=10_000)
-        x_dense = C.solve(b_flat, dense_threshold=0)
+        x_banded = C.solve(b_flat, method="rcm")
+        x_dense = C.solve(b_flat, method="dense")
         assert jnp.allclose(x_banded, x_dense, atol=ulp(1000))
 
     def test_kron_solve_multiple_rhs(self):
         """solve() on a kron matrix must work for 2-D right-hand sides."""
         A, b = _poisson_tpmats(N=6)
         C = cast(DiaMatrix, tpmats_to_kron(A))
-        rng = np.random.default_rng(42)
         n = C.shape[0]
-        X_true = jnp.array(rng.standard_normal((n, 3)))
+        X_true = jax.random.normal(jax.random.PRNGKey(42), shape=(n, 3))
         B = C.todense() @ X_true
         X_hat = C.solve(B)
         assert X_hat.shape == (n, 3)
@@ -320,7 +320,7 @@ class TestKronSolve:
         A, b = _biharmonic_tpmats(N=12)
         C = tpmats_to_kron(A)
         b_flat = b.flatten()
-        x = C.solve(b_flat)  # hits dense_threshold automatically
+        x = C.solve(b_flat)  # auto method falls back to dense for wide bandwidth
         residual = float(jnp.linalg.norm(C.todense() @ x - b_flat))
         assert residual < ulp(10000)
 
@@ -347,8 +347,7 @@ class TestManualKronSolve:
         """LU solve on I⊗T + T⊗I must match dense solve."""
         n = 7
         L = self._build_laplacian(n)
-        rng = np.random.default_rng(0)
-        b = jnp.array(rng.standard_normal(n * n))
+        b = jax.random.normal(jax.random.PRNGKey(0), shape=(n * n,))
         x_lu = L.solve(b)
         x_dense = jnp.linalg.solve(L.todense(), b)
         assert jnp.allclose(x_lu, x_dense, atol=ulp(100))
@@ -358,8 +357,7 @@ class TestManualKronSolve:
         A = _diag3(4)
         B = _diag3(5)
         K = diakron(A, B)
-        rng = np.random.default_rng(1)
-        b = jnp.array(rng.standard_normal(20))
+        b = jax.random.normal(jax.random.PRNGKey(1), shape=(20,))
         x = K.solve(b)
         assert float(jnp.linalg.norm(K.todense() @ x - b)) < ulp(1000)
 
@@ -368,18 +366,16 @@ class TestManualKronSolve:
         A = _diag5(6)
         B = _diag5(5)
         K = diakron(A, B)
-        rng = np.random.default_rng(2)
-        b = jnp.array(rng.standard_normal(30))
-        x = K.solve(b)
+        b = jax.random.normal(jax.random.PRNGKey(2), shape=(30,))
+        x = K.solve(b, method="banded")
         assert float(jnp.linalg.norm(K.todense() @ x - b)) < ulp(1000)
 
     def test_lu_vs_dense_on_kron(self):
         """LU and dense paths must agree for a manually built kron matrix."""
         L = self._build_laplacian(5)
-        rng = np.random.default_rng(3)
-        b = jnp.array(rng.standard_normal(25))
-        x_banded = L.solve(b, dense_threshold=10_000)
-        x_dense = L.solve(b, dense_threshold=0)
+        b = jax.random.normal(jax.random.PRNGKey(3), shape=(25,))
+        x_banded = L.solve(b, method="rcm")
+        x_dense = L.solve(b, method="dense")
         assert jnp.allclose(x_banded, x_dense, atol=ulp(100))
 
 
@@ -392,11 +388,10 @@ def _make_tpmatrix_2d(
     m0: int, n0: int, m1: int, n1: int, scale: float = 1.0
 ) -> tuple[TPMatrix, np.ndarray]:
     """Return a TPMatrix(A0, A1) and the corresponding dense Kronecker product."""
-    rng = np.random.default_rng(7)
-    a0 = rng.standard_normal((m0, n0)).astype(np.float32)
-    a1 = rng.standard_normal((m1, n1)).astype(np.float32)
+    a0 = jax.random.normal(jax.random.PRNGKey(7), shape=(m0, n0))
+    a1 = jax.random.normal(jax.random.PRNGKey(7), shape=(m1, n1))
     tp = TPMatrix(
-        [Matrix(jnp.array(a0)), Matrix(jnp.array(a1))],  # ty:ignore[invalid-argument-type]
+        [Matrix(a0), Matrix(a1)],  # ty:ignore[invalid-argument-type]
         scale,
     )
     K = np.kron(a0, a1) * scale
@@ -407,8 +402,7 @@ def _make_tpmatrix_3d(
     sizes: tuple[int, int, int], scale: float = 1.0, seed: int = 11
 ) -> tuple[TPMatrix, np.ndarray]:
     """Return a square TPMatrix(A0, A1, A2) and matching dense Kronecker product."""
-    rng = np.random.default_rng(seed)
-    mats_np = [rng.standard_normal((s, s)).astype(np.float32) for s in sizes]
+    mats_np = [np.random.default_rng(seed).standard_normal((s, s)) for s in sizes]
     K = mats_np[0]
     for a in mats_np[1:]:
         K = np.kron(K, a)
@@ -428,8 +422,7 @@ class TestTPMatrixMatmul:
         """(A0⊗A1) @ vec(w) == vec(A0 @ w @ A1.T) for square factors."""
         n0, n1 = 5, 4
         tp, K = _make_tpmatrix_2d(n0, n0, n1, n1)
-        rng = np.random.default_rng(0)
-        w = jnp.array(rng.standard_normal((n0, n1)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(0), shape=(n0, n1))
         result = tp(w)
         expected = (K @ np.array(w).ravel()).reshape(n0, n1)
         assert jnp.allclose(result, jnp.array(expected), atol=1e-5)
@@ -438,8 +431,7 @@ class TestTPMatrixMatmul:
         """vec(w) @ (A0⊗A1) == vec(A0.T @ w @ A1)."""
         n0, n1 = 5, 4
         tp, K = _make_tpmatrix_2d(n0, n0, n1, n1)
-        rng = np.random.default_rng(1)
-        w = jnp.array(rng.standard_normal((n0, n1)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(1), shape=(n0, n1))
         result = w @ tp  # calls __rmatmul__
         expected = (np.array(w).ravel() @ K).reshape(n0, n1)
         assert jnp.allclose(result, jnp.array(expected), atol=1e-5)
@@ -451,8 +443,7 @@ class TestTPMatrixMatmul:
         I = diags([jnp.ones(n)], offsets=(0,))
         K_dia = diakron(T, I)  # symmetric
         tp = TPMatrix([T, I], 1.0)  # ty:ignore[invalid-argument-type]
-        rng = np.random.default_rng(2)
-        w = jnp.array(rng.standard_normal((n, n)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(2), shape=(n, n))
         # A @ w (flattened) and w @ A (flattened) differ only by interpretation:
         # check against kron dense product
         K_dense = np.array(K_dia.todense())
@@ -468,8 +459,7 @@ class TestTPMatrixMatmul:
     def test_2d_matmul_nonsquare(self):
         """Works when A0 is m0×n0 with m0 ≠ n0."""
         tp, K = _make_tpmatrix_2d(3, 5, 4, 6)  # (12, 30) Kronecker product
-        rng = np.random.default_rng(3)
-        w = jnp.array(rng.standard_normal((5, 6)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(3), shape=(5, 6))
         result = tp(w)
         expected = (K @ np.array(w).ravel()).reshape(3, 4)
         assert result.shape == (3, 4)
@@ -478,8 +468,7 @@ class TestTPMatrixMatmul:
     def test_2d_rmatmul_nonsquare(self):
         """vec(w) @ kron for non-square factors."""
         tp, K = _make_tpmatrix_2d(3, 5, 4, 6)
-        rng = np.random.default_rng(4)
-        w = jnp.array(rng.standard_normal((3, 4)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(4), shape=(3, 4))
         result = w @ tp
         expected = (np.array(w).ravel() @ K).reshape(5, 6)
         assert result.shape == (5, 6)
@@ -495,8 +484,7 @@ class TestTPMatrixMatmul:
         tp1, _ = _make_tpmatrix_2d(n0, n0, n1, n1, scale=1.0)
         # same matrices, tripled scale
         tp3 = TPMatrix(list(tp1.mats), scale=3.0)
-        rng = np.random.default_rng(5)
-        w = jnp.array(rng.standard_normal((n0, n1)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(5), shape=(n0, n1))
         assert jnp.allclose(tp3(w), 3.0 * tp1(w), atol=1e-5)
 
     def test_2d_rmatmul_scale_applied(self):
@@ -504,8 +492,7 @@ class TestTPMatrixMatmul:
         tp1, _ = _make_tpmatrix_2d(n0, n0, n1, n1, scale=1.0)
         # same matrices, double scale
         tp2 = TPMatrix(list(tp1.mats), scale=2.0)
-        rng = np.random.default_rng(6)
-        w = jnp.array(rng.standard_normal((n0, n1)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(6), shape=(n0, n1))
         assert jnp.allclose(w @ tp2, 2.0 * (w @ tp1), atol=1e-5)
 
     # ------------------------------------------------------------------
@@ -516,8 +503,7 @@ class TestTPMatrixMatmul:
         """(A0⊗A1⊗A2) @ vec(w) == result from sequential matvec."""
         # Use uniform sizes to avoid JIT pytree shape mismatch across tests
         tp, K = _make_tpmatrix_3d((4, 4, 4))
-        rng = np.random.default_rng(8)
-        w = jnp.array(rng.standard_normal((4, 4, 4)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(8), shape=(4, 4, 4))
         result = tp(w)
         expected = (K @ np.array(w).ravel()).reshape(4, 4, 4)
         assert result.shape == (4, 4, 4)
@@ -526,8 +512,7 @@ class TestTPMatrixMatmul:
     def test_3d_rmatmul_vs_kron(self):
         """vec(w) @ (A0⊗A1⊗A2) via __rmatmul__."""
         tp, K = _make_tpmatrix_3d((4, 4, 4), seed=99)
-        rng = np.random.default_rng(9)
-        w = jnp.array(rng.standard_normal((4, 4, 4)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(9), shape=(4, 4, 4))
         result = w @ tp
         expected = (np.array(w).ravel() @ K).reshape(4, 4, 4)
         assert result.shape == (4, 4, 4)
@@ -537,8 +522,7 @@ class TestTPMatrixMatmul:
         """scale propagates correctly in 3-D."""
         tp1, _ = _make_tpmatrix_3d((4, 4, 4), scale=1.0)
         tp4 = TPMatrix(list(tp1.mats), scale=4.0)
-        rng = np.random.default_rng(10)
-        w = jnp.array(rng.standard_normal((4, 4, 4)).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(10), shape=(4, 4, 4))
         assert jnp.allclose(tp4(w), 4.0 * tp1(w), atol=1e-4)
 
     # ------------------------------------------------------------------
@@ -549,9 +533,8 @@ class TestTPMatrixMatmul:
         """TPMatrix from inner() with DIA factors: A@u matches tpmats_to_kron @ u."""
         A, _ = _poisson_tpmats(N=8)
         C = tpmats_to_kron(A)
-        rng = np.random.default_rng(20)
         shape = tuple(m.shape[1] for m in A[0].mats)
-        w = jnp.array(rng.standard_normal(shape).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(20), shape=tuple(shape))
         result = sum(tpm(w) for tpm in A)
         expected = (C.todense() @ np.array(w).ravel()).reshape(shape)
         assert jnp.allclose(result, jnp.array(expected), atol=1e-4)
@@ -560,9 +543,8 @@ class TestTPMatrixMatmul:
         """w @ TPMatrix from inner() matches w @ tpmats_to_kron."""
         A, _ = _poisson_tpmats(N=8)
         C = tpmats_to_kron(A)
-        rng = np.random.default_rng(21)
         shape = tuple(m.shape[0] for m in A[0].mats)
-        w = jnp.array(rng.standard_normal(shape).astype(np.float32))
+        w = jax.random.normal(jax.random.PRNGKey(21), shape=tuple(shape))
         result = sum(w @ tpm for tpm in A)
         expected = (np.array(w).ravel() @ C.todense()).reshape(shape)
         assert jnp.allclose(result, jnp.array(expected), atol=1e-4)
@@ -624,5 +606,5 @@ class TestTpmatsToScipySparse:
         A, b = _poisson_tpmats(N=8)
         K_sp = tpmats_to_scipy_kron(A)
         K_jax = tpmats_to_kron(A)
-        x = np.random.default_rng(42).standard_normal(K_sp.shape[1]).astype(np.float32)
+        x = jax.random.normal(jax.random.PRNGKey(42), shape=(K_sp.shape[1],))
         assert np.allclose(K_sp @ x, np.array(K_jax.todense()) @ x, atol=1e-4)

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -26,7 +26,7 @@ from jaxfun.galerkin import (
     TrialFunction,
 )
 from jaxfun.galerkin.inner import inner
-from jaxfun.galerkin.tensorproductspace import TPMatrix, tpmats_to_kron
+from jaxfun.galerkin.tensorproductspace import TPMatrices, TPMatrix, tpmats_to_kron
 from jaxfun.la import DiaMatrix, Matrix, diags
 from jaxfun.la.diamatrix import diakron
 from jaxfun.operators import Div, Grad
@@ -179,7 +179,7 @@ class TestDiakron:
         # Valid offsets: [-(12-1), 6-1] = [-11, 5].
         m, n, p = 4, 2, 3
         A_dense = jnp.array(
-            [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32
+            [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]], dtype=float
         )
         A = DiaMatrix.from_dense(A_dense)
         B = _diag3(p)
@@ -318,9 +318,9 @@ class TestKronSolve:
             pytest.skip("requires float64 (run with jax_enable_x64=True)")
 
         A, b = _biharmonic_tpmats(N=12)
-        C = tpmats_to_kron(A)
+        C = TPMatrices(A)
         b_flat = b.flatten()
-        x = C.solve(b_flat)  # auto method falls back to dense for wide bandwidth
+        x = C.solve(b_flat, method="kron", kron_method="rcm")
         residual = float(jnp.linalg.norm(C.todense() @ x - b_flat))
         assert residual < ulp(10000)
 

--- a/tests/pinns/test_optimizer.py
+++ b/tests/pinns/test_optimizer.py
@@ -111,7 +111,7 @@ class TestTrainer:
         assert initial_loss > 0
 
         # Train for a few epochs
-        trainer.train(optimizer, 10)
+        trainer.train(optimizer, 20)
 
         # Loss should decrease
         final_loss = lsqr_loss_fn(simple_model.module)


### PR DESCRIPTION
## Summary

Implement two additional types of solvers in addition to the already existing solvers using Kronecker product matrices.

## Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] Other (describe):


## Description of Changes

TPMatricesWavenumberSolver - Efficient solver for TensorProducts with only one non-periodic space and the rest Fourier. Solver loops over all wavenumbers and solves the 1D non-periodic problem for each wavenumber.

TPMatricesLUFactors - For tensor product spaces with more than one polynomial space. Using matrix diagonalization.

TPMatrices dispatches by checking if it can use the first solver or the next. If not fall back on Kronecker product solver.

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [ ] Coverage does not decrease
- [x] Git history is clean (squash/fixup before merge)
