### PR TITLE
Moving sharding into its own file and not pollute TensorProductSpace

### DIFF
--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -45,8 +45,8 @@ class OrthogonalSpace(BaseSpace):
 
     Attributes:
         N: Number of modes.
-        _domain: Physical Domain (None -> reference).
-        _num_quad_points: Default quadrature resolution (== N).
+        domain: Physical Domain (None -> reference).
+        num_quad_points: Default quadrature resolution (== N).
         S: Stencil matrix (identity here; overridden in Composite).
         stencil: Dict describing diagonal shifts (0:1 for identity).
         orthogonal: Self alias (Composite replaces with underlying).
@@ -178,7 +178,7 @@ class OrthogonalSpace(BaseSpace):
         Args:
             c: Coefficients of orthogonal series (length <= self.N).
             kind: Type of mesh to use (QUADRATURE or UNIFORM).
-            N: Number of points. Must be >= self._num_quad_points.
+            N: Number of points. Must be >= self.num_quad_points.
 
         Returns:
             Array of shape (N,) containing series evaluation at mesh points.
@@ -209,8 +209,8 @@ class OrthogonalSpace(BaseSpace):
 
         Args:
             c: Coefficients of orthogonal series (length <= self.N).
-            N: Number of points. Must be >= self._num_quad_points. Defaults to
-                self._num_quad_points.
+            N: Number of points. Must be >= self.num_quad_points. Defaults to
+                self.num_quad_points.
 
         Returns:
             Array of shape (N,) containing series evaluation at quadrature points.
@@ -231,8 +231,8 @@ class OrthogonalSpace(BaseSpace):
         Args:
             c: Coefficients of orthogonal series (length <= self.N).
             k: Derivative order (default 0 -> function value).
-            N: Number of points. Must be >= self._num_quad_points, defaults to
-                self._num_quad_points.
+            N: Number of points. Must be >= self.num_quad_points, defaults to
+                self.num_quad_points.
         """
         df = float(self.domain_factor**k)
         return df * self.backward(self.derivative_coeffs(c, k), N=N)

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -326,8 +326,12 @@ class TensorProductSpace:
     ) -> Array:
         """Backward transform.
 
-        In the SPMD case the separable transform runs outside JIT on each
-        device's addressable shard, eliminating spurious all-gather ops.
+        Args:
+            c: Coefficient array.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward transform values on quadrature mesh.
         """
         N = tuple(
             self.basespaces[ax].num_quad_points if N is None else N[ax]
@@ -353,7 +357,14 @@ class TensorProductSpace:
         return c
 
     def scalar_product(self, u: Array) -> Array:
-        """Return tensor of inner products along each axis (separable)."""
+        """Return tensor of inner products along each axis (separable).
+
+        Args:
+            u: Input array.
+
+        Returns:
+            Array of inner products along each axis.
+        """
         sg = self.system.sg
         if sg != 1:
             sg = lambdify(self.system.base_scalars(), sg)(*self.mesh())
@@ -374,7 +385,14 @@ class TensorProductSpace:
         return u
 
     def forward(self, u: Array) -> Array:
-        """Forward transform with optional truncation."""
+        """Forward transform with optional truncation.
+
+        Args:
+            u: Input array.
+
+        Returns:
+            Array of forward transform values.
+        """
         cache_key = ("forward",)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
@@ -396,7 +414,16 @@ class TensorProductSpace:
         k: tuple[int, ...],
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate the field or mixed derivatives on a tensor-product mesh."""
+        """Evaluate the field or mixed derivatives on a tensor-product mesh.
+
+        Args:
+            c: Coefficient array.
+            k: Tuple of derivative orders along each axis.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward primitive values on tensor-product mesh.
+        """
         N = tuple(
             self.basespaces[ax].num_quad_points if N is None else N[ax]
             for ax in range(len(self))
@@ -425,7 +452,14 @@ class TensorProductSpace:
         return c
 
     def to_orthogonal(self, c: Array) -> Array:
-        """Return coefficients c mapped to underlying orthogonal basis."""
+        """Return coefficients c mapped to underlying orthogonal basis.
+
+        Args:
+            c: Coefficient array.
+
+        Returns:
+            Array of coefficients in the orthogonal basis.
+        """
         dim = len(self)
         sharding = self._spectral_sharding
         if dim == 2:
@@ -446,7 +480,14 @@ class TensorProductSpace:
         return z
 
     def from_orthogonal(self, c: Array) -> Array:
-        """Return coefficients c mapped from underlying orthogonal basis."""
+        """Return coefficients c mapped from underlying orthogonal basis.
+
+        Args:
+            c: Coefficient array.
+
+        Returns:
+            Array of coefficients in the original basis.
+        """
         sharding = self._spectral_sharding
         S = [s.get_inverse_stencil() for s in self.basespaces]
         dim = len(self)
@@ -566,7 +607,16 @@ class VectorTensorProductSpace:
         kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
-        """Evaluate vector expansion on a mesh with optional padding."""
+        """Evaluate vector expansion on a mesh with optional padding.
+
+        Args:
+            u: Input array.
+            kind: Type of mesh to evaluate on.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of evaluated values on the mesh.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
@@ -574,7 +624,14 @@ class VectorTensorProductSpace:
         return jnp.stack(coeffs)
 
     def forward(self, u: Array) -> Array:
-        """Forward transform with optional truncation."""
+        """Forward transform with optional truncation.
+
+        Args:
+            u: Input array.
+
+        Returns:
+            Array of forward transform values.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.forward(u[i])
@@ -582,6 +639,13 @@ class VectorTensorProductSpace:
         return jnp.stack(coeffs)
 
     def scalar_product(self, u: Array) -> Array:
+        """Return tensor of inner products along each axis (separable).
+        Args:
+            u: Input array.
+
+        Returns:
+            Array of inner products along each axis.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.scalar_product(u[i])
@@ -593,7 +657,15 @@ class VectorTensorProductSpace:
         u: Array,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
-        """Backward transform with optional padding."""
+        """Backward transform with optional padding.
+
+        Args:
+            u: Input array.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward transform values.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.backward(u[i], N=N[i] if N is not None else None)
@@ -606,6 +678,16 @@ class VectorTensorProductSpace:
         k: tuple[int, ...],
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
+        """Backward primitive transform with optional padding.
+
+        Args:
+            u: Input array.
+            k: Tuple of derivative orders.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward primitive transform values.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
@@ -613,6 +695,14 @@ class VectorTensorProductSpace:
         return jnp.stack(coeffs)
 
     def to_orthogonal(self, c: Array) -> Array:
+        """Convert coefficients to orthogonal basis.
+
+        Args:
+            c: Input array of coefficients.
+
+        Returns:
+            Array of coefficients in orthogonal basis.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.to_orthogonal(c[i])
@@ -620,6 +710,14 @@ class VectorTensorProductSpace:
         return jnp.stack(coeffs)
 
     def from_orthogonal(self, c: Array) -> Array:
+        """Convert coefficients from orthogonal basis.
+
+        Args:
+            c: Input array of coefficients.
+
+        Returns:
+            Array of coefficients in the original basis.
+        """
         coeffs = []
         for i, space in enumerate(self.tensorspaces):
             ci = space.from_orthogonal(c[i])
@@ -860,22 +958,18 @@ class DirectSumTPS(TensorProductSpace):
         c: Array,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate total (homogeneous + lifting) backward transform."""
         return self.orthogonal.backward(self.to_orthogonal(c), N=N)
 
     def forward(self, u: Array) -> Array:
-        """Solve projection for homogeneous coefficients (lifting removed)."""
         d = self.orthogonal.forward(u)
         return self.from_orthogonal(d)
 
     def scalar_product(self, c: Array) -> NoReturn:  # ty:ignore[invalid-method-override]
-        """Disabled scalar product (non-homogeneous test space)."""
         raise RuntimeError(
             "Scalar product requires homogeneous test space (call on get_homogeneous())"
         )
 
     def evaluate(self, x: Array, c: Array) -> Array:
-        """Evaluate direct sum tensor product expansion at scattered points."""
         return self.orthogonal.evaluate(x, self.to_orthogonal(c))
 
     def evaluate_mesh(
@@ -884,7 +978,6 @@ class DirectSumTPS(TensorProductSpace):
         kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate expansion on tensor mesh (summing lifting parts)."""
         return self.orthogonal.evaluate_mesh(self.to_orthogonal(c), kind=kind, N=N)
 
     def backward_primitive(
@@ -893,11 +986,9 @@ class DirectSumTPS(TensorProductSpace):
         k: tuple[int, ...],
         N: tuple[int | None, ...] | None = None,
     ) -> Array:
-        """Evaluate total (homogeneous + lifting) backward transform."""
         return self.orthogonal.backward_primitive(self.to_orthogonal(c), k=k, N=N)
 
     def to_orthogonal(self, c: Array) -> Array:
-        """Return coefficients c mapped to underlying orthogonal basis."""
         result = self.get_homogeneous().to_orthogonal(c)
 
         for f, v in self.tpspaces.items():
@@ -913,7 +1004,6 @@ class DirectSumTPS(TensorProductSpace):
         return result
 
     def from_orthogonal(self, c: Array) -> Array:
-        """Return coefficients c mapped from underlying orthogonal basis."""
         # Note that c may be replicated, because the orthogonal space is not the
         # same as the original space, so we can't assume the sharding is compatible.
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -10,10 +10,17 @@ import jax
 import jax.numpy as jnp
 import sympy as sp
 from jax import Array, shard_map
-from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+from jax.sharding import NamedSharding, PartitionSpec as P
 
 from jaxfun.coordinates import CoordSys
-from jaxfun.typing import ArrayFun, MeshKind
+from jaxfun.sharding import (
+    _apply_separable_spmd_shard_map,
+    _build_local_apply_fn,
+    physical_sharding,
+    spectral_sharding,
+    spmd_mesh,
+)
+from jaxfun.typing import MeshKind
 from jaxfun.utils.common import jit_vmap, lambdify
 
 from .composite import BCGeneric, BoundaryConditions, Composite, DirectSum
@@ -68,18 +75,8 @@ class TensorProductSpace:
         self.name = name
         self.system: CoordSys = system
         self.tensorname = tensor_product_symbol.join([b.name for b in basespaces])
-        # Slab decomposition
-        self._spmd_mesh = Mesh(jax.devices(), ("k",))
-        # Sharding of arrays in spectral coefficient space.
-        self._spectral_sharding: NamedSharding | None = (
-            None if len(jax.devices()) == 1 else NamedSharding(self._spmd_mesh, P("k"))
-        )
-        # Sharding of arrays in physical space.
-        self._physical_sharding: NamedSharding | None = (
-            None
-            if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P(None, "k"))
-        )
+        self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
+        self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
         self._spmd_local_fn_cache: dict = {}
 
     def __len__(self) -> int:
@@ -237,15 +234,18 @@ class TensorProductSpace:
         cache_key = ("evaluate_mesh", kind, N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
-                self._build_local_apply_fn(
+                _build_local_apply_fn(
+                    len(self),
                     ax,
                     partial(self.basespaces[ax].evaluate_mesh, kind=kind, N=N[ax]),
                 )
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
+        if len(c.devices()) > 1:
+            return _apply_separable_spmd_shard_map(
+                c, fns, spectral_sharding, self._spmd_local_fn_cache
+            )
         for fn in fns:
             c = fn(c)
         return c
@@ -272,7 +272,7 @@ class TensorProductSpace:
         Returns:
             Scalar or (n_pts,) array of evaluated values.
         """
-        if self._spectral_sharding is not None and len(c.devices()) > 1:
+        if len(c.devices()) > 1:
             dim = len(self)
             T = self.basespaces
 
@@ -286,9 +286,8 @@ class TensorProductSpace:
                 dc = "abcdef"[:dim]
                 einsum_str = ",".join(f"j{ch}" for ch in dc) + f",{dc}->j"
 
-                c_spec = self._spectral_sharding.spec
-                mesh = self._spectral_sharding.mesh
-                physical_sharding = self._physical_sharding
+                c_spec = spectral_sharding.spec
+                mesh = spectral_sharding.mesh
 
                 def _local_eval(c_loc, C0_loc, *C_rest_loc):
                     return jax.lax.psum(
@@ -319,172 +318,6 @@ class TensorProductSpace:
             orthogonal_spaces, system=self.system, name=self.name + "o"
         )
 
-    def get_transposed_sharding(self, sharding: NamedSharding) -> NamedSharding:
-        """Return the sharding with unsharded and sharded axes transposed."""
-        if sharding is self._spectral_sharding:
-            return self._physical_sharding
-        elif sharding is self._physical_sharding:
-            return self._spectral_sharding
-        else:
-            raise ValueError("Provided sharding does not match spectral or physical.")
-
-    def _build_local_apply_fn(self, ax: int, fn: ArrayFun) -> ArrayFun:
-        """Return a ``jax.jit(jax.vmap(...))`` that applies *fn* along *ax*.
-
-        The resulting callable operates on a plain (non-sharded) local array,
-        so JAX compiles it once and reuses the compiled binary on every call.
-        """
-        dim = len(self)
-        if dim == 2:
-            axi = dim - 1 - ax
-            return jax.jit(jax.vmap(fn, in_axes=axi, out_axes=axi))
-        ax0, ax1 = sorted(set(range(dim)) - {ax})
-        return jax.jit(
-            jax.vmap(
-                jax.vmap(fn, in_axes=ax0, out_axes=ax0),
-                in_axes=ax1,
-                out_axes=ax1,
-            )
-        )
-
-    def _apply_separable_spmd(
-        self,
-        c: Array,
-        fns: tuple[ArrayFun, ...],
-        sharding: NamedSharding,
-    ) -> Array:
-        """Apply separable per-axis transforms on distributed (SPMD) arrays.
-
-        The transform is split into two fully-local phases separated by a
-        single all-to-all redistribution:
-
-        * **Phase 1 — unsharded axes**: each device holds the complete extent
-          along these axes, so no communication is needed.
-        * **All-to-all**: one ``jax.device_put`` transposes the sharding from
-          the originally-sharded axes to the formerly-unsharded axes.
-        * **Phase 2 — originally-sharded axes**: now fully local after the
-          transpose.
-
-        Note:
-        * The input sharding must be either spectral or physical, depending on
-          the transform being applied.
-        * The provided fns must be in the same order as basespaces and match the
-            sharding (e.g. spectral fns applied with spectral sharding).
-        * When input sharding is spectral, the output is physical and vice versa.
-
-        """
-        dim = len(self)
-        spec = sharding.spec
-        sharded = [ax for ax in range(dim) if ax < len(spec) and spec[ax] is not None]
-        unsharded = [ax for ax in range(dim) if ax not in sharded]
-        n_local = jax.local_device_count()
-
-        # Phase 1 — unsharded axes: operate on each local addressable shard.
-        # fns[ax] is a pre-jitted vmap; XLA cache is hit on every call.
-        local_shards = [c.addressable_data(d) for d in range(n_local)]
-        for ax in unsharded:
-            local_shards = [fns[ax](shard) for shard in local_shards]
-
-        # Reconstruct the global array from the updated local shards.
-        # Unsharded axes may have changed size (e.g. Chebyshev with BCs);
-        # sharded axes retain their original global size.
-        global_shape_p1 = tuple(
-            local_shards[0].shape[ax] if ax in unsharded else c.shape[ax]
-            for ax in range(dim)
-        )
-        c = jax.make_array_from_single_device_arrays(
-            global_shape_p1, sharding, local_shards
-        )
-
-        # All-to-all: transpose the sharding (one collective, O(N^d/P) per device).
-        # The two pre-built shardings are each other's transpose by construction.
-        transposed = self.get_transposed_sharding(sharding)
-
-        c = jax.device_put(c, transposed)
-
-        # Phase 2 — originally-sharded axes: now fully local after the transpose.
-        local_shards = [c.addressable_data(d) for d in range(n_local)]
-        for ax in sharded:
-            local_shards = [fns[ax](shard) for shard in local_shards]
-
-        # Reconstruct the final global array; sharded-axis sizes may have changed.
-        global_shape_p2 = list(global_shape_p1)
-        for ax in sharded:
-            global_shape_p2[ax] = local_shards[0].shape[ax]
-        return jax.make_array_from_single_device_arrays(
-            tuple(global_shape_p2), transposed, local_shards
-        )
-
-    def _apply_separable_spmd_shard_map(
-        self,
-        c: Array,
-        fns: tuple[ArrayFun, ...],
-        sharding: NamedSharding,
-    ) -> Array:
-        """Apply separable per-axis transforms using ``shard_map`` + ``lax.all_to_all``.
-
-        JAX-native alternative to :meth:`_apply_separable_spmd`.  The entire
-        transform — including the inter-device redistribution — is a single
-        compiled XLA computation, allowing XLA to fuse across phase boundaries.
-
-        The algorithm mirrors the three-phase structure of the addressable-data
-        approach:
-
-        * **Phase 1**: unsharded-axis transforms applied locally inside the kernel.
-        * **All-to-all**: ``lax.all_to_all(tiled=True)`` transposes the sharding.
-        * **Phase 2**: originally-sharded-axis transforms applied locally.
-
-        .. note::
-            ``lax.all_to_all(tiled=True)`` requires the ``split_axis`` dimension
-            (the first unsharded axis, after Phase 1) to be divisible by the
-            total number of devices.  This holds for typical spectral sizes
-            (powers of two for Fourier, even quadrature counts for Chebyshev).
-
-        """
-        # Cache the compiled shard_map function keyed on the (fns, sharding spec)
-        # combination.  _kernel is defined inside the method, so each call would
-        # produce a new function object and force recompilation.  Storing the
-        # shard_map-wrapped callable ensures it is compiled exactly once.
-        cache_key = ("shard_map_kernel", id(fns), sharding.spec)
-        if cache_key not in self._spmd_local_fn_cache:
-            dim = len(self)
-            spec = sharding.spec
-            sharded = [
-                ax for ax in range(dim) if ax < len(spec) and spec[ax] is not None
-            ]
-            unsharded = [ax for ax in range(dim) if ax not in sharded]
-
-            transposed = self.get_transposed_sharding(sharding)
-
-            def _kernel(c_loc: Array) -> Array:
-                # Phase 1 — unsharded axes: fully local, no communication.
-                for ax in unsharded:
-                    c_loc = fns[ax](c_loc)
-                # All-to-all: redistribute sharding from sharded → unsharded axes.
-                c_loc = jax.lax.all_to_all(
-                    c_loc,
-                    axis_name="k",
-                    split_axis=unsharded[0],
-                    concat_axis=sharded[0],
-                    tiled=True,
-                )
-                # Phase 2 — originally-sharded axes: fully local after the transpose.
-                for ax in sharded:
-                    c_loc = fns[ax](c_loc)
-                return c_loc
-
-            self._spmd_local_fn_cache[cache_key] = jax.jit(
-                shard_map(
-                    _kernel,
-                    mesh=sharding.mesh,
-                    in_specs=(sharding.spec,),
-                    out_specs=transposed.spec,
-                    check_vma=False,
-                )
-            )
-
-        return self._spmd_local_fn_cache[cache_key](c)
-
     def backward(
         self,
         c: Array,
@@ -502,15 +335,18 @@ class TensorProductSpace:
         cache_key = ("backward", N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
-                self._build_local_apply_fn(
+                _build_local_apply_fn(
+                    len(self),
                     ax,
                     partial(self.basespaces[ax].backward, N=N[ax]),
                 )
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
+        if self._spectral_sharding and len(c.devices()) > 1:
+            return _apply_separable_spmd_shard_map(
+                c, fns, spectral_sharding, self._spmd_local_fn_cache
+            )
         for fn in fns:
             c = fn(c)
         return c
@@ -524,12 +360,14 @@ class TensorProductSpace:
         cache_key = ("scalar_product",)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
-                self._build_local_apply_fn(ax, self.basespaces[ax].scalar_product)
+                _build_local_apply_fn(len(self), ax, self.basespaces[ax].scalar_product)
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if self._physical_sharding is not None and len(u.devices()) > 1:
-            return self._apply_separable_spmd_shard_map(u, fns, self._physical_sharding)
+        if self._physical_sharding and len(u.devices()) > 1:
+            return _apply_separable_spmd_shard_map(
+                u, fns, physical_sharding, self._spmd_local_fn_cache
+            )
         for fn in fns:
             u = fn(u)
         return u
@@ -539,12 +377,14 @@ class TensorProductSpace:
         cache_key = ("forward",)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
-                self._build_local_apply_fn(ax, self.basespaces[ax].forward)
+                _build_local_apply_fn(len(self), ax, self.basespaces[ax].forward)
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if self._physical_sharding is not None and len(u.devices()) > 1:
-            return self._apply_separable_spmd_shard_map(u, fns, self._physical_sharding)
+        if self._physical_sharding and len(u.devices()) > 1:
+            return _apply_separable_spmd_shard_map(
+                u, fns, physical_sharding, self._spmd_local_fn_cache
+            )
         for fn in fns:
             u = fn(u)
         return u
@@ -563,7 +403,8 @@ class TensorProductSpace:
         cache_key = ("backward_primitive", k, N)
         if cache_key not in self._spmd_local_fn_cache:
             self._spmd_local_fn_cache[cache_key] = tuple(
-                self._build_local_apply_fn(
+                _build_local_apply_fn(
+                    len(self),
                     ax,
                     partial(
                         self.basespaces[ax].backward_primitive,
@@ -574,8 +415,10 @@ class TensorProductSpace:
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if self._spectral_sharding is not None and len(c.devices()) > 1:
-            return self._apply_separable_spmd_shard_map(c, fns, self._spectral_sharding)
+        if self._spectral_sharding and len(c.devices()) > 1:
+            return _apply_separable_spmd_shard_map(
+                c, fns, spectral_sharding, self._spmd_local_fn_cache
+            )
         for fn in fns:
             c = fn(c)
         return c
@@ -583,18 +426,18 @@ class TensorProductSpace:
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped to underlying orthogonal basis."""
         dim = len(self)
-        if self._spectral_sharding is not None and len(c.devices()) > 1:
+        if self._spectral_sharding and len(c.devices()) > 1:
             S = [s.S for s in self.basespaces]
             cache_key = "to_orthogonal"
             if cache_key not in self._spmd_local_fn_cache:
                 self._spmd_local_fn_cache[cache_key] = tuple(
-                    self._build_local_apply_fn(ax, S[ax].rmatvec) for ax in range(dim)
+                    _build_local_apply_fn(dim, ax, S[ax].rmatvec) for ax in range(dim)
                 )
             fns = self._spmd_local_fn_cache[cache_key]
-            result = self._apply_separable_spmd_shard_map(
-                c, fns, self._spectral_sharding
+            result = _apply_separable_spmd_shard_map(
+                c, fns, spectral_sharding, self._spmd_local_fn_cache
             )
-            return jax.device_put(result, self._spectral_sharding)
+            return jax.device_put(result, spectral_sharding)
         if dim == 2:
             S = [s.S for s in self.basespaces]
             return S[0].T @ c @ S[1]
@@ -605,16 +448,18 @@ class TensorProductSpace:
         """Return coefficients c mapped from underlying orthogonal basis."""
         S = [s.get_inverse_stencil() for s in self.basespaces]
         dim = len(self)
-        if self._physical_sharding is not None and len(c.devices()) > 1:
+        if self._physical_sharding and len(c.devices()) > 1:
             cache_key = "from_orthogonal"
             if cache_key not in self._spmd_local_fn_cache:
                 self._spmd_local_fn_cache[cache_key] = tuple(
-                    self._build_local_apply_fn(ax, lambda x, _S=S[ax]: jnp.dot(x, _S))
+                    _build_local_apply_fn(dim, ax, lambda x, _S=S[ax]: jnp.dot(x, _S))
                     for ax in range(dim)
                 )
             fns = self._spmd_local_fn_cache[cache_key]
             c = jax.device_put(c, self._physical_sharding)
-            return self._apply_separable_spmd_shard_map(c, fns, self._physical_sharding)
+            return _apply_separable_spmd_shard_map(
+                c, fns, self._physical_sharding, self._spmd_local_fn_cache
+            )
         if dim == 2:
             return S[0].T @ c @ S[1]
         return jnp.einsum("is,jp,kl,ijk->spl", *S, c)
@@ -653,17 +498,14 @@ class VectorTensorProductSpace:
         self.num_quad_points = self.tensorspaces[0].num_quad_points
         # Slab decomposition for vector spaces
         # First index is vector component, which is not sharded.
-        self._spmd_mesh = Mesh(jax.devices(), ("k",))
         self._spectral_sharding: NamedSharding | None = (
-            None
-            if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P(None, "k"))
+            None if len(jax.devices()) == 1 else NamedSharding(spmd_mesh, P(None, "k"))
         )
         # Sharding of arrays in physical space.
         self._physical_sharding: NamedSharding | None = (
             None
             if len(jax.devices()) == 1
-            else NamedSharding(self._spmd_mesh, P(None, None, "k"))
+            else NamedSharding(spmd_mesh, P(None, None, "k"))
         )
 
     def __len__(self) -> int:
@@ -890,6 +732,8 @@ class DirectSumTPS(TensorProductSpace):
         self.name = name
         self.bndvals: dict[tuple[OrthogonalSpace, ...], Array] = {}
         self.tensorname = tensor_product_symbol.join([b.name for b in basespaces])
+        self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
+        self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
 
         # Normalize symbolic BC expressions to base scalar form
         for space in basespaces:
@@ -986,14 +830,6 @@ class DirectSumTPS(TensorProductSpace):
                 else:
                     self.bndvals[tensorspace] = jnp.array(uh).T
         self.orthogonal = self.get_orthogonal()
-
-    @property
-    def _physical_sharding(self) -> NamedSharding | None:
-        return self.tpspaces[next(iter(self.tpspaces))]._physical_sharding
-
-    @property
-    def _spectral_sharding(self) -> NamedSharding | None:
-        return self.tpspaces[next(iter(self.tpspaces))]._spectral_sharding
 
     def split(
         self, spaces: list[OrthogonalSpace | DirectSum]

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -243,7 +243,7 @@ class TensorProductSpace:
                 for ax in range(len(self))
             )
         fns = self._spmd_local_fn_cache[cache_key]
-        if len(c.devices()) > 1:
+        if self._spectral_sharding and len(c.devices()) > 1:
             return _apply_separable_spmd_shard_map(
                 c, fns, spectral_sharding, self._spmd_local_fn_cache
             )
@@ -273,7 +273,7 @@ class TensorProductSpace:
         Returns:
             Scalar or (n_pts,) array of evaluated values.
         """
-        if len(c.devices()) > 1:
+        if self._spectral_sharding and len(c.devices()) > 1:
             dim = len(self)
             T = self.basespaces
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -10,7 +10,6 @@ import jax
 import jax.numpy as jnp
 import sympy as sp
 from jax import Array, shard_map
-from jax._src.sharding import IndivisibleError
 from jax.sharding import NamedSharding, PartitionSpec as P
 
 from jaxfun.coordinates import CoordSys
@@ -29,6 +28,8 @@ from .orthogonal import OrthogonalSpace
 
 tensor_product_symbol = "\u2297"
 multiplication_sign = "\u00d7"
+
+IndivisibleError = ValueError
 
 
 class TensorProductSpace:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -10,6 +10,7 @@ import jax
 import jax.numpy as jnp
 import sympy as sp
 from jax import Array, shard_map
+from jax._src.sharding import IndivisibleError
 from jax.sharding import NamedSharding, PartitionSpec as P
 
 from jaxfun.coordinates import CoordSys
@@ -287,7 +288,7 @@ class TensorProductSpace:
                 einsum_str = ",".join(f"j{ch}" for ch in dc) + f",{dc}->j"
 
                 c_spec = spectral_sharding.spec
-                mesh = spectral_sharding.mesh
+                p_spec = physical_sharding.spec
 
                 def _local_eval(c_loc, C0_loc, *C_rest_loc):
                     return jax.lax.psum(
@@ -298,9 +299,8 @@ class TensorProductSpace:
                     C0_sharded = jax.device_put(C0, physical_sharding)
                     return shard_map(
                         _local_eval,
-                        mesh=mesh,
-                        in_specs=(c_spec, P(None, "k"))
-                        + tuple(P() for _ in range(1, dim)),
+                        mesh=spectral_sharding.mesh,
+                        in_specs=(c_spec, p_spec) + tuple(P() for _ in range(1, dim)),
                         out_specs=P(),
                         check_vma=False,
                     )(c, C0_sharded, *C_rest)
@@ -426,43 +426,36 @@ class TensorProductSpace:
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped to underlying orthogonal basis."""
         dim = len(self)
-        if self._spectral_sharding and len(c.devices()) > 1:
-            S = [s.S for s in self.basespaces]
-            cache_key = "to_orthogonal"
-            if cache_key not in self._spmd_local_fn_cache:
-                self._spmd_local_fn_cache[cache_key] = tuple(
-                    _build_local_apply_fn(dim, ax, S[ax].rmatvec) for ax in range(dim)
-                )
-            fns = self._spmd_local_fn_cache[cache_key]
-            result = _apply_separable_spmd_shard_map(
-                c, fns, spectral_sharding, self._spmd_local_fn_cache
-            )
-            return jax.device_put(result, spectral_sharding)
+        sharding = self._spectral_sharding
         if dim == 2:
             S = [s.S for s in self.basespaces]
-            return S[0].T @ c @ S[1]
-        S = [s.S.todense() for s in self.basespaces]
-        return jnp.einsum("is,jp,kl,ijk->spl", *S, c)
+            z = S[0].T @ c @ S[1]
+        else:
+            S = [s.S for s in self.basespaces]
+            # z = jnp.einsum("is,jp,kl,ijk->spl", *S, c)
+            z = c
+            for i, Si in enumerate(S):
+                z = Si.rmatvec(z, axis=i)
+
+        if sharding:  # return sharded if possible, otherwise fallback to replicated
+            try:
+                return jax.device_put(z, sharding)
+            except IndivisibleError:
+                pass
+        return z
 
     def from_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped from underlying orthogonal basis."""
+        sharding = self._spectral_sharding
         S = [s.get_inverse_stencil() for s in self.basespaces]
         dim = len(self)
-        if self._physical_sharding and len(c.devices()) > 1:
-            cache_key = "from_orthogonal"
-            if cache_key not in self._spmd_local_fn_cache:
-                self._spmd_local_fn_cache[cache_key] = tuple(
-                    _build_local_apply_fn(dim, ax, lambda x, _S=S[ax]: jnp.dot(x, _S))
-                    for ax in range(dim)
-                )
-            fns = self._spmd_local_fn_cache[cache_key]
-            c = jax.device_put(c, self._physical_sharding)
-            return _apply_separable_spmd_shard_map(
-                c, fns, self._physical_sharding, self._spmd_local_fn_cache
-            )
-        if dim == 2:
-            return S[0].T @ c @ S[1]
-        return jnp.einsum("is,jp,kl,ijk->spl", *S, c)
+        z = S[0].T @ c @ S[1] if dim == 2 else jnp.einsum("is,jp,kl,ijk->spl", *S, c)
+        if sharding:  # return sharded if possible, otherwise fallback to replicated
+            try:
+                return jax.device_put(z, sharding)
+            except IndivisibleError:
+                pass
+        return z
 
 
 class VectorTensorProductSpace:
@@ -904,50 +897,39 @@ class DirectSumTPS(TensorProductSpace):
 
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped to underlying orthogonal basis."""
-        result: Array | None = None
-        sharding = self.orthogonal._spectral_sharding
+        result = self.get_homogeneous().to_orthogonal(c)
+
         for f, v in self.tpspaces.items():
             inp = self.bndvals.get(f, c)
-            ai = v.to_orthogonal(inp)
-            # bndvals are computed replicated (local).  When inp is bndvals
-            # rather than c, ai is a single-device array; shard it to the
-            # spectral sharding so it can be combined with the sharded result
-            # from c.
-            if sharding is not None and inp is not c:
-                ai = jax.device_put(ai, sharding)
-            if result is None:
-                result = ai
-            else:
-                result = result + jnp.pad(
-                    ai,
-                    [
-                        (0, result.shape[0] - ai.shape[0]),
-                        (0, result.shape[1] - ai.shape[1]),
-                    ],
-                )
-        assert result is not None
+            if inp is c:
+                continue
+            ai = v.to_orthogonal(inp)  # sharded if possible
+            result = result + jnp.pad(
+                ai,
+                [(0, result.shape[i] - ai.shape[i]) for i in range(c.ndim)],
+            )
+
         return result
 
     def from_orthogonal(self, c: Array) -> Array:
         """Return coefficients c mapped from underlying orthogonal basis."""
-        result: Array | None = None
-        sharding = self.orthogonal._spectral_sharding
+        # Note that c may be replicated, because the orthogonal space is not the
+        # same as the original space, so we can't assume the sharding is compatible.
+
+        result: Array = jnp.zeros(1)
+
         for f, v in self.tpspaces.items():
-            if f in self.bndvals:
-                ai = -v.to_orthogonal(self.bndvals[f])
-                if sharding is not None:
-                    ai = jax.device_put(ai, sharding)
-            else:
-                ai = c
-            if result is None:
-                result = ai
-            else:
-                result = result + jnp.pad(
-                    ai,
-                    [
-                        (0, result.shape[0] - ai.shape[0]),
-                        (0, result.shape[1] - ai.shape[1]),
-                    ],
-                )
-        assert result is not None
+            inp = self.bndvals.get(f, c)
+            if inp is c:
+                continue
+            ai = -v.to_orthogonal(inp)  # sharded if possible
+            result = result + jnp.pad(
+                ai,
+                [(0, c.shape[i] - ai.shape[i]) for i in range(c.ndim)],
+            )
+        # ensure replicated result is on same sharding as c
+        try:
+            result = c + jax.device_put(result, c.sharding)
+        except IndivisibleError:
+            result = c + result
         return self.get_homogeneous().from_orthogonal(result)

--- a/src/jaxfun/sharding.py
+++ b/src/jaxfun/sharding.py
@@ -18,7 +18,7 @@ def get_transposed_sharding(sharding: NamedSharding) -> NamedSharding:
     elif sharding.spec == P(None, "k"):
         return spectral_sharding
     else:
-        raise ValueError("Provided sharding does not match spectral or physical.")
+        raise ValueError(f"Provided {sharding} does not match spectral or physical.")
 
 
 def _build_local_apply_fn(dim: int, ax: int, fn: ArrayFun) -> ArrayFun:
@@ -105,6 +105,7 @@ def _apply_separable_spmd_shard_map(
     return cache[cache_key](c)
 
 
+# Experimental:
 def _apply_separable_spmd(
     c: Array,
     fns: tuple[ArrayFun, ...],

--- a/src/jaxfun/sharding.py
+++ b/src/jaxfun/sharding.py
@@ -13,9 +13,9 @@ physical_sharding = NamedSharding(spmd_mesh, P(None, "k"))
 
 def get_transposed_sharding(sharding: NamedSharding) -> NamedSharding:
     """Return the sharding with unsharded and sharded axes transposed."""
-    if sharding.spec == P("k"):
+    if sharding == spectral_sharding:
         return physical_sharding
-    elif sharding.spec == P(None, "k"):
+    elif sharding == physical_sharding:
         return spectral_sharding
     else:
         raise ValueError(f"Provided {sharding} does not match spectral or physical.")

--- a/src/jaxfun/sharding.py
+++ b/src/jaxfun/sharding.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import jax
+from jax import shard_map
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+
+from jaxfun.typing import Array, ArrayFun
+
+spmd_mesh = Mesh(jax.devices(), ("k",))
+spectral_sharding = NamedSharding(spmd_mesh, P("k"))
+physical_sharding = NamedSharding(spmd_mesh, P(None, "k"))
+
+
+def get_transposed_sharding(sharding: NamedSharding) -> NamedSharding:
+    """Return the sharding with unsharded and sharded axes transposed."""
+    if sharding.spec == P("k"):
+        return physical_sharding
+    elif sharding.spec == P(None, "k"):
+        return spectral_sharding
+    else:
+        raise ValueError("Provided sharding does not match spectral or physical.")
+
+
+def _build_local_apply_fn(dim: int, ax: int, fn: ArrayFun) -> ArrayFun:
+    """Return a ``jax.jit(jax.vmap(...))`` that applies *fn* along *ax*.
+
+    The resulting callable operates on a plain (non-sharded) local array,
+    so JAX compiles it once and reuses the compiled binary on every call.
+    """
+    if dim == 2:
+        axi = dim - 1 - ax
+        return jax.jit(jax.vmap(fn, in_axes=axi, out_axes=axi))
+    ax0, ax1 = sorted(set(range(dim)) - {ax})
+    return jax.jit(
+        jax.vmap(
+            jax.vmap(fn, in_axes=ax0, out_axes=ax0),
+            in_axes=ax1,
+            out_axes=ax1,
+        )
+    )
+
+
+def _apply_separable_spmd_shard_map(
+    c: Array, fns: tuple[ArrayFun, ...], sharding: NamedSharding, cache: dict
+) -> Array:
+    """Apply separable per-axis transforms using ``shard_map`` + ``lax.all_to_all``.
+
+    JAX-native alternative to :meth:`_apply_separable_spmd`.  The entire
+    transform — including the inter-device redistribution — is a single
+    compiled XLA computation, allowing XLA to fuse across phase boundaries.
+
+    The algorithm mirrors the three-phase structure of the addressable-data
+    approach:
+
+    * **Phase 1**: unsharded-axis transforms applied locally inside the kernel.
+    * **All-to-all**: ``lax.all_to_all(tiled=True)`` transposes the sharding.
+    * **Phase 2**: originally-sharded-axis transforms applied locally.
+
+    .. note::
+        ``lax.all_to_all(tiled=True)`` requires the ``split_axis`` dimension
+        (the first unsharded axis, after Phase 1) to be divisible by the
+        total number of devices.  This holds for typical spectral sizes
+        (powers of two for Fourier, even quadrature counts for Chebyshev).
+
+    """
+    # Cache the compiled shard_map function keyed on the (fns, sharding spec)
+    # combination.  _kernel is defined inside the method, so each call would
+    # produce a new function object and force recompilation.  Storing the
+    # shard_map-wrapped callable ensures it is compiled exactly once.
+    cache_key = ("shard_map_kernel", id(fns), sharding.spec)
+    if cache_key not in cache:
+        dim = c.ndim
+        spec = sharding.spec
+        sharded = [ax for ax in range(dim) if ax < len(spec) and spec[ax] is not None]
+        unsharded = [ax for ax in range(dim) if ax not in sharded]
+        transposed = get_transposed_sharding(sharding)
+
+        def _kernel(c_loc: Array) -> Array:
+            # Phase 1 — unsharded axes: fully local, no communication.
+            for ax in unsharded:
+                c_loc = fns[ax](c_loc)
+            # All-to-all: redistribute sharding from sharded → unsharded axes.
+            c_loc = jax.lax.all_to_all(
+                c_loc,
+                axis_name="k",
+                split_axis=unsharded[0],
+                concat_axis=sharded[0],
+                tiled=True,
+            )
+            # Phase 2 — originally-sharded axes: fully local after the transpose.
+            for ax in sharded:
+                c_loc = fns[ax](c_loc)
+            return c_loc
+
+        cache[cache_key] = jax.jit(
+            shard_map(
+                _kernel,
+                mesh=sharding.mesh,
+                in_specs=(sharding.spec,),
+                out_specs=transposed.spec,
+                check_vma=False,
+            )
+        )
+
+    return cache[cache_key](c)
+
+
+def _apply_separable_spmd(
+    c: Array,
+    fns: tuple[ArrayFun, ...],
+    sharding: NamedSharding,
+) -> Array:
+    """Apply separable per-axis transforms on distributed (SPMD) arrays.
+
+    The transform is split into two fully-local phases separated by a
+    single all-to-all redistribution:
+
+    * **Phase 1 — unsharded axes**: each device holds the complete extent
+      along these axes, so no communication is needed.
+    * **All-to-all**: one ``jax.device_put`` transposes the sharding from
+      the originally-sharded axes to the formerly-unsharded axes.
+    * **Phase 2 — originally-sharded axes**: now fully local after the
+      transpose.
+
+    Note:
+    * The input sharding must be either spectral or physical, depending on
+      the transform being applied.
+    * The provided fns must be in the same order as basespaces and match the
+        sharding (e.g. spectral fns applied with spectral sharding).
+    * When input sharding is spectral, the output is physical and vice versa.
+
+    """
+    dim = c.ndim
+    spec = sharding.spec
+    sharded = [ax for ax in range(dim) if ax < len(spec) and spec[ax] is not None]
+    unsharded = [ax for ax in range(dim) if ax not in sharded]
+    n_local = jax.local_device_count()
+
+    # Phase 1 — unsharded axes: operate on each local addressable shard.
+    # fns[ax] is a pre-jitted vmap; XLA cache is hit on every call.
+    local_shards = [c.addressable_data(d) for d in range(n_local)]
+    for ax in unsharded:
+        local_shards = [fns[ax](shard) for shard in local_shards]
+
+    # Reconstruct the global array from the updated local shards.
+    # Unsharded axes may have changed size (e.g. Chebyshev with BCs);
+    # sharded axes retain their original global size.
+    global_shape_p1 = tuple(
+        local_shards[0].shape[ax] if ax in unsharded else c.shape[ax]
+        for ax in range(dim)
+    )
+    c = jax.make_array_from_single_device_arrays(
+        global_shape_p1, sharding, local_shards
+    )
+
+    # All-to-all: transpose the sharding (one collective, O(N^d/P) per device).
+    # The two pre-built shardings are each other's transpose by construction.
+    transposed = get_transposed_sharding(sharding)
+
+    c = jax.device_put(c, transposed)
+
+    # Phase 2 — originally-sharded axes: now fully local after the transpose.
+    local_shards = [c.addressable_data(d) for d in range(n_local)]
+    for ax in sharded:
+        local_shards = [fns[ax](shard) for shard in local_shards]
+
+    # Reconstruct the final global array; sharded-axis sizes may have changed.
+    global_shape_p2 = list(global_shape_p1)
+    for ax in sharded:
+        global_shape_p2[ax] = local_shards[0].shape[ax]
+    return jax.make_array_from_single_device_arrays(
+        tuple(global_shape_p2), transposed, local_shards
+    )

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from jaxfun.galerkin.arguments import Jaxc
     from jaxfun.galerkin.orthogonal import OrthogonalSpace
 
-
 type FloatLike = float | sp.Number
 type Padding = int | tuple[int | None, ...] | tuple[tuple[int | None, ...], ...] | None
 type FunctionSpaceType = (

--- a/tests/galerkin/test_evaluate_spmd.py
+++ b/tests/galerkin/test_evaluate_spmd.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import pytest
 import sympy as sp
@@ -12,6 +13,9 @@ from jaxfun.galerkin.inner import project
 from jaxfun.utils.common import lambdify, ulp
 
 pytestmark = pytest.mark.spmd
+
+if jax.device_count() not in (1, 2, 4):
+    pytest.skip("SPMD tests require 1, 2 or 4 devices", allow_module_level=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -24,6 +24,7 @@ from jaxfun.galerkin import (
     TensorProduct,
 )
 from jaxfun.galerkin.inner import project
+from jaxfun.sharding import physical_sharding, spectral_sharding
 from jaxfun.utils.common import ulp
 
 pytestmark = pytest.mark.spmd
@@ -67,9 +68,9 @@ def test_forward_backward_2d_spmd(space0, space1) -> None:
 )
 def test_scalar_product_2d_spmd(space0, space1) -> None:
     T = TensorProduct(space0(8), space1(8))
-    u = jax.device_put(jnp.ones(T.shape()), T._physical_sharding)
+    u = jax.device_put(jnp.ones(T.shape()), physical_sharding)
     uh = T.scalar_product(u)
-    assert uh.sharding == T._spectral_sharding
+    assert uh.sharding == spectral_sharding
 
 
 # ---------------------------------------------------------------------------
@@ -106,9 +107,9 @@ def test_forward_backward_3d_spmd(space0, space1, space2) -> None:
 )
 def test_scalar_product_3d_spmd(space0, space1, space2) -> None:
     T = TensorProduct(space0(8), space1(8), space2(8))
-    u = jax.device_put(jnp.ones(T.shape()), T._physical_sharding)
+    u = jax.device_put(jnp.ones(T.shape()), physical_sharding)
     uh = T.scalar_product(u)
-    assert uh.sharding == T._spectral_sharding
+    assert uh.sharding == spectral_sharding
 
 
 @pytest.mark.parametrize("domain", [(-1, 1), (0, 2), (-2, 2)])

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -29,6 +29,8 @@ from jaxfun.utils.common import ulp
 
 pytestmark = pytest.mark.spmd
 
+if jax.device_count() not in (1, 2, 4):
+    pytest.skip("SPMD tests require 1, 2 or 4 devices", allow_module_level=True)
 
 # ---------------------------------------------------------------------------
 # 2-D

--- a/tests/galerkin/test_to_from_orthogonal_spmd.py
+++ b/tests/galerkin/test_to_from_orthogonal_spmd.py
@@ -12,7 +12,7 @@ from jaxfun.utils import ulp
 
 pytestmark = pytest.mark.spmd
 
-assert jax.device_count() in (2, 4), "SPMD tests require 2 or 4 devices"
+assert jax.device_count() in (1, 2, 4), "SPMD tests require 1, 2 or 4 devices"
 
 
 @pytest.fixture(
@@ -45,7 +45,7 @@ def test_to_from_orthogonal_2d_fourier_directsum(jspace: type[Jacobi]):
     N = 10
     bcs = {"left": {"D": 1}, "right": {"D": 1}}
     D = FunctionSpace(N, jspace, bcs=bcs)
-    F = FunctionSpace(N, Fourier, name="F", fun_str="E")
+    F = FunctionSpace(N - 2, Fourier, name="F", fun_str="E")
     T = TensorProduct(F, D)
     u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
     assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(100)
@@ -64,7 +64,7 @@ def test_to_from_orthogonal_fourier_3d(jspace: type[Jacobi]):
     N = 10
     bcs = {"left": {"D": 0}, "right": {"D": 0}}
     D = FunctionSpace(N, jspace, bcs=bcs)
-    F = FunctionSpace(N, Fourier, name="F", fun_str="E")
+    F = FunctionSpace(N - 2, Fourier, name="F", fun_str="E")
     T = TensorProduct(F, D, D)
     u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
     assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(1000)

--- a/tests/galerkin/test_to_from_orthogonal_spmd.py
+++ b/tests/galerkin/test_to_from_orthogonal_spmd.py
@@ -1,20 +1,18 @@
+import jax
 import jax.numpy as jnp
 import pytest
 
 from jaxfun.galerkin import FunctionSpace, TensorProduct
 from jaxfun.galerkin.Chebyshev import Chebyshev
+from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.Jacobi import Jacobi
 from jaxfun.galerkin.Legendre import Legendre
-from jaxfun.utils import Domain, ulp
+from jaxfun.sharding import spectral_sharding
+from jaxfun.utils import ulp
 
 pytestmark = pytest.mark.spmd
 
-
-@pytest.fixture(
-    params=(Domain(-1, 1), Domain(-2, 2)), ids=("domain-default", "domain-mapped")
-)
-def domain(request: pytest.FixtureRequest) -> Domain:
-    return request.param
+assert jax.device_count() in (2, 4), "SPMD tests require 2 or 4 devices"
 
 
 @pytest.fixture(
@@ -25,28 +23,48 @@ def jspace(request: pytest.FixtureRequest) -> type[Jacobi]:
     return request.param
 
 
-def test_to_from_orthogonal_2d(jspace: type[Jacobi], domain: Domain):
-    N = 8
+def test_to_from_orthogonal_2d(jspace: type[Jacobi]):
+    N = 10
     bcs = {"left": {"D": 0}, "right": {"D": 0}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
+    D = FunctionSpace(N, jspace, bcs=bcs)
     T = TensorProduct(D, D)
-    u = jnp.ones(T.num_dofs)
+    u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
     assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(100)
 
 
-def test_to_from_orthogonal_2d_directsum(jspace: type[Jacobi], domain: Domain):
-    N = 8
+def test_to_from_orthogonal_2d_directsum(jspace: type[Jacobi]):
+    N = 10
     bcs = {"left": {"D": 1}, "right": {"D": 1}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
+    D = FunctionSpace(N, jspace, bcs=bcs)
     T = TensorProduct(D, D)
-    u = jnp.ones(T.num_dofs)
+    u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
     assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(100)
 
 
-def test_to_from_orthogonal_3d(jspace: type[Jacobi], domain: Domain):
-    N = 8
+def test_to_from_orthogonal_2d_fourier_directsum(jspace: type[Jacobi]):
+    N = 10
+    bcs = {"left": {"D": 1}, "right": {"D": 1}}
+    D = FunctionSpace(N, jspace, bcs=bcs)
+    F = FunctionSpace(N, Fourier, name="F", fun_str="E")
+    T = TensorProduct(F, D)
+    u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
+    assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(100)
+
+
+def test_to_from_orthogonal_3d(jspace: type[Jacobi]):
+    N = 10
     bcs = {"left": {"D": 0}, "right": {"D": 0}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
+    D = FunctionSpace(N, jspace, bcs=bcs)
     T = TensorProduct(D, D, D)
-    u = jnp.ones(T.num_dofs)
+    u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
+    assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(1000)
+
+
+def test_to_from_orthogonal_fourier_3d(jspace: type[Jacobi]):
+    N = 10
+    bcs = {"left": {"D": 0}, "right": {"D": 0}}
+    D = FunctionSpace(N, jspace, bcs=bcs)
+    F = FunctionSpace(N, Fourier, name="F", fun_str="E")
+    T = TensorProduct(F, D, D)
+    u = jax.device_put(jnp.ones(T.num_dofs), spectral_sharding)
     assert jnp.linalg.norm(u - T.from_orthogonal(T.to_orthogonal(u))) < ulp(1000)

--- a/tests/galerkin/test_to_from_orthogonal_spmd.py
+++ b/tests/galerkin/test_to_from_orthogonal_spmd.py
@@ -12,7 +12,8 @@ from jaxfun.utils import ulp
 
 pytestmark = pytest.mark.spmd
 
-assert jax.device_count() in (1, 2, 4), "SPMD tests require 1, 2 or 4 devices"
+if jax.device_count() not in (1, 2, 4):
+    pytest.skip("SPMD tests require 1, 2 or 4 devices", allow_module_level=True)
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Summary

Explain the motivation for this change. Link related issues or discussions.

## Types of Changes

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] Other (describe):

## Description of Changes

The sharding mesh and NamedSharding as well as parallel helper functions are placed in own file sharding.py outside TensorProductSpace class. 

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [x] Coverage does not decrease
- [x] Git history is clean (squash/fixup before merge)
