### PR TITLE
Test cleanup

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,33 +15,179 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: python
+  fast:
+    name: fast tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv (with caching)
+      - name: Install uv with caching
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
-      - name: Sync deps once
+      - name: Sync deps
         run: uv sync --frozen --all-groups
 
-      - name: Run fast tests (default, excludes slow)
-        run: |
-          uv run pytest -m 'not slow'
-          uv run pytest --float64 -m 'not slow'
+      - name: Run fast tests
+        run: uv run pytest -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
 
-      - name: Run SPMD tests (2 virtual CPU devices)
-        run: |
-          uv run pytest --num-devices=2
-          uv run pytest --float64 --num-devices=2
-          uv run pytest -m slow --num-devices=2
-          uv run pytest --float64 -m slow --num-devices=2
+  fast-float64:
+    name: fast tests, x64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-      - name: Run slow demo tests
-        run: |
-          uv run pytest -m slow
-          uv run pytest --float64 -m slow
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run fast tests in x64 mode
+        run: uv run pytest --float64 -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
+
+  smoke:
+    name: smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run smoke tests
+        run: uv run pytest -m smoke
+
+  integration:
+    name: integration tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run integration tests
+        run: uv run pytest -m "integration and not slow and not spmd and not pinn and not examples and not gpu"
+
+  slow:
+    name: slow tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run slow non-example tests
+        run: uv run pytest -m "slow and not examples and not spmd and not pinn and not gpu"
+
+  examples:
+    name: example tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run example tests
+        run: uv run pytest -m "examples and not spmd and not gpu"
+
+  pinn:
+    name: PINN tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run PINN tests
+        run: uv run pytest -m "pinn and not gpu"
+
+  spmd:
+    name: SPMD tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run SPMD tests
+        run: uv run pytest --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
+
+  spmd-float64:
+    name: SPMD tests, x64
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run SPMD tests in x64 mode
+        run: uv run pytest --float64 --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
+
+  spmd-examples:
+    name: SPMD example tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync deps
+        run: uv sync --frozen --all-groups
+
+      - name: Run SPMD example tests
+        run: uv run pytest --num-devices=2 -m "spmd and examples and not gpu"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,9 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fast:
-    name: fast tests
+  quick:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: fast tests
+            command: uv run pytest -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
+
+          - name: fast tests, x64
+            command: uv run pytest --float64 -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
+
+          - name: smoke tests
+            command: uv run pytest -m smoke
+
     steps:
       - uses: actions/checkout@v6
 
@@ -29,12 +41,38 @@ jobs:
       - name: Sync deps
         run: uv sync --frozen --all-groups
 
-      - name: Run fast tests
-        run: uv run pytest -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
+      - name: Run tests
+        run: ${{ matrix.command }}
 
-  fast-float64:
-    name: fast tests, x64
+  full:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: integration tests
+            command: uv run pytest -m "integration and not slow and not spmd and not pinn and not examples and not gpu"
+
+          - name: slow tests
+            command: uv run pytest -m "slow and not examples and not spmd and not pinn and not gpu"
+
+          - name: example tests
+            command: uv run pytest -m "examples and not spmd and not gpu"
+
+          - name: PINN tests
+            command: uv run pytest -m "pinn and not gpu"
+
+          - name: SPMD tests
+            command: uv run pytest --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
+
+          - name: SPMD tests, x64
+            command: uv run pytest --float64 --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
+
+          - name: SPMD example tests
+            command: uv run pytest --num-devices=2 -m "spmd and examples and not gpu"
+
     steps:
       - uses: actions/checkout@v6
 
@@ -46,148 +84,5 @@ jobs:
       - name: Sync deps
         run: uv sync --frozen --all-groups
 
-      - name: Run fast tests in x64 mode
-        run: uv run pytest --float64 -m "not slow and not integration and not examples and not pinn and not gpu and not spmd"
-
-  smoke:
-    name: smoke tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run smoke tests
-        run: uv run pytest -m smoke
-
-  integration:
-    name: integration tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run integration tests
-        run: uv run pytest -m "integration and not slow and not spmd and not pinn and not examples and not gpu"
-
-  slow:
-    name: slow tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run slow non-example tests
-        run: uv run pytest -m "slow and not examples and not spmd and not pinn and not gpu"
-
-  examples:
-    name: example tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run example tests
-        run: uv run pytest -m "examples and not spmd and not gpu"
-
-  pinn:
-    name: PINN tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run PINN tests
-        run: uv run pytest -m "pinn and not gpu"
-
-  spmd:
-    name: SPMD tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run SPMD tests
-        run: uv run pytest --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
-
-  spmd-float64:
-    name: SPMD tests, x64
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run SPMD tests in x64 mode
-        run: uv run pytest --float64 --num-devices=2 -m "spmd and not slow and not examples and not pinn and not gpu"
-
-  spmd-examples:
-    name: SPMD example tests
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync deps
-        run: uv sync --frozen --all-groups
-
-      - name: Run SPMD example tests
-        run: uv run pytest --num-devices=2 -m "spmd and examples and not gpu"
+      - name: Run tests
+        run: ${{ matrix.command }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,6 +61,9 @@ jobs:
           - name: example tests
             command: uv run pytest -m "examples and not spmd and not gpu"
 
+          - name: example tests, x64
+            command: uv run pytest --float64 -m "examples and not spmd and not gpu"
+
           - name: PINN tests
             command: uv run pytest -m "pinn and not gpu"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
   full:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -80,7 +80,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
         with:
           enable-cache: true
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,9 @@ jobs:
   quick:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,11 @@ uv run pre-commit install
 Run tests:
 
 ```bash
-uv run pytest -q
+uv run pytest
 ```
+
+See [docs/testing.md](docs/testing.md) for marker-specific commands and test
+tier guidance.
 
 Run pre-commit checks locally before pushing:
 
@@ -54,6 +57,7 @@ uv run pre-commit run --all-files
 - Add tests for new features or bug fixes
 - Aim for coverage >= existing module average; avoid regressions
 - Use parametrization for concise test cases
+- Mark expensive tests with the appropriate pytest tier marker
 
 ## Documentation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,8 @@ with `-n0` unless the test has its own serialization mechanism.
 
 ## CI Tiers
 
-Pull requests run fast default tests, fast x64 tests, and the smoke suite.
+Pull requests and branch pushes run fast default tests, fast x64 tests, and the
+smoke suite.
 
 Pushes to `main`, manual workflow runs, and the nightly schedule also run
 integration, slow, example, PINN, SPMD, and SPMD x64 jobs. The jobs are split

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,64 @@
+# Testing
+
+`jaxfun` uses pytest markers to keep local feedback fast while preserving
+slower numerical and end-to-end confidence checks.
+
+## Common Commands
+
+```bash
+# Fast local tests
+uv run pytest
+
+# Fast tests in x64 mode
+uv run pytest --float64
+
+# Smoke tests
+uv run pytest -m smoke
+
+# Slow tests
+uv run pytest -m slow
+
+# Integration tests
+uv run pytest -m integration
+
+# PINN tests
+uv run pytest -m pinn
+
+# SPMD tests
+uv run pytest --num-devices=2 -m spmd
+
+# Full local suite except GPU-only tests
+uv run pytest -m "not gpu"
+```
+
+## Marker Guide
+
+Use no marker for small unit tests that should run by default.
+
+Use `smoke` for a small end-to-end test that exercises a realistic user-facing
+flow and is cheap enough for every pull request.
+
+Use `integration` for tests that solve a complete problem or combine several
+subsystems. Add `slow` as well when the test is long-running.
+
+Use `examples` with `slow` for full example-script execution.
+
+Use `pinn` for neural-network and PINN tests. Add `slow` to longer training
+loops or expensive model checks.
+
+Use `spmd` for tests that require more than one JAX device. Run these with
+`--num-devices=2` or a larger device count.
+
+Use `gpu` for tests that require a GPU backend.
+
+Use `serial` for tests that must not run under pytest-xdist. Run serial tests
+with `-n0` unless the test has its own serialization mechanism.
+
+## CI Tiers
+
+Pull requests run fast default tests, fast x64 tests, and the smoke suite.
+
+Pushes to `main`, manual workflow runs, and the nightly schedule also run
+integration, slow, example, PINN, SPMD, and SPMD x64 jobs. The jobs are split
+so failures point at the relevant test tier and slow tests are not duplicated
+across unrelated jobs.

--- a/examples/poisson1D_spikan.py
+++ b/examples/poisson1D_spikan.py
@@ -17,7 +17,7 @@ from jaxfun.utils import lambdify
 from jaxfun.utils.common import Domain, ulp
 
 domain = Domain(-jnp.pi, jnp.pi)
-V = sPIKANSpace(4, [8], dims=1, rank=0, name="V", domains=[domain])
+V = sPIKANSpace(4, [10], dims=1, rank=0, name="V", domains=[domain])
 # V = KANMLPSpace(4, [16], dims=1, rank=0, name="V", domains=[domain])
 w = FlaxFunction(V, name="w", rngs=nnx.Rngs(101))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,23 @@ dependencies = [
 ]
 
 [tool.pytest.ini_options]
-markers = [ "slow: marks tests as slow (select with '-m slow')" ]
-addopts = [ "-m", "not slow", "-n", "logical" ]
+markers = [
+  "slow: long-running tests excluded from local default",
+  "integration: solves a complete problem or exercises several subsystems",
+  "smoke: small end-to-end test suitable for every PR",
+  "spmd: requires multiple JAX devices",
+  "pinn: neural-network/PINN tests",
+  "examples: runs example scripts",
+  "serial: must not run under xdist",
+  "gpu: requires GPU backend",
+]
+addopts = [
+  "--strict-markers",
+  "-m",
+  "not slow and not integration and not examples and not pinn and not gpu and not spmd",
+  "-n",
+  "logical",
+]
 filterwarnings = [
   "ignore::DeprecationWarning:flax",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,15 @@ import os
 import pytest
 
 
+@pytest.fixture(autouse=True, scope="module")
+def clear_jax_caches_after_module():
+    yield
+
+    import jax
+
+    jax.clear_caches()
+
+
 def pytest_addoption(parser) -> None:
     parser.addoption("--float64", action="store_true", default=False)
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,6 @@ def pytest_configure(config) -> None:
     if n > 1:
         jax.config.update("jax_num_cpu_devices", n)
     os.environ["PYTEST"] = "True"
-    config.addinivalue_line(
-        "markers",
-        "spmd: mark test as requiring multiple JAX devices (pass --num-devices=N to enable)",  # noqa: E501
-    )
 
 
 def pytest_collection_modifyitems(config, items) -> None:

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -25,6 +25,8 @@ from jaxfun.la import TPMatrix
 from jaxfun.operators import Div, Dot, Grad
 from jaxfun.utils.common import ulp
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture(params=(None, Domain(-2, 2)), ids=("domain-default", "domain-mapped"))
 def domain(request: pytest.FixtureRequest) -> Domain | None:

--- a/tests/galerkin/test_tensorproductspace.py
+++ b/tests/galerkin/test_tensorproductspace.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import pytest
 import sympy as sp
 
 from jaxfun.galerkin import (
@@ -17,6 +18,8 @@ from jaxfun.galerkin.composite import DirectSum
 from jaxfun.galerkin.inner import inner
 from jaxfun.la import TensorMatrix, TPMatrices, TPMatrix
 from jaxfun.utils.common import ulp
+
+pytestmark = pytest.mark.integration
 
 
 def test_tensorproduct_forward_backward_padding_fourier():

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -22,6 +22,8 @@ from jaxfun.galerkin.tensorproductspace import DirectSumTPS
 from jaxfun.la import TPMatrix
 from jaxfun.utils.common import ulp
 
+pytestmark = pytest.mark.integration
+
 
 def test_directsum_two_inhomogeneous_bnd_assembly_and_backward():
     # Exercise two_inhomogeneous branch lines 211-233 etc.

--- a/tests/integrators/test_backward_euler.py
+++ b/tests/integrators/test_backward_euler.py
@@ -13,6 +13,8 @@ from jaxfun.integrators import ETDRK4, RK4, BackwardEuler
 from jaxfun.operators import Constant, Div, Grad
 from jaxfun.utils.common import lambdify, n, ulp
 
+pytestmark = pytest.mark.integration
+
 
 def test_backward_euler_linear_advection_fourier() -> None:
     N = 32

--- a/tests/integrators/test_etdrk4.py
+++ b/tests/integrators/test_etdrk4.py
@@ -16,6 +16,8 @@ from jaxfun.operators import Constant
 from jaxfun.utils import ulp
 from jaxfun.utils.common import lambdify
 
+pytestmark = pytest.mark.integration
+
 
 def _count_primitive(jpr, primitive: str) -> int:
     total = 0

--- a/tests/integrators/test_nls1d_etdrk4.py
+++ b/tests/integrators/test_nls1d_etdrk4.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import pytest
 import sympy as sp
 
 from jaxfun import Domain
@@ -6,6 +7,8 @@ from jaxfun.galerkin.arguments import TestFunction, TrialFunction
 from jaxfun.galerkin.Fourier import Fourier as FourierSpace
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.integrators import ETDRK4
+
+pytestmark = pytest.mark.integration
 
 
 def test_etdrk4_focusing_nls_soliton_tracks_exact_short_time() -> None:

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -17,6 +17,7 @@ from typing import cast
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from jaxfun.galerkin import (
     FunctionSpace,
@@ -39,6 +40,8 @@ from jaxfun.la import (
 from jaxfun.la.diamatrix import diakron
 from jaxfun.operators import Div, Grad
 from jaxfun.utils.common import n as sym_n, ulp
+
+pytestmark = pytest.mark.integration
 
 
 def _diag3(n: int) -> DiaMatrix:

--- a/tests/la/test_tpmatrices_solvers.py
+++ b/tests/la/test_tpmatrices_solvers.py
@@ -36,6 +36,8 @@ from jaxfun.la.tpmatrix import (
 from jaxfun.operators import Div, Dot, Grad
 from jaxfun.utils.common import lambdify, ulp
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/pinns/test_embeddings.py
+++ b/tests/pinns/test_embeddings.py
@@ -5,6 +5,8 @@ from flax import nnx
 from jaxfun.pinns.embeddings import Embedding, FourierEmbs, PeriodEmbs
 from jaxfun.utils.common import ulp
 
+pytestmark = pytest.mark.pinn
+
 
 def test_period_embs_values_and_shape_nontrainable():
     # Embed only the first axis -> output is [cos(p*x0), sin(p*x0), x1]

--- a/tests/pinns/test_kan_spikan.py
+++ b/tests/pinns/test_kan_spikan.py
@@ -7,6 +7,8 @@ from flax import nnx
 from jaxfun.coordinates import BaseTime, CartCoordSys, x
 from jaxfun.pinns import module as mod, nnspaces as nns
 
+pytestmark = pytest.mark.pinn
+
 
 def test_kanlayer_forward_shape_and_params():
     rngs = nnx.Rngs(0)

--- a/tests/pinns/test_loss.py
+++ b/tests/pinns/test_loss.py
@@ -22,6 +22,8 @@ from jaxfun.pinns.loss import (
 )
 from jaxfun.pinns.module import FlaxFunction, MLPSpace
 
+pytestmark = pytest.mark.pinn
+
 
 @pytest.fixture
 def base_scalars():

--- a/tests/pinns/test_mesh.py
+++ b/tests/pinns/test_mesh.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import pytest
 from flax import nnx
 
 from jaxfun.pinns.mesh import (
@@ -17,6 +18,8 @@ from jaxfun.pinns.mesh import (
 )
 from jaxfun.utils import leggauss
 from jaxfun.utils.common import ulp
+
+pytestmark = pytest.mark.pinn
 
 
 def _meshgrid_flatten(x, y):

--- a/tests/pinns/test_module.py
+++ b/tests/pinns/test_module.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import pytest
 from flax import nnx
 
 from jaxfun.galerkin import Legendre, TensorProduct
@@ -12,6 +13,8 @@ from jaxfun.pinns.module import (
     SpectralModule,
 )
 from jaxfun.pinns.nnspaces import MLPSpace, PirateSpace
+
+pytestmark = pytest.mark.pinn
 
 
 def test_rwflinear_forward_shapes_and_bias():

--- a/tests/pinns/test_nnspaces.py
+++ b/tests/pinns/test_nnspaces.py
@@ -5,6 +5,8 @@ import sympy as sp
 from jaxfun.coordinates import BaseScalar, BaseTime
 from jaxfun.pinns.nnspaces import MLPSpace, MLPVectorSpace, NNSpace, PirateSpace
 
+pytestmark = pytest.mark.pinn
+
 
 def test_nnspace_basic_attributes_and_out_size():
     ns = NNSpace(dims=3, rank=2, transient=False, name="testNN")

--- a/tests/pinns/test_optimizer.py
+++ b/tests/pinns/test_optimizer.py
@@ -6,6 +6,8 @@ from flax import nnx
 
 from jaxfun.pinns import FlaxFunction, Loss, MLPSpace, optimizer as opt_mod
 
+pytestmark = pytest.mark.pinn
+
 
 class DummyModule(nnx.Module):
     def __init__(self):

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -14,26 +14,41 @@ spmd_files = [
 ]
 files = [f.stem for f in _all_files if f.stem not in spmd_files]
 
+SMOKE_DEMOS = [
+    "poisson1D",
+]
+
+
+def _run_demo(demo: str) -> None:
+    with contextlib.suppress(SystemExit):
+        runpy.run_path(str(root / "examples" / f"{demo}.py"), run_name="__main__")
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("demo", SMOKE_DEMOS)
+def test_demo_smoke(demo: str) -> None:
+    _run_demo(demo)
+
 
 @pytest.mark.slow
+@pytest.mark.examples
 @pytest.mark.parametrize(
     "demo",
     files,
 )
 def test_demos(demo: str) -> None:
-    with contextlib.suppress(SystemExit):
-        runpy.run_path(f"examples/{demo}.py", run_name="__main__")
+    _run_demo(demo)
 
 
 @pytest.mark.slow
+@pytest.mark.examples
 @pytest.mark.spmd
 @pytest.mark.parametrize(
     "demo",
     spmd_files,
 )
 def test_demos_spmd(demo: str) -> None:
-    with contextlib.suppress(SystemExit):
-        runpy.run_path(f"examples/{demo}.py", run_name="__main__")
+    _run_demo(demo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Split up the tests into multiple groups, with fast tests run by defaults, and broader sweeps left to CI in PR / explicit runs.

## Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] Other (describe):

## Description of Changes

The tests themselves are not materially changed (with the exception of `examples/poisson1D_spikan.py` which for some reason exploded when run locally, but worked fine in CI (finicky numerics...).

`uv run pytest` now selects `796/1331 tests collected (535 deselected)`. The selected defaults now take 78s on my relatively slow machine, compared with around 5 minutes for all the tests. The broader sweeps are placed under the `integration` marker (as in continuous integration (CI), not numeric), with 294/1331 currently.

There is still the remaining cleanup job of identifying redundant work in the tests, as some are likely doing too much pre-processing to check a simple behaviour. GPT5.5 was surprisingly inept at performing this task. Also, some tests should likely be moved between markers, as there may be behaviour which is not checked in the fast run, but that is a simple fix as it is identified (tests pass locally/on a branch, fail in PR).

## Screenshots / Logs (if applicable)
<img width="1294" height="220" alt="bilde" src="https://github.com/user-attachments/assets/28fa47ab-8a02-4121-81b5-dc4acc377813" />

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [ ] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [x] Coverage does not decrease
- [ ] Git history is clean (squash/fixup before merge)