### PR TITLE
Remove Meshkind from backward, move functionality to evaluate_mesh

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           uv run pytest --num-devices=2
           uv run pytest --float64 --num-devices=2
+          uv run pytest -m slow --num-devices=2
+          uv run pytest --float64 -m slow --num-devices=2
 
       - name: Run slow demo tests
         run: |

--- a/examples/Burgers_lstsq.py
+++ b/examples/Burgers_lstsq.py
@@ -47,7 +47,7 @@ trainer.train(adam(u), 1000, abs_limit_change=0)
 trainer.train(lbfgs(u), 1000, print_final_loss=True)
 
 if "PYTEST" in os.environ:
-    sys.exit(1)
+    sys.exit(0)
 
 xj = jnp.linspace(left, right, 50)
 tj = jnp.linspace(t0, tmax, 50)

--- a/examples/Helmholtz_vpinn.py
+++ b/examples/Helmholtz_vpinn.py
@@ -80,4 +80,4 @@ print_error(t0)
 if "PYTEST" in os.environ:
     error = jnp.linalg.norm((w.module(t0) - uej(t0)) / len(t0))
     assert error < 1e-4, error
-    sys.exit(1)
+    sys.exit(0)

--- a/examples/advection1D_backward_euler.py
+++ b/examples/advection1D_backward_euler.py
@@ -60,7 +60,7 @@ error = jnp.linalg.norm(u_num - u_ex_j)
 if "PYTEST" in os.environ:
     # Backward Euler is diffusive for pure advection; keep tolerance loose.
     assert error < 0.35, error
-    sys.exit(1)
+    sys.exit(0)
 
 print("L2 error =", float(error))
 plt.plot(xj, lambdify(x, u0)(xj), "--k", label="initial")

--- a/examples/biharmonic2D.py
+++ b/examples/biharmonic2D.py
@@ -43,13 +43,13 @@ uh = A.solve(b)
 
 N = 100
 xj = T.mesh(kind="uniform", N=(N, N))
-uj = T.backward(uh, kind="uniform", N=(N, N))
+uj = T.evaluate_mesh(uh, kind="uniform", N=(N, N))
 uej = lambdify((x, y), ue)(*xj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(100), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/diffusion1D_rk4.py
+++ b/examples/diffusion1D_rk4.py
@@ -64,7 +64,7 @@ u_ex_j = lambdify(x, u_ex)(xj)
 error = jnp.linalg.norm(u_num - u_ex_j)
 if "PYTEST" in os.environ:
     assert error < 5e-2, error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Relative L2 error =", float(error))
 plt.plot(xj, lambdify(x, u0)(xj), "--k", label="initial")

--- a/examples/helmholtz1D.py
+++ b/examples/helmholtz1D.py
@@ -39,7 +39,7 @@ uej = lambdify(D.system.x, ue)(xj)
 error = jnp.linalg.norm(uj - uej)
 if "PYTEST" in os.environ:
     assert error < jnp.sqrt(ulp(10)), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 plt.plot(xj, uej, "r")

--- a/examples/helmholtz2D.py
+++ b/examples/helmholtz2D.py
@@ -43,14 +43,14 @@ A, L = inner(v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True)
 un = A.solve(L, method="kron", kron_method="banded")
 
 N = 100
-uj = T.backward(un, kind="uniform", N=(N, N))
+uj = T.evaluate_mesh(un, kind="uniform", N=(N, N))
 xj = T.mesh(kind="uniform", N=(N, N))
 uej = lambdify((x, y), ue)(*xj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/kdv1D_rk4.py
+++ b/examples/kdv1D_rk4.py
@@ -68,7 +68,7 @@ if "PYTEST" in os.environ:
     uhat_T = states[-1]
     u_num = V.backward(uhat_T).real
     assert jnp.isfinite(u_num).all()
-    sys.exit(1)
+    sys.exit(0)
 
 states_phys = jnp.array([V.backward(uhat).real for uhat in states])
 

--- a/examples/nls1D_etdrk4.py
+++ b/examples/nls1D_etdrk4.py
@@ -115,7 +115,7 @@ if "PYTEST" in os.environ:
     assert jnp.isfinite(psi_states).all()
     assert density_change > 0.1, density_change
     assert mass_drift < 1e-3, mass_drift
-    sys.exit(1)
+    sys.exit(0)
 
 gif_path = Path(
     os.environ.get("NLS_GIF_PATH", Path(__file__).with_name("nls1d_etdrk4.gif"))

--- a/examples/notebooks/annulus.py
+++ b/examples/notebooks/annulus.py
@@ -330,7 +330,7 @@ def _(mo):
 @app.cell
 def _(P, plt, uh):
     xc, yc = P.cartesian_mesh(kind="uniform", N=(100, 100))
-    uj = P.backward(uh, kind="uniform", N=(100, 100))
+    uj = P.evaluate_mesh(uh, kind="uniform", N=(100, 100))
     fig = plt.figure(figsize=(8, 6))
     ax = fig.gca()
     ax.contourf(xc, yc, uj.real, 50)

--- a/examples/notebooks/poisson2D.py
+++ b/examples/notebooks/poisson2D.py
@@ -135,7 +135,7 @@ def _():
         F = inner(2 * v)
         h = A.solve(F, method="lu")
         xj = T.mesh(kind="uniform", N=(50, 50), broadcast=False)
-        plt.contourf(xj[0], xj[1], T.backward(h, kind="uniform", N=(50, 50)))
+        plt.contourf(xj[0], xj[1], T.evaluate_mesh(h, kind="uniform", N=(50, 50)))
         plt.colorbar()
         plt.show()
         return JAXFunction(h, T, name="h")
@@ -193,8 +193,7 @@ def _(mo):
 
 @app.cell
 def _(h):
-    xj = h.functionspace.mesh()
-    hj = h.evaluate_mesh(xj)
+    hj = h.evaluate_mesh(kind="quadrature")
     print(hj.shape)
     return (hj,)
 

--- a/examples/poisson1D.py
+++ b/examples/poisson1D.py
@@ -41,7 +41,7 @@ uej = lambdify(x, ue)(xj)
 error = jnp.linalg.norm(uj - uej)
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 plt.plot(xj, uej, "r")

--- a/examples/poisson1D_curv.py
+++ b/examples/poisson1D_curv.py
@@ -58,7 +58,7 @@ uq = lambdify(t, ue)(xj)
 error = np.linalg.norm(uj - uq)
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print(f"poisson1D_curv l2 error = {error:2.6e}")
 

--- a/examples/poisson1D_periodic.py
+++ b/examples/poisson1D_periodic.py
@@ -32,7 +32,7 @@ uej = lambdify(x, ue)(xj)
 error = jnp.linalg.norm(uj - uej)
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 plt.plot(xj, uej.real, "r")

--- a/examples/poisson1D_spikan.py
+++ b/examples/poisson1D_spikan.py
@@ -6,6 +6,7 @@ import time
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import sympy as sp
+from flax import nnx
 
 from jaxfun.operators import Div, Grad
 from jaxfun.pinns import FlaxFunction, Loss, Trainer
@@ -18,7 +19,7 @@ from jaxfun.utils.common import Domain, ulp
 domain = Domain(-jnp.pi, jnp.pi)
 V = sPIKANSpace(4, [8], dims=1, rank=0, name="V", domains=[domain])
 # V = KANMLPSpace(4, [16], dims=1, rank=0, name="V", domains=[domain])
-w = FlaxFunction(V, name="w")
+w = FlaxFunction(V, name="w", rngs=nnx.Rngs(101))
 
 i = sp.symbols("i", integer=True)
 x = V.system.x
@@ -47,7 +48,7 @@ print(f"L-BFGS time {time.time() - t1:.1f}s")
 error = jnp.sqrt(loss_fn(w.module))
 if "PYTEST" in os.environ:
     assert error < 1e-1, error
-    sys.exit(1)
+    sys.exit(0)
 
 print(f"L2 Error {error:.2e} ({error / ulp(1):.1f} ulp)")
 xj = jnp.linspace(float(domain.lower), float(domain.upper), 1000)

--- a/examples/poisson2D.py
+++ b/examples/poisson2D.py
@@ -33,14 +33,14 @@ A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
 uh = A.solve(b, method="lu")
 
 N = 100
-uj = T.backward(uh, kind="uniform", N=(N, N))
+uj = T.evaluate_mesh(uh, kind="uniform", N=(N, N))
 xj = T.mesh(kind="uniform", N=(N, N), broadcast=True)
 uej = lambdify((x, y), ue)(*xj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/poisson2D_curv.py
+++ b/examples/poisson2D_curv.py
@@ -42,13 +42,13 @@ uh = A.solve(b)
 
 rj, tj = T.mesh(kind="uniform", N=(100, 100))
 xc, yc = T.cartesian_mesh(kind="uniform", N=(100, 100))
-uj = T.backward(uh, kind="uniform", N=(100, 100))
+uj = T.evaluate_mesh(uh, kind="uniform", N=(100, 100))
 uej = lambdify((r, theta), ue)(rj, tj)
 
 error = jnp.linalg.norm(uj - uej) / 100
 if "PYTEST" in os.environ:
     assert error < ulp(10000), f"Error = {error} exceeds tolerance {ulp(1000)}"
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/poisson2D_lstsq.py
+++ b/examples/poisson2D_lstsq.py
@@ -62,7 +62,7 @@ print("Error", error)
 
 if "PYTEST" in os.environ:
     assert error < ulp(1000000), (error, ulp(1000000))
-    sys.exit(1)
+    sys.exit(0)
 
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(10, 5))

--- a/examples/poisson2D_parabolic.py
+++ b/examples/poisson2D_parabolic.py
@@ -47,13 +47,13 @@ un = A.solve(b)
 N = 100
 rj, tj = T.mesh(kind="uniform", N=(N, N))
 xc, yc = T.cartesian_mesh(kind="uniform", N=(N, N))
-uj = T.backward(un, kind="uniform", N=(N, N))
+uj = T.evaluate_mesh(un, kind="uniform", N=(N, N))
 uej = lambdify((tau, sigma), ue)(rj, tj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(10000), f"Error {error} exceeds tolerance {ulp(10000)}"
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/poisson2D_parametric.py
+++ b/examples/poisson2D_parametric.py
@@ -69,13 +69,13 @@ uh = A.solve(b)
 N = 100
 xij, etaj = T.mesh(kind="uniform", N=(N, N))
 xc, yc = T.cartesian_mesh(kind="uniform", N=(N, N))
-uj = T.backward(uh, kind="uniform", N=(N, N))
+uj = T.evaluate_mesh(uh, kind="uniform", N=(N, N))
 uej = lambdify((xi, eta), ue)(xij, etaj)
 
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(1000)
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/poisson2D_periodic.py
+++ b/examples/poisson2D_periodic.py
@@ -43,7 +43,7 @@ uej = lambdify((x, y), ue)(*xj)
 error = jnp.linalg.norm(uj - uej) / N
 if "PYTEST" in os.environ:
     assert error < ulp(100), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/poisson3D.py
+++ b/examples/poisson3D.py
@@ -27,7 +27,7 @@ A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True)
 
 uh = A.solve(b, method="lu")
 
-uj = T.backward(uh, kind="uniform", N=(20, 20, 20))
+uj = T.evaluate_mesh(uh, kind="uniform", N=(20, 20, 20))
 xj = T.mesh(kind="uniform", N=(20, 20, 20))
 uej = lambdify((x, y, z), ue)(*xj)
 error = jnp.linalg.norm(uj - uej) / jnp.sqrt(T.dim)

--- a/examples/sphere_helmholtz.py
+++ b/examples/sphere_helmholtz.py
@@ -64,7 +64,7 @@ uej = lambdify((theta, phi), ue)(rj, tj)
 error = jnp.linalg.norm(uj - uej) / 100
 if "PYTEST" in os.environ:
     assert error < ulp(1000), error
-    sys.exit(1)
+    sys.exit(0)
 
 print("Error =", error)
 

--- a/examples/zk2D_rk4.py
+++ b/examples/zk2D_rk4.py
@@ -81,7 +81,7 @@ if "PYTEST" in os.environ:
     uT_phys = V.backward(states[-1]).real
     assert jnp.isfinite(uT_phys).all()
     assert float(jnp.linalg.norm(uT_phys - u0_phys)) > 1e-8
-    sys.exit(1)
+    sys.exit(0)
 
 states_phys = backward_saved_states(states)
 x_plot, y_plot = V.mesh(broadcast=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 markers = [ "slow: marks tests as slow (select with '-m slow')" ]
-addopts = [ "-m", "not slow", "-n", "2" ]
+addopts = [ "-m", "not slow", "-n", "logical" ]
 filterwarnings = [
   "ignore::DeprecationWarning:flax",
 ]

--- a/src/jaxfun/galerkin/Chebyshev.py
+++ b/src/jaxfun/galerkin/Chebyshev.py
@@ -9,7 +9,7 @@ from sympy import Expr, Symbol
 from jaxfun.coordinates import CoordSys
 from jaxfun.galerkin.composite import Composite, PGComposite
 from jaxfun.la import DiaMatrix, Matrix, diags
-from jaxfun.typing import MeshKind, TestSpaceKind
+from jaxfun.typing import TestSpaceKind
 from jaxfun.utils.common import Domain, jit_vmap
 
 from .Jacobi import Jacobi
@@ -134,7 +134,7 @@ class Chebyshev(Jacobi):
 
         Args:
             N: Number of quadrature points (defaults self.num_quad_points
-               if 0).
+               if None).
 
         Returns:
             Tuple (x, w) of nodes and weights.
@@ -198,10 +198,8 @@ class Chebyshev(Jacobi):
 
         return jnp.concatenate((jnp.expand_dims(x0, axis=0), xs))
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Return Chebyshev series evaluated at quadrature points.
 
         Args:
@@ -211,9 +209,6 @@ class Chebyshev(Jacobi):
             Reversed coefficient array.
         """
         n: int = self.num_quad_points if N is None else N
-
-        if MeshKind(kind) is not MeshKind.QUADRATURE:
-            return super().backward(c, kind=kind, N=n)  # Does not require padding of c
 
         if n > len(c):
             c = jnp.pad(c, (0, n - len(c)))

--- a/src/jaxfun/galerkin/ChebyshevU.py
+++ b/src/jaxfun/galerkin/ChebyshevU.py
@@ -7,7 +7,6 @@ from sympy import Expr, Symbol
 from jaxfun.coordinates import CoordSys
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
 from jaxfun.la import DiaMatrix, Matrix, diags
-from jaxfun.typing import MeshKind
 from jaxfun.utils.common import Domain, dst, jit_vmap
 
 from .Jacobi import Jacobi
@@ -92,7 +91,7 @@ class ChebyshevU(Jacobi):
 
         Args:
             N: Number of quadrature points (defaults self.num_quad_points
-               if 0).
+               if None).
 
         Returns:
             Tuple (x, w) of nodes and weights.
@@ -159,10 +158,8 @@ class ChebyshevU(Jacobi):
     def norm_squared(self) -> Array:
         return jnp.full(self.N, jnp.pi / 2)
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Return Chebyshev series U_k evaluated at quadrature points.
 
         Args:
@@ -172,9 +169,6 @@ class ChebyshevU(Jacobi):
             Reversed coefficient array.
         """
         n: int = self.num_quad_points if N is None else N
-
-        if MeshKind(kind) is not MeshKind.QUADRATURE:
-            return super().backward(c, kind=kind, N=n)  # Does not require padding of c
 
         if n > len(c):
             c = jnp.pad(c, (0, n - len(c)))

--- a/src/jaxfun/galerkin/Fourier.py
+++ b/src/jaxfun/galerkin/Fourier.py
@@ -114,15 +114,12 @@ class Fourier(OrthogonalSpace):
         z = (1j * v) ** k * y
         return z
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Inverse FFT (possible padding) to physical space.
 
         Args:
             c: Coefficient array.
-            kind: Integration strategy (unused placeholder).
             N: Transform length. If N > len(c), pads coefficients with zeros in the
                 middle (high wavenumbers).
 
@@ -228,8 +225,8 @@ class Fourier(OrthogonalSpace):
         """
         # Both quadrature and uniform meshes are equispaced for Fourier, so ignore kind.
         a, b = self.domain
-        M = N if N is not None else self.num_quad_points
-        return jnp.linspace(float(a), float(b), M, endpoint=False)
+        N = self.num_quad_points if N is None else N
+        return jnp.linspace(float(a), float(b), N, endpoint=False)
 
     def _matrices(
         self, i: int, trial: tuple[OrthogonalSpace, int], q: int = 0

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -774,12 +774,11 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         assert isinstance(
             functionspace, TensorProductSpace | VectorTensorProductSpace | DirectSumTPS
         )
-        z = functionspace.evaluate(x, self.array, True)
+        z = functionspace.evaluate(x, self.array)
         if functionspace.rank == 0:
             return jnp.expand_dims(z, -1)
         return z
 
-    @jax.jit(static_argnums=(0, 1, 2))
     def evaluate_mesh(
         self, kind: MeshKind | str = MeshKind.QUADRATURE, N: Padding = None
     ) -> Array:

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -782,7 +782,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
     def evaluate_mesh(
         self, kind: MeshKind | str = MeshKind.QUADRATURE, N: Padding = None
     ) -> Array:
-        """Evaluate the JAXFunction at given points x in the physical domain.
+        """Evaluate the JAXFunction at tensor mesh in the physical domain.
 
         Args:
             kind: Mesh type (quadrature, uniform).

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -692,10 +692,9 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
 
     def backward(
         self,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: Padding = None,
     ) -> Array:
-        return self.functionspace.backward(self.array, kind=kind, N=N)  # ty: ignore[invalid-argument-type]
+        return self.functionspace.backward(self.array, N=N)  # ty: ignore[invalid-argument-type]
 
     def doit(self, **hints: Any) -> Expr | AppliedUndef:
         hints["linear"] = hints.get("linear", False)
@@ -780,21 +779,17 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
             return jnp.expand_dims(z, -1)
         return z
 
-    @jax.jit(static_argnums=0)
-    def evaluate_mesh(self, x: Array | list[Array]) -> Array:
+    @jax.jit(static_argnums=(0, 1, 2))
+    def evaluate_mesh(
+        self, kind: MeshKind | str = MeshKind.QUADRATURE, N: Padding = None
+    ) -> Array:
         """Evaluate the JAXFunction at given points x in the physical domain.
 
         Args:
-            x: Cartesian product coordinates. For example, for a 2D tensor product
-            space, x should be a list of two arrays [x1, x2], where x1 and x2 are 1D
-            arrays of coordinates in each dimension. Such a mesh is formed by calling
-            self.functionspace.mesh().
+            kind: Mesh type (quadrature, uniform).
+            N: Optional padding for the number of points in each dimension.
         """
-        if isinstance(self.functionspace, OrthogonalSpace | DirectSum):
-            assert isinstance(x, Array)
-            return self.functionspace.evaluate(x, self.array)
-
-        return self.functionspace.evaluate_mesh(x, self.array, True)
+        return self.functionspace.evaluate_mesh(self.array, kind=kind, N=N)  # ty:ignore[invalid-argument-type]
 
 
 def evaluate_jaxfunction_expr_quad(

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -174,23 +174,20 @@ class Composite(OrthogonalSpace):
         """Evaluate constrained expansion at X with composite coeffs c."""
         return self.orthogonal._evaluate(X, self.to_orthogonal(c))
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Inverse transform (physical -> coefficients) via underlying basis."""
-        return self.orthogonal.backward(self.to_orthogonal(c), kind, N)
+        return self.orthogonal.backward(self.to_orthogonal(c), N)
 
-    @jax.jit(static_argnums=(0, 2, 3, 4))
+    @jax.jit(static_argnums=(0, 2, 3))
     def backward_primitive(
         self,
         c: Array,
         k: int = 0,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ) -> Array:
         """Inverse transform (physical -> coefficients) via underlying basis."""
-        return self.orthogonal.backward_primitive(self.to_orthogonal(c), k, kind, N)
+        return self.orthogonal.backward_primitive(self.to_orthogonal(c), k, N)
 
     @jax.jit(static_argnums=(0, 2))
     def evaluate_basis_derivative(self, X: Array, k: int = 0) -> Array:
@@ -565,23 +562,20 @@ class DirectSum:
         """Evaluate direct-sum expansion at points x."""
         return self.orthogonal.evaluate(x, self.to_orthogonal(c))
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Return backward transform."""
-        return self.orthogonal.backward(self.to_orthogonal(c), kind, N)
+        return self.orthogonal.backward(self.to_orthogonal(c), N)
 
-    @jax.jit(static_argnums=(0, 2, 3, 4))
+    @jax.jit(static_argnums=(0, 2, 3))
     def backward_primitive(
         self,
         c: Array,
         k: int = 0,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ) -> Array:
         """Return backward transform for k-th derivative."""
-        return self.orthogonal.backward_primitive(self.to_orthogonal(c), k, kind, N)
+        return self.orthogonal.backward_primitive(self.to_orthogonal(c), k, N)
 
     @jax.jit(static_argnums=0)
     def forward(self, uj: Array) -> Array:
@@ -592,12 +586,6 @@ class DirectSum:
     def scalar_product(self, uj: Array) -> Array:
         """Return scalar product <u, φ_i> for direct-sum basis."""
         return self[0].scalar_product(uj)  # No BC part in test functions
-
-    @jax.jit(static_argnums=(0, 3))
-    def evaluate_derivative(self, x: Array, c: Array, k: int = 0) -> float:
-        """Evaluate k-th derivative at X (composite + boundary)."""
-        c0 = self.to_orthogonal(c)
-        return self.orthogonal.evaluate_derivative(x, c0, k)
 
     def get_homogeneous(self) -> Composite:
         """Return homogeneous Composite part of the direct sum."""

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -134,24 +134,55 @@ class OrthogonalSpace(BaseSpace):
 
     @abstractmethod
     def eval_basis_function(self, X: float | Array, i: int) -> Array:
-        """Evaluate single basis function psi_i at point X."""
+        """Evaluate single basis function psi_i at point X.
+
+        Args:
+            X: Evaluation point(s) in reference coordinates.
+            i: Basis index (0 <= i < N).
+
+        Returns:
+            Array of shape like X containing basis function values.
+        """
         pass
 
     @abstractmethod
     def eval_basis_functions(self, X: float | Array) -> Array:
-        """Evaluate all basis functions psi_0..psi_{N-1} at X."""
+        """Evaluate all basis functions psi_0..psi_{N-1} at X.
+
+        Args:
+            X: Evaluation point(s) in reference coordinates.
+
+        Returns:
+            Array of shape (len(X), N) containing basis function values.
+        """
         pass
 
     @jax.jit(static_argnums=(0, 2))
     def evaluate_basis_derivative(self, X: Array, k: int = 0) -> Array:
-        """Return k-th derivative Vandermonde."""
+        """Return k-th derivative Vandermonde.
+
+        Args:
+            X: 1D array of sample points (reference domain).
+            k: Derivative order (default 0 -> function values).
+        Returns:
+            Array shape (len(X), N) with k-th derivatives of basis functions.
+        """
         return jacn(self.eval_basis_functions, k)(X)
 
     @jax.jit(static_argnums=(0, 2, 3))
     def evaluate_mesh(
         self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
     ) -> Array:
-        """Implementation of backward transform."""
+        """Evaluate series at mesh points of given kind.
+
+        Args:
+            c: Coefficients of orthogonal series (length <= self.N).
+            kind: Type of mesh to use (QUADRATURE or UNIFORM).
+            N: Number of points. Must be >= self._num_quad_points.
+
+        Returns:
+            Array of shape (N,) containing series evaluation at mesh points.
+        """
         if kind is MeshKind.QUADRATURE:
             return self.backward(c, N)
         assert kind == MeshKind.UNIFORM, f"Unsupported mesh kind: {kind}"
@@ -173,7 +204,16 @@ class OrthogonalSpace(BaseSpace):
 
     @jax.jit(static_argnums=(0, 2))
     def backward(self, c: Array, N: int | None = None) -> Array:
-        """Implementation of backward transform."""
+        """Return series evaluation at quadrature points (possibly with padding).
+
+        Args:
+            c: Coefficients of orthogonal series (length <= self.N).
+            N: Number of points. Must be >= self._num_quad_points. Defaults to
+                self._num_quad_points.
+
+        Returns:
+            Array of shape (N,) containing series evaluation at quadrature points.
+        """
         xj = self.mesh(kind=MeshKind.QUADRATURE, N=N)
         return self.evaluate(xj, c)
 
@@ -184,12 +224,14 @@ class OrthogonalSpace(BaseSpace):
         k: int = 0,
         N: int | None = None,
     ) -> Array:
-        r"""Evaluate ``u(x_i)`` or ``\frac{d^k u}{dx^k}`` in physical space.
+        r"""Evaluate ``u(x_i)`` or ``\frac{d^k u(x_i)}{dx^k}`` in physical space
+        for quadrature points x_i.
 
         Args:
             c: Coefficients of orthogonal series (length <= self.N).
             k: Derivative order (default 0 -> function value).
-            N: Number of points. Must be >= self._num_quad_points.
+            N: Number of points. Must be >= self._num_quad_points, defaults to
+                self._num_quad_points.
         """
         df = float(self.domain_factor**k)
         return df * self.backward(self.derivative_coeffs(c, k), N=N)

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -120,22 +120,6 @@ class OrthogonalSpace(BaseSpace):
         assert len(c) <= self.N, f"Coefficient length {len(c)} exceeds N={self.N}"
         return self.eval_basis_functions(X)[..., : len(c)] @ c
 
-    @jax.jit(static_argnums=(0, 3))
-    def evaluate_derivative(self, x: Array, c: Array, k: int = 0) -> Array:
-        """Evaluate truncated series sum_k c_k psi_k(x).
-
-        Args:
-            x: Evaluation point(s) in real coordinates.
-            c: Coefficient vector ( <= self.N).
-            k: Derivative order (default 0 -> function value).
-        Returns:
-            Array of shape like x containing series evaluation.
-        """
-        assert len(c) <= self.N, f"Coefficient length {len(c)} exceeds N={self.N}"
-        X = self.map_reference_domain(x)
-        df = float(self.domain_factor**k)
-        return df * self.evaluate_basis_derivative(X, k)[..., : len(c)] @ c
-
     @jax.jit(static_argnums=0)
     def vandermonde(self, X: Array) -> Array:
         r"""Return pseudo-Vandermonde matrix V_{m,k}=psi_k(X_m).
@@ -163,6 +147,17 @@ class OrthogonalSpace(BaseSpace):
         """Return k-th derivative Vandermonde."""
         return jacn(self.eval_basis_functions, k)(X)
 
+    @jax.jit(static_argnums=(0, 2, 3))
+    def evaluate_mesh(
+        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
+    ) -> Array:
+        """Implementation of backward transform."""
+        if kind is MeshKind.QUADRATURE:
+            return self.backward(c, N)
+        assert kind == MeshKind.UNIFORM, f"Unsupported mesh kind: {kind}"
+        xj = self.mesh(kind=kind, N=N)
+        return self.evaluate(xj, c)
+
     @abstractmethod
     def derivative_coeffs(self, c: Array, k: int = 0) -> Array:
         """Return coefficients of k-th derivative series given c for original series.
@@ -176,20 +171,17 @@ class OrthogonalSpace(BaseSpace):
         """
         pass
 
-    @jax.jit(static_argnums=(0, 2, 3))
-    def backward(
-        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
-    ) -> Array:
+    @jax.jit(static_argnums=(0, 2))
+    def backward(self, c: Array, N: int | None = None) -> Array:
         """Implementation of backward transform."""
-        xj = self.mesh(kind=kind, N=N)
+        xj = self.mesh(kind=MeshKind.QUADRATURE, N=N)
         return self.evaluate(xj, c)
 
-    @jax.jit(static_argnums=(0, 2, 3, 4))
+    @jax.jit(static_argnums=(0, 2, 3))
     def backward_primitive(
         self,
         c: Array,
         k: int = 0,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ) -> Array:
         r"""Evaluate ``u(x_i)`` or ``\frac{d^k u}{dx^k}`` in physical space.
@@ -197,13 +189,10 @@ class OrthogonalSpace(BaseSpace):
         Args:
             c: Coefficients of orthogonal series (length <= self.N).
             k: Derivative order (default 0 -> function value).
-            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
-                MeshKind.UNIFORM).
             N: Number of points. Must be >= self._num_quad_points.
         """
-        N = self.num_quad_points if N is None else N
         df = float(self.domain_factor**k)
-        return df * self.backward(self.derivative_coeffs(c, k), kind=kind, N=N)
+        return df * self.backward(self.derivative_coeffs(c, k), N=N)
 
     def mass_matrix(self) -> DiaMatrix:
         """Return diagonal mass matrix (orthogonality) in sparse format."""
@@ -391,15 +380,15 @@ class OrthogonalSpace(BaseSpace):
                 MeshKind.UNIFORM).
             N: Number of points (defaults to self.num_quad_points).
         """
+        N = self.num_quad_points if N is None else N
         kind = MeshKind(kind)
         if kind is MeshKind.QUADRATURE:
             return self.map_true_domain(self.quad_points_and_weights(N)[0])
         a, b = self.domain
-        M = N if N is not None else self.num_quad_points
-        return jnp.linspace(float(a), float(b), M)
+        return jnp.linspace(float(a), float(b), N)
 
     def cartesian_mesh(
-        self, kind: MeshKind | str = MeshKind.QUADRATURE, N: int = 0
+        self, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
     ) -> tuple[Array, ...]:
         """Return physical Cartesian mesh (tuple) for current coordinate system."""
         rv = self.system._position_vector

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -183,9 +183,10 @@ class OrthogonalSpace(BaseSpace):
         Returns:
             Array of shape (N,) containing series evaluation at mesh points.
         """
+        kind = MeshKind(kind)
         if kind is MeshKind.QUADRATURE:
             return self.backward(c, N)
-        assert kind == MeshKind.UNIFORM, f"Unsupported mesh kind: {kind}"
+        assert kind is MeshKind.UNIFORM, f"Unsupported mesh kind: {kind}"
         xj = self.mesh(kind=kind, N=N)
         return self.evaluate(xj, c)
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -72,9 +72,7 @@ class TensorProductSpace:
         self._spmd_mesh = Mesh(jax.devices(), ("k",))
         # Sharding of arrays in spectral coefficient space.
         self._spectral_sharding: NamedSharding | None = (
-            None
-            if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P("k", None))
+            None if len(jax.devices()) == 1 else NamedSharding(self._spmd_mesh, P("k"))
         )
         # Sharding of arrays in physical space.
         self._physical_sharding: NamedSharding | None = (

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -146,7 +146,7 @@ class TensorProductSpace:
         Args:
             kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
             MeshKind.UNIFORM).
-            N: Optional per-axis counts (defaults each to space.N).
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
             broadcast: If True broadcast each axis array to nd-grid shape.
 
         Returns:
@@ -214,7 +214,6 @@ class TensorProductSpace:
             u = space.map_expr_reference_domain(u)
         return u
 
-    @jax.jit(static_argnums=(0, 2, 3))
     def evaluate_mesh(
         self,
         c: Array,
@@ -232,11 +231,12 @@ class TensorProductSpace:
         Returns:
             Array of evaluated field values with broadcast shape.
         """
+        kind = MeshKind(kind)
         N = tuple(
             self.basespaces[ax].num_quad_points if N is None else N[ax]
             for ax in range(len(self))
         )
-        cache_key = ("evaluate_mesh", N)
+        cache_key = ("evaluate_mesh", kind, N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
                 self._build_local_apply_fn(
@@ -247,7 +247,7 @@ class TensorProductSpace:
             )
         fns = self._spmd_local_fn_cache[cache_key]
         if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd(c, fns, self._spectral_sharding)
+            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
         for fn in fns:
             c = fn(c)
         return c

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -309,12 +309,14 @@ class TensorProductSpace:
                     jnp.einsum(einsum_str, C0_loc, *C_rest_loc, c_loc), "k"
                 )
 
-            return shard_map(
-                _local_eval,
-                mesh=self._spectral_sharding.mesh,
-                in_specs=(c_spec, P(None, "k")) + tuple(P() for _ in range(1, dim)),
-                out_specs=P(),
-                check_vma=False,
+            return jax.jit(
+                shard_map(
+                    _local_eval,
+                    mesh=self._spectral_sharding.mesh,
+                    in_specs=(c_spec, P(None, "k")) + tuple(P() for _ in range(1, dim)),
+                    out_specs=P(),
+                    check_vma=False,
+                )
             )(c, C0_sharded, *C[1:])
 
         return self._evaluate_single_device(x, c)
@@ -675,13 +677,13 @@ class VectorTensorProductSpace:
         self._spectral_sharding: NamedSharding | None = (
             None
             if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P(None, "k", None))
+            else NamedSharding(self._spmd_mesh, P(None, "k"))
         )
         # Sharding of arrays in physical space.
         self._physical_sharding: NamedSharding | None = (
             None
             if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P(None, None, "k", None))
+            else NamedSharding(self._spmd_mesh, P(None, None, "k"))
         )
 
     def __len__(self) -> int:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -459,9 +459,12 @@ class TensorProductSpace:
             ]
             unsharded = [ax for ax in range(dim) if ax not in sharded]
 
-            new_spec: list = [None] * dim
-            for s_ax, u_ax in zip(sharded, unsharded):
-                new_spec[u_ax] = spec[s_ax]
+            transposed = (
+                self._physical_sharding
+                if sharding is self._spectral_sharding
+                else self._spectral_sharding
+            )
+            assert isinstance(transposed, NamedSharding)
 
             def _kernel(c_loc: Array) -> Array:
                 # Phase 1 — unsharded axes: fully local, no communication.
@@ -485,7 +488,7 @@ class TensorProductSpace:
                     _kernel,
                     mesh=sharding.mesh,
                     in_specs=(sharding.spec,),
-                    out_specs=P(*new_spec),
+                    out_specs=transposed.spec,
                     check_vma=False,
                 )
             )

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -295,29 +295,37 @@ class TensorProductSpace:
                 for i in range(dim)
             ]
 
-            dc = "abcdef"[:dim]
-            einsum_str = ",".join(f"j{ch}" for ch in dc) + f",{dc}->j"
+            cache_key = ("evaluate_spmd",)
+            if cache_key not in self._spmd_local_fn_cache:
+                dc = "abcdef"[:dim]
+                einsum_str = ",".join(f"j{ch}" for ch in dc) + f",{dc}->j"
 
-            # Shard C[0] along axis 1 (N_0 dim) to match c's axis-0 sharding.
-            # C[1], ..., C[dim-1] are replicated so every device sees them in full.
-            C0_sharded = jax.device_put(C[0], self._physical_sharding)
+                c_spec = self._spectral_sharding.spec
+                mesh = self._spectral_sharding.mesh
+                physical_sharding = self._physical_sharding
 
-            c_spec = self._spectral_sharding.spec
+                def _local_eval(c_loc, C0_loc, *C_rest_loc):
+                    return jax.lax.psum(
+                        jnp.einsum(einsum_str, C0_loc, *C_rest_loc, c_loc), "k"
+                    )
 
-            def _local_eval(c_loc, C0_loc, *C_rest_loc):
-                return jax.lax.psum(
-                    jnp.einsum(einsum_str, C0_loc, *C_rest_loc, c_loc), "k"
-                )
+                def _jitted(c, C0, *C_rest):
+                    # Scatter C0 to P(None, "k") inside JIT so XLA can fuse the
+                    # scatter collective with the shard_map kernel rather than
+                    # performing an eager host-memory round-trip.
+                    C0_sharded = jax.device_put(C0, physical_sharding)
+                    return shard_map(
+                        _local_eval,
+                        mesh=mesh,
+                        in_specs=(c_spec, P(None, "k"))
+                        + tuple(P() for _ in range(1, dim)),
+                        out_specs=P(),
+                        check_vma=False,
+                    )(c, C0_sharded, *C_rest)
 
-            return jax.jit(
-                shard_map(
-                    _local_eval,
-                    mesh=self._spectral_sharding.mesh,
-                    in_specs=(c_spec, P(None, "k")) + tuple(P() for _ in range(1, dim)),
-                    out_specs=P(),
-                    check_vma=False,
-                )
-            )(c, C0_sharded, *C[1:])
+                self._spmd_local_fn_cache[cache_key] = jax.jit(_jitted)
+
+            return self._spmd_local_fn_cache[cache_key](c, C[0], *C[1:])
 
         return self._evaluate_single_device(x, c)
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -214,7 +214,6 @@ class TensorProductSpace:
             u = space.map_expr_reference_domain(u)
         return u
 
-    # Cannot jit_vmap since tensor product mesh.
     @jax.jit(static_argnums=(0, 2, 3))
     def evaluate_mesh(
         self,
@@ -222,7 +221,7 @@ class TensorProductSpace:
         kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate expansion on tensor-product mesh arrays.
+        """Evaluate expansion on tensor-product mesh.
 
         Args:
             c: Coefficient array
@@ -253,8 +252,8 @@ class TensorProductSpace:
             c = fn(c)
         return c
 
-    @jit_vmap(in_axes=(0, None, None), static_argnums=(0, 3), ndim=1)
-    def _evaluate_single_device(self, x: Array, c: Array, use_einsum: bool) -> Array:
+    @jit_vmap(in_axes=(0, None), static_argnums=(0,), ndim=1)
+    def _evaluate_single_device(self, x: Array, c: Array) -> Array:
         """Evaluate expansion at scattered points — single-device path."""
         dim = len(self)
         T = self.basespaces
@@ -262,18 +261,10 @@ class TensorProductSpace:
             T[i].eval_basis_functions(T[i].map_reference_domain(x[i]))
             for i in range(dim)
         ]
-        if not use_einsum:
-            if dim == 2:
-                c = C[0] @ c @ C[1]
-            else:
-                for Ci in C:
-                    c = jnp.tensordot(Ci, c, axes=[[0], [0]])
-        else:
-            path = "i,j,ij" if dim == 2 else "i,j,k,ijk"
-            c = jnp.einsum(path, *C, c)
-        return c
+        path = "i,j,ij" if dim == 2 else "i,j,k,ijk"
+        return jnp.einsum(path, *C, c)
 
-    def evaluate(self, x: Array, c: Array, use_einsum: bool = False) -> Array:
+    def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate expansion at scattered points.
 
         For SPMD (multi-device): c carries spectral sharding P("k", None).
@@ -290,8 +281,6 @@ class TensorProductSpace:
             x: Stacked coordinate array, shape (n_pts, d).
             c: Coefficient tensor; expected to carry spectral sharding in the
                SPMD case.
-            use_einsum: Passed through to the single-device path (unused in
-               the SPMD path, which is using einsum).
 
         Returns:
             Scalar or (n_pts,) array of evaluated values; replicated in SPMD.
@@ -308,9 +297,6 @@ class TensorProductSpace:
                 for i in range(dim)
             ]
 
-            # Build einsum string for arbitrary dim:
-            #   C[0]:"ja", C[1]:"jb", ..., c_loc:"ab..." → "j"
-            # Contracts all spectral axes; j is the evaluation-point axis.
             dc = "abcdef"[:dim]
             einsum_str = ",".join(f"j{ch}" for ch in dc) + f",{dc}->j"
 
@@ -332,7 +318,8 @@ class TensorProductSpace:
                 out_specs=P(),
                 check_vma=False,
             )(c, C0_sharded, *C[1:])
-        return self._evaluate_single_device(x, c, use_einsum)
+
+        return self._evaluate_single_device(x, c)
 
     def get_orthogonal(self) -> TensorProductSpace:
         """Return underlying orthogonal basis instance."""
@@ -735,14 +722,13 @@ class VectorTensorProductSpace:
         """Return raw modal shape (N0, N1, ...)."""
         return (self.dims,) + self.tensorspaces[0].shape()
 
-    @jit_vmap(in_axes=(0, None, None), static_argnums=(0, 3), ndim=1)
-    def evaluate(self, x: Array, c: Array, use_einsum: bool) -> Array:
+    @jit_vmap(in_axes=(0, None), static_argnums=(0,), ndim=1)
+    def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate vector expansion at scattered points.
 
         Args:
             x: Array of per-axis coordinates stacked (N, d).
             c: Coefficient array shaped (dims, N0, N1, ...).
-            use_einsum: Whether to use einsum contraction.
 
         Returns:
             Evaluated values with shape determined by leading dims of x.
@@ -750,7 +736,7 @@ class VectorTensorProductSpace:
         vals = []
         for i, space in enumerate(self.tensorspaces):
             ci = c[i]
-            vi = space.evaluate(x, ci, use_einsum)
+            vi = space.evaluate(x, ci)
             vals.append(vi)
         return jnp.array(vals)
 
@@ -1067,9 +1053,9 @@ class DirectSumTPS(TensorProductSpace):
             "Scalar product requires homogeneous test space (call on get_homogeneous())"
         )
 
-    def evaluate(self, x: Array, c: Array, use_einsum: bool = False) -> Array:
+    def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate direct sum tensor product expansion at scattered points."""
-        return self.orthogonal.evaluate(x, self.to_orthogonal(c), use_einsum)
+        return self.orthogonal.evaluate(x, self.to_orthogonal(c))
 
     def evaluate_mesh(
         self,

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -480,12 +480,14 @@ class TensorProductSpace:
                     c_loc = fns[ax](c_loc)
                 return c_loc
 
-            self._spmd_local_fn_cache[cache_key] = shard_map(
-                _kernel,
-                mesh=sharding.mesh,
-                in_specs=(sharding.spec,),
-                out_specs=P(*new_spec),
-                check_vma=False,
+            self._spmd_local_fn_cache[cache_key] = jax.jit(
+                shard_map(
+                    _kernel,
+                    mesh=sharding.mesh,
+                    in_specs=(sharding.spec,),
+                    out_specs=P(*new_spec),
+                    check_vma=False,
+                )
             )
 
         return self._spmd_local_fn_cache[cache_key](c)
@@ -515,7 +517,7 @@ class TensorProductSpace:
             )
         fns = self._spmd_local_fn_cache[cache_key]
         if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd(c, fns, self._spectral_sharding)
+            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
         for fn in fns:
             c = fn(c)
         return c
@@ -534,7 +536,7 @@ class TensorProductSpace:
             )
         fns = self._spmd_local_fn_cache[cache_key]
         if self._physical_sharding is not None and len(u.devices()) > 1:
-            return self._apply_separable_spmd(u, fns, self._physical_sharding)
+            return self._apply_separable_spmd_shard_map(u, fns, self._physical_sharding)
         for fn in fns:
             u = fn(u)
         return u
@@ -549,7 +551,7 @@ class TensorProductSpace:
             )
         fns = self._spmd_local_fn_cache[cache_key]
         if self._physical_sharding is not None and len(u.devices()) > 1:
-            return self._apply_separable_spmd(u, fns, self._physical_sharding)
+            return self._apply_separable_spmd_shard_map(u, fns, self._physical_sharding)
         for fn in fns:
             u = fn(u)
         return u
@@ -580,7 +582,7 @@ class TensorProductSpace:
             )
         fns = self._spmd_local_fn_cache[cache_key]
         if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd(c, fns, self._spectral_sharding)
+            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
         for fn in fns:
             c = fn(c)
         return c

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -265,31 +265,17 @@ class TensorProductSpace:
     def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate expansion at scattered points.
 
-        For SPMD (multi-device): c carries spectral sharding P("k", None).
-        The per-axis evaluation matrices C[i] are computed once on the calling
-        process (fully replicated, since x may be as small as one point).
-        Each local addressable shard of c contributes a partial contraction
-        which is summed locally and then all-reduced across MPI processes so
-        that every process holds the same replicated result.
-
-        For single-device: x is a stacked (n_pts, d) array evaluated via the
-        jit-vmapped single-device path.
-
         Args:
             x: Stacked coordinate array, shape (n_pts, d).
-            c: Coefficient tensor; expected to carry spectral sharding in the
-               SPMD case.
+            c: Coefficient tensor
 
         Returns:
-            Scalar or (n_pts,) array of evaluated values; replicated in SPMD.
+            Scalar or (n_pts,) array of evaluated values.
         """
         if self._spectral_sharding is not None and len(c.devices()) > 1:
             dim = len(self)
             T = self.basespaces
 
-            # Per-axis evaluation matrices — fully replicated.
-            # eval_basis_functions is @jit_vmap'd: 1-D input (n_pts,) → (n_pts, N).
-            # x has shape (n_pts, dim); x[:, i] gives axis-i coordinates.
             C = [
                 T[i].eval_basis_functions(T[i].map_reference_domain(x[:, i]))
                 for i in range(dim)
@@ -310,9 +296,6 @@ class TensorProductSpace:
                     )
 
                 def _jitted(c, C0, *C_rest):
-                    # Scatter C0 to P(None, "k") inside JIT so XLA can fuse the
-                    # scatter collective with the shard_map kernel rather than
-                    # performing an eager host-memory round-trip.
                     C0_sharded = jax.device_put(C0, physical_sharding)
                     return shard_map(
                         _local_eval,
@@ -335,6 +318,15 @@ class TensorProductSpace:
         return TensorProductSpace(
             orthogonal_spaces, system=self.system, name=self.name + "o"
         )
+
+    def get_transposed_sharding(self, sharding: NamedSharding) -> NamedSharding:
+        """Return the sharding with unsharded and sharded axes transposed."""
+        if sharding is self._spectral_sharding:
+            return self._physical_sharding
+        elif sharding is self._physical_sharding:
+            return self._spectral_sharding
+        else:
+            raise ValueError("Provided sharding does not match spectral or physical.")
 
     def _build_local_apply_fn(self, ax: int, fn: ArrayFun) -> ArrayFun:
         """Return a ``jax.jit(jax.vmap(...))`` that applies *fn* along *ax*.
@@ -406,12 +398,7 @@ class TensorProductSpace:
 
         # All-to-all: transpose the sharding (one collective, O(N^d/P) per device).
         # The two pre-built shardings are each other's transpose by construction.
-        transposed = (
-            self._physical_sharding
-            if sharding is self._spectral_sharding
-            else self._spectral_sharding
-        )
-        assert isinstance(transposed, NamedSharding)
+        transposed = self.get_transposed_sharding(sharding)
 
         c = jax.device_put(c, transposed)
 
@@ -467,12 +454,7 @@ class TensorProductSpace:
             ]
             unsharded = [ax for ax in range(dim) if ax not in sharded]
 
-            transposed = (
-                self._physical_sharding
-                if sharding is self._spectral_sharding
-                else self._spectral_sharding
-            )
-            assert isinstance(transposed, NamedSharding)
+            transposed = self.get_transposed_sharding(sharding)
 
             def _kernel(c_loc: Array) -> Array:
                 # Phase 1 — unsharded axes: fully local, no communication.
@@ -601,25 +583,21 @@ class TensorProductSpace:
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped to underlying orthogonal basis."""
         dim = len(self)
+        if self._spectral_sharding is not None and len(c.devices()) > 1:
+            S = [s.S for s in self.basespaces]
+            cache_key = "to_orthogonal"
+            if cache_key not in self._spmd_local_fn_cache:
+                self._spmd_local_fn_cache[cache_key] = tuple(
+                    self._build_local_apply_fn(ax, S[ax].rmatvec) for ax in range(dim)
+                )
+            fns = self._spmd_local_fn_cache[cache_key]
+            result = self._apply_separable_spmd_shard_map(
+                c, fns, self._spectral_sharding
+            )
+            return jax.device_put(result, self._spectral_sharding)
         if dim == 2:
-            if self._spectral_sharding is not None and len(c.devices()) > 1:
-                S = [s.S for s in self.basespaces]
-                cache_key = "to_orthogonal"
-                if cache_key not in self._spmd_local_fn_cache:
-                    self._spmd_local_fn_cache[cache_key] = tuple(
-                        self._build_local_apply_fn(ax, S[ax].rmatvec)
-                        for ax in range(dim)
-                    )
-                fns = self._spmd_local_fn_cache[cache_key]
-                result = self._apply_separable_spmd(c, fns, self._spectral_sharding)
-                return jax.device_put(result, self._spectral_sharding)
             S = [s.S for s in self.basespaces]
             return S[0].T @ c @ S[1]
-
-        if self._spectral_sharding is not None:
-            raise NotImplementedError(
-                "to_orthogonal with SPMD sharding is not implemented yet for dim > 2"
-            )
         S = [s.S.todense() for s in self.basespaces]
         return jnp.einsum("is,jp,kl,ijk->spl", *S, c)
 
@@ -627,24 +605,18 @@ class TensorProductSpace:
         """Return coefficients c mapped from underlying orthogonal basis."""
         S = [s.get_inverse_stencil() for s in self.basespaces]
         dim = len(self)
+        if self._physical_sharding is not None and len(c.devices()) > 1:
+            cache_key = "from_orthogonal"
+            if cache_key not in self._spmd_local_fn_cache:
+                self._spmd_local_fn_cache[cache_key] = tuple(
+                    self._build_local_apply_fn(ax, lambda x, _S=S[ax]: jnp.dot(x, _S))
+                    for ax in range(dim)
+                )
+            fns = self._spmd_local_fn_cache[cache_key]
+            c = jax.device_put(c, self._physical_sharding)
+            return self._apply_separable_spmd_shard_map(c, fns, self._physical_sharding)
         if dim == 2:
-            if self._physical_sharding is not None and len(c.devices()) > 1:
-                cache_key = "from_orthogonal"
-                if cache_key not in self._spmd_local_fn_cache:
-                    self._spmd_local_fn_cache[cache_key] = tuple(
-                        self._build_local_apply_fn(
-                            ax, lambda x, _S=S[ax]: jnp.dot(x, _S)
-                        )
-                        for ax in range(dim)
-                    )
-                fns = self._spmd_local_fn_cache[cache_key]
-                c = jax.device_put(c, self._physical_sharding)
-                return self._apply_separable_spmd(c, fns, self._physical_sharding)
             return S[0].T @ c @ S[1]
-        if self._physical_sharding is not None:
-            raise NotImplementedError(
-                "from_orthogonal with SPMD sharding is not implemented yet for dim > 2"
-            )
         return jnp.einsum("is,jp,kl,ijk->spl", *S, c)
 
 
@@ -735,7 +707,6 @@ class VectorTensorProductSpace:
         """Return raw modal shape (N0, N1, ...)."""
         return (self.dims,) + self.tensorspaces[0].shape()
 
-    @jit_vmap(in_axes=(0, None), static_argnums=(0,), ndim=1)
     def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate vector expansion at scattered points.
 
@@ -809,6 +780,13 @@ class VectorTensorProductSpace:
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.to_orthogonal(c[i])
+            coeffs.append(ci)
+        return jnp.stack(coeffs)
+
+    def from_orthogonal(self, c: Array) -> Array:
+        coeffs = []
+        for i, space in enumerate(self.tensorspaces):
+            ci = space.from_orthogonal(c[i])
             coeffs.append(ci)
         return jnp.stack(coeffs)
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -138,7 +138,7 @@ class TensorProductSpace:
     def mesh(
         self,
         kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[int, ...] | None = None,
+        N: tuple[int | None, ...] | None = None,
         broadcast: bool = True,
     ) -> tuple[Array, ...]:
         """Return tensor mesh (as tuple of arrays) in true domain.
@@ -153,8 +153,10 @@ class TensorProductSpace:
             Tuple (X0, X1, ...) each either 1D or broadcasted.
         """
         mesh = []
-        if N is None:
-            N = self.shape()
+        N = tuple(
+            self.basespaces[ax].num_quad_points if N is None else N[ax]
+            for ax in range(len(self))
+        )
         for ax, space in enumerate(self.basespaces):
             X = space.mesh(kind, N[ax])
             mesh.append(self.broadcast_to_ndims(X, ax) if broadcast else X)
@@ -163,7 +165,7 @@ class TensorProductSpace:
     def flatmesh(
         self,
         kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[int, ...] | None = None,
+        N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Return flattened list of all coordinate tuples.
 
@@ -182,7 +184,7 @@ class TensorProductSpace:
     def cartesian_mesh(
         self,
         kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[int, ...] | None = None,
+        N: tuple[int | None, ...] | None = None,
     ) -> tuple[Array, ...]:
         """Return mapped Cartesian mesh (position vector evaluation)."""
         rv = self.system.position_vector(False)
@@ -213,62 +215,42 @@ class TensorProductSpace:
         return u
 
     # Cannot jit_vmap since tensor product mesh.
-    @jax.jit(static_argnums=(0, 3))
+    @jax.jit(static_argnums=(0, 2, 3))
     def evaluate_mesh(
-        self, x: list[Array], c: Array, use_einsum: bool = False
+        self,
+        c: Array,
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate expansion on provided tensor-product mesh arrays.
+        """Evaluate expansion on tensor-product mesh arrays.
 
         Args:
-            x: List of per-axis coordinate arrays (broadcasted or 1D).
-            c: Coefficient tensor shaped (N0, N1, ...).
-            use_einsum: If True use einsum path; else iterative vmaps.
+            c: Coefficient array
+            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
+                MeshKind.UNIFORM).
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
 
         Returns:
             Array of evaluated field values with broadcast shape.
         """
-        dim: int = len(self)
-        if dim == 2:
-            if not use_einsum:
-                for i, (xi, ax) in enumerate(zip(x, range(dim), strict=False)):
-                    axi: int = dim - 1 - ax
-                    c = jax.vmap(
-                        self.basespaces[i].evaluate, in_axes=(None, axi), out_axes=axi
-                    )(jnp.atleast_1d(xi.squeeze()), c)
-            else:
-                T0, T1 = self.basespaces
-                C0 = T0.eval_basis_functions(
-                    jnp.atleast_1d(T0.map_reference_domain(x[0]).squeeze())
+        N = tuple(
+            self.basespaces[ax].num_quad_points if N is None else N[ax]
+            for ax in range(len(self))
+        )
+        cache_key = ("evaluate_mesh", N)
+        if cache_key not in self._spmd_local_fn_cache:
+            self._spmd_local_fn_cache[cache_key] = tuple(
+                self._build_local_apply_fn(
+                    ax,
+                    partial(self.basespaces[ax].evaluate_mesh, kind=kind, N=N[ax]),
                 )
-                C1 = T1.eval_basis_functions(
-                    jnp.atleast_1d(T1.map_reference_domain(x[1]).squeeze())
-                )
-                return jnp.einsum("ij,jk,lk->il", C0, c, C1)
-        else:
-            if not use_einsum:
-                for i, (xi, ax) in enumerate(zip(x, range(dim), strict=False)):
-                    ax0, ax1 = set(range(dim)) - set((ax,))
-                    c = jax.vmap(
-                        jax.vmap(
-                            self.basespaces[i].evaluate,
-                            in_axes=(None, ax0),
-                            out_axes=ax0,
-                        ),
-                        in_axes=(None, ax1),
-                        out_axes=ax1,
-                    )(jnp.atleast_1d((xi).squeeze()), c)
-            else:
-                T0, T1, T2 = self.basespaces
-                C0 = T0.eval_basis_functions(
-                    jnp.atleast_1d(T0.map_reference_domain(x[0]).squeeze())
-                )
-                C1 = T1.eval_basis_functions(
-                    jnp.atleast_1d(T1.map_reference_domain(x[1]).squeeze())
-                )
-                C2 = T2.eval_basis_functions(
-                    jnp.atleast_1d(T2.map_reference_domain(x[2]).squeeze())
-                )
-                c = jnp.einsum("ik,jl,nm,klm->ijn", C0, C1, C2, c)
+                for ax in range(len(self))
+            )
+        fns = self._spmd_local_fn_cache[cache_key]
+        if self._spectral_sharding is not None and len(c.devices()) > 1:
+            return self._apply_separable_spmd(c, fns, self._spectral_sharding)
+        for fn in fns:
+            c = fn(c)
         return c
 
     @jit_vmap(in_axes=(0, None, None), static_argnums=(0, 3), ndim=1)
@@ -351,30 +333,6 @@ class TensorProductSpace:
                 check_vma=False,
             )(c, C0_sharded, *C[1:])
         return self._evaluate_single_device(x, c, use_einsum)
-
-    @jax.jit(static_argnums=(0, 3))
-    def evaluate_derivative(
-        self, x: list[Array], c: Array, k: tuple[int, ...]
-    ) -> Array:
-        """Evaluate expansion (with derivatives) on provided tensor-product mesh arrays.
-
-        Args:
-            x: List of per-axis coordinate arrays (broadcasted or 1D).
-            c: Coefficient tensor shaped (N0, N1, ...).
-            k: Derivative order for each axis.
-
-        Returns:
-            Array of evaluated field values with broadcast shape.
-        """
-        df = 1
-        for i, Ti in enumerate(self.basespaces):
-            Ci = Ti.evaluate_basis_derivative(
-                Ti.map_reference_domain(x[i]).squeeze(), k[i]
-            )
-            c = jnp.tensordot(Ci, c, axes=(1, i), precision=jax.lax.Precision.HIGHEST)
-            c = jnp.moveaxis(c, 0, i)
-            df = df * (float(Ti.domain_factor ** k[i]))
-        return c * df
 
     def get_orthogonal(self) -> TensorProductSpace:
         """Return underlying orthogonal basis instance."""
@@ -548,7 +506,6 @@ class TensorProductSpace:
     def backward(
         self,
         c: Array,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Backward transform.
@@ -556,16 +513,16 @@ class TensorProductSpace:
         In the SPMD case the separable transform runs outside JIT on each
         device's addressable shard, eliminating spurious all-gather ops.
         """
-        N_resolved = tuple(
+        N = tuple(
             self.basespaces[ax].num_quad_points if N is None else N[ax]
             for ax in range(len(self))
         )
-        cache_key = ("backward", kind, N_resolved)
+        cache_key = ("backward", N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
                 self._build_local_apply_fn(
                     ax,
-                    partial(self.basespaces[ax].backward, kind=kind, N=N_resolved[ax]),
+                    partial(self.basespaces[ax].backward, N=N[ax]),
                 )
                 for ax in range(len(self))
             )
@@ -614,15 +571,14 @@ class TensorProductSpace:
         self,
         c: Array,
         k: tuple[int, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Evaluate the field or mixed derivatives on a tensor-product mesh."""
-        N_resolved = tuple(
+        N = tuple(
             self.basespaces[ax].num_quad_points if N is None else N[ax]
             for ax in range(len(self))
         )
-        cache_key = ("backward_primitive", k, kind, N_resolved)
+        cache_key = ("backward_primitive", k, N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
                 self._build_local_apply_fn(
@@ -630,8 +586,7 @@ class TensorProductSpace:
                     partial(
                         self.basespaces[ax].backward_primitive,
                         k=k[ax],
-                        kind=kind,
-                        N=N_resolved[ax],
+                        N=N[ax],
                     ),
                 )
                 for ax in range(len(self))
@@ -723,7 +678,6 @@ class VectorTensorProductSpace:
         self.name = name
         self.tensorname = multiplication_sign.join([b.name for b in self.tensorspaces])
         self.mesh = self.tensorspaces[0].mesh
-        self.evaluate_mesh = self.tensorspaces[0].evaluate_mesh
         self.num_quad_points = self.tensorspaces[0].num_quad_points
         # Slab decomposition for vector spaces
         # First index is vector component, which is not sharded.
@@ -800,15 +754,18 @@ class VectorTensorProductSpace:
             vals.append(vi)
         return jnp.array(vals)
 
-    @jit_vmap(in_axes=(0, None, None), static_argnums=(0, 3), ndim=1)
-    def evaluate_derivative(self, x: Array, c: Array, k: tuple[int, ...]) -> Array:
-        """Evaluate vector expansion derivatives at scattered points."""
-        vals = []
+    def evaluate_mesh(
+        self,
+        u: Array,
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> Array:
+        """Evaluate vector expansion on a mesh with optional padding."""
+        coeffs = []
         for i, space in enumerate(self.tensorspaces):
-            ci = c[i]
-            vi = space.evaluate_derivative(x, ci, k)
-            vals.append(vi)
-        return jnp.stack(vals)
+            ci = space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
+            coeffs.append(ci)
+        return jnp.stack(coeffs)
 
     def forward(self, u: Array) -> Array:
         """Forward transform with optional truncation."""
@@ -828,13 +785,12 @@ class VectorTensorProductSpace:
     def backward(
         self,
         u: Array,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
         """Backward transform with optional padding."""
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
-            ci = space.backward(u[i], kind=kind, N=N[i] if N is not None else None)
+            ci = space.backward(u[i], N=N[i] if N is not None else None)
             coeffs.append(ci)
         return jnp.stack(coeffs)
 
@@ -842,14 +798,11 @@ class VectorTensorProductSpace:
         self,
         u: Array,
         k: tuple[int, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
-            ci = space.backward_primitive(
-                u[i], k=k, kind=kind, N=N[i] if N is not None else None
-            )
+            ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
             coeffs.append(ci)
         return jnp.stack(coeffs)
 
@@ -1098,11 +1051,10 @@ class DirectSumTPS(TensorProductSpace):
     def backward(
         self,
         c: Array,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Evaluate total (homogeneous + lifting) backward transform."""
-        return self.orthogonal.backward(self.to_orthogonal(c), kind=kind, N=N)
+        return self.orthogonal.backward(self.to_orthogonal(c), N=N)
 
     def forward(self, u: Array) -> Array:
         """Solve projection for homogeneous coefficients (lifting removed)."""
@@ -1119,27 +1071,23 @@ class DirectSumTPS(TensorProductSpace):
         """Evaluate direct sum tensor product expansion at scattered points."""
         return self.orthogonal.evaluate(x, self.to_orthogonal(c), use_einsum)
 
-    def evaluate_derivative(self, x: Array, c: Array, k: tuple[int, ...]) -> Array:
-        """Evaluate direct sum tensor product expansion at scattered points."""
-        return self.orthogonal.evaluate_derivative(x, self.to_orthogonal(c), k)
-
     def evaluate_mesh(
-        self, x: list[Array], c: Array, use_einsum: bool = False
+        self,
+        c: Array,
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Evaluate expansion on tensor mesh (summing lifting parts)."""
-        return self.orthogonal.evaluate_mesh(x, self.to_orthogonal(c), use_einsum)
+        return self.orthogonal.evaluate_mesh(self.to_orthogonal(c), kind=kind, N=N)
 
     def backward_primitive(
         self,
         c: Array,
         k: tuple[int, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
         """Evaluate total (homogeneous + lifting) backward transform."""
-        return self.orthogonal.backward_primitive(
-            self.to_orthogonal(c), k=k, kind=kind, N=N
-        )
+        return self.orthogonal.backward_primitive(self.to_orthogonal(c), k=k, N=N)
 
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped to underlying orthogonal basis."""

--- a/src/jaxfun/pinns/module.py
+++ b/src/jaxfun/pinns/module.py
@@ -668,7 +668,7 @@ class SpectralModule(BaseModule):
         if isinstance(self.space, OrthogonalSpace | DirectSum):
             return self.space.evaluate(x, self.kernel[0])
 
-        z = self.space.evaluate(x, self.kernel[...], True)
+        z = self.space.evaluate(x, self.kernel[...])
         if self.space.rank == 0:
             return jnp.expand_dims(z, -1)
         return z

--- a/tests/galerkin/test_additional_coverage.py
+++ b/tests/galerkin/test_additional_coverage.py
@@ -152,8 +152,7 @@ def test_tensorproductspace_3d_paths_and_mapping():
     uh = T3.backward(c)
     assert uh.shape == u.shape
     # Evaluate path
-    mesh = T3.mesh()
-    val = T3.evaluate_mesh(mesh, c)
+    val = T3.evaluate_mesh(c)
     # evaluation returns broadcasted shape (dim interleaved); collapse via squeeze
     assert jnp.squeeze(val).shape == u.shape
     # Mapping of expression through composed map_expr_true_domain

--- a/tests/galerkin/test_backward_primitive_eval.py
+++ b/tests/galerkin/test_backward_primitive_eval.py
@@ -54,7 +54,7 @@ def test_chebyshev_backward_primitive_matches_analytical() -> None:
         got = V.backward_primitive(uh, k=2)
         expected = lambdify(x, sp.diff(ue, x, 2))(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
-        assert float(rel) < ulp(10000), f"k=2: rel={float(rel)}"
+        assert float(rel) < jnp.sqrt(ulp(1)), f"k=2: rel={float(rel)}"
 
 
 def test_directsum_backward_primitive_includes_boundary_lift() -> None:

--- a/tests/galerkin/test_backward_primitive_eval.py
+++ b/tests/galerkin/test_backward_primitive_eval.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import sympy as sp
 
 from jaxfun import Domain
 from jaxfun.galerkin import TensorProductSpace
@@ -7,7 +8,8 @@ from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.ChebyshevU import ChebyshevU
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.functionspace import FunctionSpace
-from jaxfun.utils.common import ulp
+from jaxfun.galerkin.inner import project, project1D
+from jaxfun.utils.common import lambdify, ulp
 
 
 def _complex_coeffs(key: jax.Array, n: int) -> jax.Array:
@@ -15,30 +17,44 @@ def _complex_coeffs(key: jax.Array, n: int) -> jax.Array:
     return jax.random.normal(kr, (n,)) + 1j * jax.random.normal(ki, (n,))
 
 
-def test_fourier_backward_primitive_matches_evaluate_derivative() -> None:
+def test_fourier_backward_primitive_matches_analytical() -> None:
     N = 32
     V = Fourier(N, domain=Domain(-1, 1))
-    c = _complex_coeffs(jax.random.PRNGKey(1), N)
+    x = V.system.base_scalars()[0]
+    ue = sp.sin(sp.pi * x)
+    uh = project1D(ue, V)
     xj = V.mesh()
 
-    for k in (0, 1, 3):
-        got = V.backward_primitive(c, k=k)
-        expected = V.evaluate_derivative(xj, c, k=k)
+    for k, deriv in [(0, ue), (1, sp.diff(ue, x))]:
+        got = V.backward_primitive(uh, k=k)
+        expected = lambdify(x, deriv)(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
-        assert float(rel) < ulp(100)
+        assert float(rel) < ulp(100), f"k={k}: rel={float(rel)}"
+    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+        got = V.backward_primitive(uh, k=3)
+        expected = lambdify(x, sp.diff(ue, x, 3))(xj)
+        rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
+        assert float(rel) < ulp(10000), f"k=3: rel={float(rel)}"
 
 
-def test_chebyshev_backward_primitive_matches_evaluate_derivative() -> None:
+def test_chebyshev_backward_primitive_matches_analytical() -> None:
     N = 36
     V = Chebyshev(N, domain=Domain(0, 2))
-    c = jax.random.normal(jax.random.PRNGKey(2), (N,))
+    x = V.system.base_scalars()[0]
+    ue = x**4 - 3 * x**2 + x
+    uh = project1D(ue, V)
     xj = V.mesh()
 
-    for k in (0, 1, 2):
-        got = V.backward_primitive(c, k=k)
-        expected = V.evaluate_derivative(xj, c, k=k)
+    for k, deriv in [(0, ue), (1, sp.diff(ue, x))]:
+        got = V.backward_primitive(uh, k=k)
+        expected = lambdify(x, deriv)(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
-        assert float(rel) < ulp(1000)
+        assert float(rel) < ulp(1000), f"k={k}: rel={float(rel)}"
+    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+        got = V.backward_primitive(uh, k=2)
+        expected = lambdify(x, sp.diff(ue, x, 2))(xj)
+        rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
+        assert float(rel) < ulp(10000), f"k=2: rel={float(rel)}"
 
 
 def test_directsum_backward_primitive_includes_boundary_lift() -> None:
@@ -49,29 +65,42 @@ def test_directsum_backward_primitive_includes_boundary_lift() -> None:
         bcs={"left": {"D": 1.0}, "right": {"D": -0.5}},
         domain=Domain(-1, 1),
     )
-    c = jax.random.normal(jax.random.PRNGKey(3), (V.num_dofs,))
+    x = V.system.base_scalars()[0]
+    # Quadratic satisfying BCs u(-1)=1.0, u(1)=-0.5;
+    # homogeneous part 7(1-x²)/10 is non-trivial.
+    ue = -sp.Rational(7, 10) * x**2 - sp.Rational(3, 4) * x + sp.Rational(19, 20)
+    uh = project1D(ue, V)
     xj = V.mesh()
 
-    for k in (0, 1):
-        got = V.backward_primitive(c, k=k)
-        expected = V.evaluate_derivative(xj, c, k=k)
+    for k, deriv in [(0, ue), (1, sp.diff(ue, x))]:
+        got = V.backward_primitive(uh, k=k)
+        expected = lambdify(x, deriv)(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
-        assert float(rel) < ulp(1000)
+        assert float(rel) < ulp(1000), f"k={k}: rel={float(rel)}"
 
 
-def test_tensorproduct_fourier_backward_primitive_matches_derivative() -> None:
+def test_tensorproduct_fourier_backward_primitive_matches_analytical() -> None:
     N = 24
     F = Fourier(N, domain=Domain(-1, 1))
     V = TensorProductSpace((F, F))
-    c = _complex_coeffs(jax.random.PRNGKey(4), N * N).reshape((N, N))
+    x, y = V.system.base_scalars()
+    ue = sp.sin(sp.pi * x) * sp.sin(sp.pi * y)
+    uh = project(ue, V)
     xj = list(V.mesh())
 
-    orders = ((0, 0), (1, 0), (0, 2), (1, 1))
-    for k in orders:
-        got = V.backward_primitive(c, k=k)
-        expected = V.evaluate_derivative(xj, c, k=k)
+    for k in [(0, 0), (1, 0), (1, 1)]:
+        got = V.backward_primitive(uh, k=k)
+        deriv = sp.diff(sp.diff(ue, x, k[0]), y, k[1])
+        expected = lambdify((x, y), deriv)(*xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
-        assert float(rel) < ulp(100)
+        assert float(rel) < ulp(100), f"k={k}: rel={float(rel)}"
+    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+        k2 = (0, 2)
+        got = V.backward_primitive(uh, k=k2)
+        deriv = sp.diff(sp.diff(ue, x, k2[0]), y, k2[1])
+        expected = lambdify((x, y), deriv)(*xj)
+        rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
+        assert float(rel) < ulp(10000), f"k=(0,2): rel={float(rel)}"
 
 
 def test_tensorproduct_fourier_backward_primitive_uses_fft_fast_path() -> None:

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -18,6 +18,8 @@ import sympy as sp
 from jaxfun.galerkin import (
     Chebyshev,
     Fourier,
+    FunctionSpace,
+    JAXFunction,
     Legendre,
     TensorProduct,
 )
@@ -107,3 +109,43 @@ def test_scalar_product_3d_spmd(space0, space1, space2) -> None:
     u = jax.device_put(jnp.ones(T.shape()), T._physical_sharding)
     uh = T.scalar_product(u)
     assert uh.sharding == T._spectral_sharding
+
+
+@pytest.mark.parametrize("domain", [(-1, 1), (0, 2), (-2, 2)])
+def test_backward_primitive_tps_2d(domain):
+    N = 16
+    D = FunctionSpace(N, Legendre.Legendre, domain=domain)
+    T = TensorProduct(D, D)
+    x, y = T.system.base_scalars()
+    f = sp.sin(x) * sp.cos(y)
+    uf = JAXFunction(f, T)
+    du = JAXFunction(sp.diff(f, x, y), T)
+    df = T.backward_primitive(uf.array, (1, 1))
+    error = jnp.linalg.norm(df - du.backward())
+
+    assert error < jnp.sqrt(ulp(100))
+    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+        du = JAXFunction(sp.diff(f, x, 2, y, 1), T)
+        df = T.backward_primitive(uf.array, (2, 1))
+        error = jnp.linalg.norm(df - du.backward())
+        assert error < jnp.sqrt(ulp(100)), error
+
+
+@pytest.mark.parametrize("domain", [(-1, 1), (0, 2), (-2, 2)])
+def test_backward_primitive_tps_3d(domain):
+    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+        N = 16
+        D = FunctionSpace(N, Legendre.Legendre, domain=domain)
+        T = TensorProduct(D, D, D)
+        x, y, z = T.system.base_scalars()
+        f = sp.sin(x) * sp.cos(y) * sp.sin(z)
+        uf = JAXFunction(f, T)
+        du = JAXFunction(sp.diff(f, x, y, z), T)
+        df = T.backward_primitive(uf.array, (1, 1, 1))
+        error = jnp.linalg.norm(df - du.backward())
+
+        assert error < jnp.sqrt(ulp(100))
+        du = JAXFunction(sp.diff(f, x, 2, y, 1, z, 1), T)
+        df = T.backward_primitive(uf.array, (2, 1, 1))
+        error = jnp.linalg.norm(df - du.backward())
+        assert error < jnp.sqrt(ulp(100)), error

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -1,4 +1,3 @@
-import jax
 import jax.numpy as jnp
 import pytest
 import sympy as sp
@@ -223,32 +222,6 @@ def test_jaxfunction_2d_vector(space: type[OrthogonalSpace], domain: Domain | No
     b0 = A @ uf.array
     b1 = inner(Dot(uf, v))
     assert jnp.linalg.norm(b0 - b1) < jnp.sqrt(ulp(10))
-
-
-def test_evaluate_derivative():
-    N = 24 if jax.config.jax_enable_x64 else 16  # ty:ignore[unresolved-attribute]
-    D = Legendre.Legendre(N)
-    T = TensorProduct(D, D, name="T")
-    x, y = T.system.base_scalars()
-    ue = sp.sin(sp.pi * x) * sp.cos(sp.pi * y)
-    w = JAXFunction(ue, T, name="w")
-    xj, yj = T.mesh()
-
-    dw_dx = T.evaluate_derivative((xj, yj), w.array, k=(1, 0))
-    dw_dx_analytic = JAXFunction(sp.diff(ue, x), T).backward()
-    assert jnp.linalg.norm(dw_dx - dw_dx_analytic) < jnp.sqrt(ulp(100))
-
-    dw_dy = T.evaluate_derivative((xj, yj), w.array, k=(0, 1))
-    dw_dy_analytic = JAXFunction(sp.diff(ue, y), T).backward()
-    assert jnp.linalg.norm(dw_dy - dw_dy_analytic) < jnp.sqrt(ulp(100))
-
-    dw_dx_dy = T.evaluate_derivative((xj, yj), w.array, k=(1, 1))
-    dw_dx_dy_analytic = JAXFunction(sp.diff(ue, x, y), T).backward()
-    assert jnp.linalg.norm(dw_dx_dy - dw_dx_dy_analytic) < jnp.sqrt(ulp(1000))
-
-    # dw_dx_dy2 = T.evaluate_derivative((xj, yj), w.array, k=(1, 2))
-    # dw_dx_dy2_analytic = JAXFunction(sp.diff(ue, x, y, y), T).backward()
-    # assert jnp.linalg.norm(dw_dx_dy2 - dw_dx_dy2_analytic) < jnp.sqrt(ulp(1000))
 
 
 def test_jaxfunction_vector(jspace: type[OrthogonalSpace], domain: Domain | None):

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -160,18 +160,3 @@ def test_directsumtps():
     z0 = jnp.sum(jnp.array(a), axis=0)
     z1 = T.evaluate(xj, c, True)
     assert jnp.linalg.norm(z0 - z1) < jnp.sqrt(ulp(100))
-
-    a = []
-    for f, v in T.tpspaces.items():
-        a.append(v.evaluate_derivative(xj, T.bndvals.get(f, c), (1, 1)))
-    z0 = jnp.sum(jnp.array(a), axis=0)
-    z1 = T.evaluate_derivative(xj, c, (1, 1))
-    assert jnp.linalg.norm(z0 - z1) < jnp.sqrt(ulp(100))
-
-    a = []
-    xj = T.mesh(kind="uniform", N=N)
-    for f, v in T.tpspaces.items():
-        a.append(v.evaluate_mesh(xj, T.bndvals.get(f, c), True))
-    z0 = jnp.sum(jnp.array(a), axis=0)
-    z1 = T.evaluate_mesh(list(xj), c, True)
-    assert jnp.linalg.norm(z0 - z1) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -156,7 +156,7 @@ def test_directsumtps():
     xj = T.flatmesh(kind="uniform", N=N)
     a = []
     for f, v in T.tpspaces.items():
-        a.append(v.evaluate(xj, T.bndvals.get(f, c), True))
+        a.append(v.evaluate(xj, T.bndvals.get(f, c)))
     z0 = jnp.sum(jnp.array(a), axis=0)
-    z1 = T.evaluate(xj, c, True)
+    z1 = T.evaluate(xj, c)
     assert jnp.linalg.norm(z0 - z1) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_tensorproductspace_more.py
+++ b/tests/galerkin/test_tensorproductspace_more.py
@@ -30,7 +30,7 @@ def test_tensorproductspace_broadcast_and_evaluate_2d():
     by = T.broadcast_to_ndims(mesh[1], 1)
     assert bx.shape[0] == mesh[0].shape[0] and by.shape[1] == mesh[1].shape[0]
     # evaluate 2D path
-    val = T.evaluate_mesh(mesh, coeffs)
+    val = T.evaluate_mesh(coeffs)
     # evaluate inserts singleton axis for second dimension order (shape (N0,1,N1))
     assert val.shape[0] == coeffs.shape[0] and val.shape[-1] == coeffs.shape[1]
 
@@ -97,16 +97,9 @@ def test_directsum_two_inhomogeneous_bnd_evaluate():
     x, y = T.system.base_scalars()
     u0 = T.evaluate(jnp.array([0.5, 0.5]), uf, True)
     assert abs(u0 - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
-    u1 = T.evaluate_mesh([jnp.array([[0.5]]), jnp.array([[0.5]])], uf)
-    assert abs(u1[0, 0] - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
     u0 = T.evaluate(jnp.array([[0.5, 0.5], [0.6, 0.6]]), uf, False)
     assert abs(u0[0] - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
     assert abs(u0[1] - ue.subs({x: 0.6, y: 0.6})) < ulp(100)
-    u1 = T.evaluate_mesh([jnp.array([[0.5, 0.6]]), jnp.array([[0.5, 0.6]])], uf)
-    assert abs(u1[0, 0] - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
-    assert abs(u1[0, 1] - ue.subs({x: 0.5, y: 0.6})) < ulp(100)
-    assert abs(u1[1, 0] - ue.subs({x: 0.6, y: 0.5})) < ulp(100)
-    assert abs(u1[1, 1] - ue.subs({x: 0.6, y: 0.6})) < ulp(100)
 
 
 if __name__ == "__main__":

--- a/tests/galerkin/test_tensorproductspace_more.py
+++ b/tests/galerkin/test_tensorproductspace_more.py
@@ -95,11 +95,8 @@ def test_directsum_two_inhomogeneous_bnd_evaluate():
     ue = T.system.expr_psi_to_base_scalar(ue)
     uf = project(ue, T)
     x, y = T.system.base_scalars()
-    u0 = T.evaluate(jnp.array([0.5, 0.5]), uf, True)
+    u0 = T.evaluate(jnp.array([0.5, 0.5]), uf)
     assert abs(u0 - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
-    u0 = T.evaluate(jnp.array([[0.5, 0.5], [0.6, 0.6]]), uf, False)
-    assert abs(u0[0] - ue.subs({x: 0.5, y: 0.5})) < ulp(100)
-    assert abs(u0[1] - ue.subs({x: 0.6, y: 0.6})) < ulp(100)
 
 
 if __name__ == "__main__":

--- a/tests/galerkin/test_to_from_orthogonal_spmd.py
+++ b/tests/galerkin/test_to_from_orthogonal_spmd.py
@@ -3,11 +3,11 @@ import pytest
 
 from jaxfun.galerkin import FunctionSpace, TensorProduct
 from jaxfun.galerkin.Chebyshev import Chebyshev
-from jaxfun.galerkin.ChebyshevU import ChebyshevU
 from jaxfun.galerkin.Jacobi import Jacobi
 from jaxfun.galerkin.Legendre import Legendre
-from jaxfun.galerkin.Ultraspherical import Ultraspherical
 from jaxfun.utils import Domain, ulp
+
+pytestmark = pytest.mark.spmd
 
 
 @pytest.fixture(
@@ -18,27 +18,11 @@ def domain(request: pytest.FixtureRequest) -> Domain:
 
 
 @pytest.fixture(
-    params=(Legendre, Chebyshev, ChebyshevU, Jacobi, Ultraspherical),
-    ids=("Legendre", "Chebyshev", "ChebyshevU", "Jacobi", "Ultraspherical"),
+    params=(Legendre, Chebyshev),
+    ids=("Legendre", "Chebyshev"),
 )
 def jspace(request: pytest.FixtureRequest) -> type[Jacobi]:
     return request.param
-
-
-def test_to_from_orthogonal_1d(jspace: type[Jacobi], domain: Domain):
-    N = 16
-    bcs = {"left": {"D": 0}, "right": {"D": 0}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
-    u = jnp.ones(D.num_dofs)
-    assert jnp.linalg.norm(u - D.from_orthogonal(D.to_orthogonal(u))) < ulp(100)
-
-
-def test_to_from_orthogonal_1d_directsum(jspace: type[Jacobi], domain: Domain):
-    N = 16
-    bcs = {"left": {"D": 1}, "right": {"D": 1}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
-    u = jnp.ones(D.num_dofs)
-    assert jnp.linalg.norm(u - D.from_orthogonal(D.to_orthogonal(u))) < ulp(100)
 
 
 def test_to_from_orthogonal_2d(jspace: type[Jacobi], domain: Domain):

--- a/tests/integrators/test_backward_euler.py
+++ b/tests/integrators/test_backward_euler.py
@@ -11,7 +11,6 @@ from jaxfun.galerkin.Fourier import Fourier as FourierSpace
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.integrators import ETDRK4, RK4, BackwardEuler
 from jaxfun.operators import Constant, Div, Grad
-from jaxfun.typing import MeshKind
 from jaxfun.utils.common import lambdify, n, ulp
 
 
@@ -151,9 +150,8 @@ def test_rk4_nonlinear_rhs_uses_direct_jaxfunction_evaluation() -> None:
     uhat = integrator.initial_coefficients()
     nonlinear = integrator.nonlinear_rhs(uhat)
 
-    xj = V.mesh()
     u_phys = V.backward(uhat)
-    ux_phys = V.evaluate_derivative(xj, uhat, k=1)
+    ux_phys = V.backward_primitive(uhat, k=1)
     expected = V.forward(-u_phys * ux_phys)
 
     assert jnp.allclose(nonlinear, expected, atol=5 * ulp(2.0))
@@ -176,7 +174,7 @@ def test_rk4_nonlinear_rhs_caches_repeated_primitives(
     integrator = RK4(V, weak_form, time=(0.0, 0.01), initial=sp.sin(x), sparse=True)
     uhat = integrator.initial_coefficients()
     u_phys = V.backward(uhat)
-    ux_phys = V.evaluate_derivative(V.mesh(), uhat, k=1)
+    ux_phys = V.backward_primitive(uhat, k=1)
     expected = V.forward(-((u_phys + ux_phys) ** 2))
 
     calls: list[int] = []
@@ -185,20 +183,18 @@ def test_rk4_nonlinear_rhs_caches_repeated_primitives(
 
     def count_backward(
         c,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ):
         calls.append(0)
-        return original_backward(c, kind=kind, N=N)  # ty:ignore[invalid-argument-type]
+        return original_backward(c, N=N)  # ty:ignore[invalid-argument-type]
 
     def count_eval(
         c,
         k: int = 0,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ):
         calls.append(int(k))
-        return original_eval(c, k=k, kind=kind, N=N)  # ty:ignore[invalid-argument-type]
+        return original_eval(c, k=k, N=N)  # ty:ignore[invalid-argument-type]
 
     monkeypatch.setattr(integrator.functionspace, "backward", count_backward)
     monkeypatch.setattr(integrator.functionspace, "backward_primitive", count_eval)
@@ -247,11 +243,10 @@ def test_rk4_solve_passes_padding_to_nonlinear_backward_calls(
     def count_eval(
         c,
         k: int = 0,
-        kind: MeshKind = MeshKind.QUADRATURE,
         N: int | None = None,
     ):
         calls.append(N)
-        return original_eval(c, k=k, kind=kind, N=N)  # ty:ignore[invalid-argument-type]
+        return original_eval(c, k=k, N=N)  # ty:ignore[invalid-argument-type]
 
     monkeypatch.setattr(integrator.functionspace, "backward_primitive", count_eval)
 
@@ -330,10 +325,9 @@ def test_rk4_tensorproduct_nonlinear_rhs_uses_mixed_derivative_path() -> None:
     uhat = integrator.initial_coefficients()
     nonlinear = integrator.nonlinear_rhs(uhat)
 
-    xj = list(V.mesh())
     u_phys = V.backward(uhat)
-    ux_phys = V.evaluate_derivative(xj, uhat, k=(1, 0))
-    uy_phys = V.evaluate_derivative(xj, uhat, k=(0, 1))
+    ux_phys = V.backward_primitive(uhat, k=(1, 0))
+    uy_phys = V.backward_primitive(uhat, k=(0, 1))
     expected = V.forward(-(u_phys * ux_phys + u_phys * uy_phys))
 
     assert jnp.allclose(nonlinear, expected, atol=5 * ulp(0.5))

--- a/tests/integrators/test_etdrk4.py
+++ b/tests/integrators/test_etdrk4.py
@@ -368,11 +368,10 @@ def test_etdrk4_tensorproduct_solve_passes_padding_through(
     def count_eval(
         c,
         k: int | tuple[int, ...] = 0,
-        kind: str = "quadrature",
         N: tuple[int, ...] | None = None,
     ):
         calls.append(N)
-        return original_eval(c, k=k, kind=kind, N=N)  # ty:ignore[invalid-argument-type]
+        return original_eval(c, k=k, N=N)  # ty:ignore[invalid-argument-type]
 
     monkeypatch.setattr(integrator.functionspace, "backward_primitive", count_eval)
     _ = integrator.solve(dt=dt, steps=steps, N=(pad, pad), progress=False)

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -5,8 +5,14 @@ from pathlib import Path
 import pytest
 
 root = Path(__file__).parent.parent
-files = [f.stem for f in root.glob("examples/*.py") if f.is_file()]
-files.remove("DrivenCavity_lstsq")
+
+_all_files = [f for f in root.glob("examples/*.py") if f.is_file()]
+_all_files = [f for f in _all_files if f.stem != "DrivenCavity_lstsq"]
+
+spmd_files = [
+    f.stem for f in _all_files if "pytestmark = pytest.mark.spmd" in f.read_text()
+]
+files = [f.stem for f in _all_files if f.stem not in spmd_files]
 
 
 @pytest.mark.slow
@@ -15,6 +21,17 @@ files.remove("DrivenCavity_lstsq")
     files,
 )
 def test_demos(demo: str) -> None:
+    with contextlib.suppress(SystemExit):
+        runpy.run_path(f"examples/{demo}.py", run_name="__main__")
+
+
+@pytest.mark.slow
+@pytest.mark.spmd
+@pytest.mark.parametrize(
+    "demo",
+    spmd_files,
+)
+def test_demos_spmd(demo: str) -> None:
     with contextlib.suppress(SystemExit):
         runpy.run_path(f"examples/{demo}.py", run_name="__main__")
 


### PR DESCRIPTION
## Summary

Method backward now only works on quadrature points, as it should. It is now just the inverse of forward, which is also just using quadrature points.

Move the possibility of evaluating a spectral function on a uniform mesh to evaluate_mesh.

## Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] Other (describe):

## Description of Changes

* Remove kind parameter from backward. Add kind parameter to evaluate_mesh.
* evaluate_mesh does no longer take the mesh as input. Instead it is using parameter kind and N.
* Remove use_einsum from TensorProductSpace.evaluate.
* Remove method evaluate_derivative as only backward_primitive is currently in use.

## Breaking Changes

- [x] Yes (describe below)
- [ ] No

    T.backward(u, kind="uniform")

will no longer work. Use

    T.evaluate_mesh(u, kind="uniform") 

Furthermore, evaluate has one less parameter since use_einsum is removed.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [x] Coverage does not decrease
- [x] Git history is clean (squash/fixup before merge)
