### PR TITLE
DirectSumTPS working in 3D, with one or 2 DirectSum spaces.

### DIFF
--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -40,7 +40,7 @@ class BoundaryConditions(dict):
 
     Args:
         bc: User dictionary (partial). Missing sides are filled.
-        domain: Physical domain (unused here, kept for future features).
+        domain: Physical domain.
 
     Attributes:
         left/right: Dicts of condition_code -> value.

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -84,14 +84,6 @@ class BoundaryConditions(dict):
                 ls.append(val[1] if isinstance(val, tuple | list) else val)
         return ls
 
-    def orderedkeys(self) -> list[Number]:
-        """Return boundary condition values in same order as orderednames()."""
-        ls = []
-        for lr in ("left", "right"):
-            for key in sorted(self[lr].keys()):
-                ls.append(key)
-        return ls
-
     def num_bcs(self) -> int:
         """Return number of scalar boundary conditions."""
         return len(self.orderedvals())
@@ -458,7 +450,12 @@ class BCGeneric(Composite):
 
     def bnd_vals(self) -> Array:
         """Return ordered boundary values vector."""
-        return jnp.array(self.bcs.orderedvals(), dtype=float)
+        return jnp.array(
+            [
+                complex(s) if sp.sympify(s).has(sp.I) else float(s)
+                for s in self.bcs.orderedvals()
+            ]
+        )
 
     @jax.jit(static_argnums=(0, 1))
     def quad_points_and_weights(self, N: int | None = None) -> Array:

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -44,6 +44,15 @@ class BoundaryConditions(dict):
 
     Attributes:
         left/right: Dicts of condition_code -> value.
+
+    Note:
+        Neumann boundary conditions are normalized to domain if input dict is
+        not already a BoundaryConditions instance. This ensures correct scaling
+        of Neumann BCs when using non-standard domains. Hence, if passing a
+        dict, the user can specify Neumann values in physical units and they
+        will be normalized appropriately. If passing a BoundaryConditions
+        instance, it is assumed that the values are already normalized (e.g.
+        if the instance was created with a non-standard domain).
     """
 
     def __init__(self, bc: dict, domain: Domain | None = None) -> None:
@@ -52,6 +61,13 @@ class BoundaryConditions(dict):
         bcs = {"left": {}, "right": {}}
         bcs.update(copy.deepcopy(bc))
         dict.__init__(self, bcs)
+        if not isinstance(bc, BoundaryConditions):  # Normalize if dict was passed in
+            df = 2 / (domain.upper - domain.lower)
+            for val in self.values():
+                for k, v in val.items():
+                    if k[0] == "N":
+                        nd = int(k[1:]) if len(k) > 1 else 1
+                        val[k] = v / df**nd
 
     def orderednames(self) -> list[str]:
         """Return ordered boundary condition codes (prefixed with L/R)."""
@@ -66,6 +82,14 @@ class BoundaryConditions(dict):
             for key in sorted(self[lr].keys()):
                 val = self[lr][key]
                 ls.append(val[1] if isinstance(val, tuple | list) else val)
+        return ls
+
+    def orderedkeys(self) -> list[Number]:
+        """Return boundary condition values in same order as orderednames()."""
+        ls = []
+        for lr in ("left", "right"):
+            for key in sorted(self[lr].keys()):
+                ls.append(key)
         return ls
 
     def num_bcs(self) -> int:

--- a/src/jaxfun/galerkin/functionspace.py
+++ b/src/jaxfun/galerkin/functionspace.py
@@ -157,6 +157,7 @@ def FunctionSpace(
             kwb["name"] = kw["name"] + "_b"
         if "fun_str" in kw:
             kwb["fun_str"] = kw["fun_str"] + "_b"
+
         B = BCGeneric(
             bcs.num_bcs(),
             space,

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -495,7 +495,6 @@ def _assemble_separable_bilinear_form(
         fun = _separable_boundary_values(context.trial_space, coeffs, trial, gi)
         sign = _linear_sign(context.all_linear)
         res = TPMatrix(mats_, sign) @ fun
-        # res = sign * (mats_[0] @ fun @ mats_[1].T)
         bresult = vectorize_bresult(res, context.test_space, gi[0][0])
 
     else:

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -492,10 +492,10 @@ def _assemble_separable_bilinear_form(
 
     assert isinstance(context.test_space, TensorProductSpace | VectorTensorProductSpace)
     if has_bcs:
-        assert len(mats_) == 2
         fun = _separable_boundary_values(context.trial_space, coeffs, trial, gi)
         sign = _linear_sign(context.all_linear)
-        res = sign * (mats_[0] @ fun @ mats_[1].T)
+        res = TPMatrix(mats_, sign) @ fun
+        # res = sign * (mats_[0] @ fun @ mats_[1].T)
         bresult = vectorize_bresult(res, context.test_space, gi[0][0])
 
     else:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -4,7 +4,7 @@ import copy
 import itertools
 from collections.abc import Iterable, Iterator, Sequence
 from functools import partial
-from typing import NoReturn, TypeGuard, cast
+from typing import NoReturn, cast
 
 import jax
 import jax.numpy as jnp
@@ -12,7 +12,7 @@ import sympy as sp
 from jax import Array, shard_map
 from jax.sharding import NamedSharding, PartitionSpec as P
 
-from jaxfun.coordinates import CoordSys
+from jaxfun.coordinates import CartCoordSys, CoordSys
 from jaxfun.sharding import (
     _apply_separable_spmd_shard_map,
     _build_local_apply_fn,
@@ -762,44 +762,29 @@ def TensorProduct(
     basespaces_list: list[OrthogonalSpace | DirectSum] = [
         copy.deepcopy(space) for space in basespaces
     ]
-    names = [space.name for space in basespaces_list]
-
-    if jnp.any(jnp.array([name == names[0] for name in names[1:]])):
-        for i, space in enumerate(basespaces_list):
-            if isinstance(space, DirectSum):
-                for spi in space.basespaces:
-                    spi.name = spi.name + str(i)
-            else:
-                space.name = space.name + str(i)
 
     for i, space in enumerate(basespaces_list):
-        # ty does not like this weird duck typing
         space.system = system.sub_system(i)  # ty:ignore[invalid-assignment]
         if isinstance(space, Composite):
-            space.orthogonal.system = system.sub_system(i)  # ty:ignore[invalid-assignment]
+            space.orthogonal.system = space.system
         if isinstance(space, DirectSum):
-            space.basespaces[0].system = system.sub_system(i)  # ty:ignore[invalid-assignment]
+            space.basespaces[0].system = space.system
             if isinstance(space.basespaces[0], Composite):
-                space.basespaces[0].orthogonal.system = system.sub_system(i)  # ty:ignore[invalid-assignment]
-            space.basespaces[1].system = system.sub_system(i)  # ty:ignore[invalid-assignment]
-            space.basespaces[1].orthogonal.system = system.sub_system(i)  # ty:ignore[invalid-assignment]
+                space.basespaces[0].orthogonal.system = space.system
+            space.basespaces[1].system = space.system
+            space.basespaces[1].orthogonal.system = space.system
 
-    if isinstance(basespaces_list[0], DirectSum) or isinstance(
-        basespaces_list[1], DirectSum
-    ):
+    if jnp.any(jnp.array([isinstance(s, DirectSum) for s in basespaces_list])):
         return DirectSumTPS(basespaces_list, system, name)
 
-    def _all_orthogonal(
-        spaces: list[OrthogonalSpace | DirectSum],
-    ) -> TypeGuard[list[OrthogonalSpace]]:
-        return all(isinstance(s, OrthogonalSpace) for s in spaces)
-
-    assert _all_orthogonal(basespaces_list)
-    return TensorProductSpace(basespaces_list, system, name)
+    assert all(isinstance(s, OrthogonalSpace | DirectSum) for s in basespaces_list)
+    return TensorProductSpace(
+        cast(list[OrthogonalSpace], basespaces_list), system, name
+    )
 
 
 class DirectSumTPS(TensorProductSpace):
-    """Tensor product where one/both axes are DirectSum spaces (BC lifting).
+    """Tensor product space where one or two basespaces are DirectSums.
 
     Builds a dictionary of homogeneous tensor-product subspaces produced
     by expanding DirectSum components. Also precomputes boundary lifting
@@ -817,7 +802,7 @@ class DirectSumTPS(TensorProductSpace):
         system: CoordSys,
         name: str = "DSTPS",
     ) -> None:
-        from jaxfun.galerkin.inner import project1D
+        from jaxfun.galerkin.inner import project, project1D
 
         self.basespaces: list[OrthogonalSpace | DirectSum] = basespaces
         self.system = system
@@ -828,6 +813,14 @@ class DirectSumTPS(TensorProductSpace):
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
 
         # Normalize symbolic BC expressions to base scalar form
+        bcindices = [
+            i for i, space in enumerate(basespaces) if isinstance(space, DirectSum)
+        ]
+        if len(basespaces) == 3 and bcindices[0] == 0:
+            raise ValueError(
+                "DirectSum cannot be the first space in a 3D tensor product."
+            )
+
         for space in basespaces:
             if space.bcs is None:
                 continue
@@ -842,10 +835,14 @@ class DirectSumTPS(TensorProductSpace):
 
         two_inhomogeneous = False
         bcall: list[list[BoundaryConditions]] = []
-        if isinstance(basespaces[0], DirectSum) and isinstance(
-            basespaces[1], DirectSum
-        ):
-            bcspaces = (basespaces[0].basespaces[1], basespaces[1].basespaces[1])
+        if len(bcindices) == 2:
+            # If there are two DirectSums, we need to project to the other for each.
+            # When projecting to the other space, we need to use the BC values
+            # corresponding to the current space's BC values.
+            bcspaces = (
+                cast(DirectSum, basespaces[bcindices[0]]).basespaces[1],
+                cast(DirectSum, basespaces[bcindices[1]]).basespaces[1],
+            )
             two_inhomogeneous = bcspaces
             bc0, bc1 = bcspaces
             bc0bcs = copy.deepcopy(bc0.bcs)
@@ -855,7 +852,7 @@ class DirectSumTPS(TensorProductSpace):
                 return {"left": bcz.domain.lower, "right": bcz.domain.upper}[z]
 
             for bcthis, bcother, zother in zip(
-                [bc0bcs, bc1bcs], [bc1bcs, bc0bcs], [bc1, bc0], strict=False
+                [bc0bcs, bc1bcs], [bc1bcs, bc0bcs], [bc1, bc0], strict=True
             ):
                 assert isinstance(bcthis, BoundaryConditions)
                 assert isinstance(bcother, BoundaryConditions)
@@ -863,28 +860,30 @@ class DirectSumTPS(TensorProductSpace):
 
                 bcall.append([])
                 df = 2.0 / (zother.domain.upper - zother.domain.lower)
+                s = zother.system.base_scalars()[0]
                 for bcval in bcthis.orderedvals():
                     bcs: BoundaryConditions = copy.deepcopy(bcother)
                     for lr_other, bco in bcs.items():
                         z = lr(zother, lr_other)
                         for key in bco:
                             if key == "D":
-                                bco[key] = float(
-                                    sp.sympify(bcval).subs(
-                                        zother.system.base_scalars()[0], z
-                                    )
-                                )
+                                fun = sp.sympify(bcval).subs(s, z)
+                                if len(fun.free_symbols) == 0:
+                                    bco[key] = float(fun)
+                                else:
+                                    bco[key] = fun
                             elif key[0] == "N":
                                 nd = 1 if len(key) == 1 else int(key[1])
-                                var = zother.system.base_scalars()[0]
-                                bco[key] = float(
-                                    (sp.sympify(bcval).diff(var, nd) / df**nd).subs(
-                                        var, z
-                                    )
-                                )
-
+                                df = sp.sympify(bcval).diff(s, nd) / df**nd
+                                fun = df.subs(s, z)
+                                if len(fun.free_symbols) == 0:
+                                    bco[key] = float(fun)
+                                else:
+                                    bco[key] = fun
                     bcall[-1].append(bcs)
-            self.bndvals[bcspaces] = jnp.array([z.orderedvals() for z in bcall[0]])
+
+            if len(basespaces) == 2:
+                self.bndvals[bcspaces] = jnp.array([z.orderedvals() for z in bcall[0]])
 
         self.tpspaces: dict[tuple[OrthogonalSpace, ...], TensorProductSpace] = (
             self.split(basespaces)
@@ -903,8 +902,7 @@ class DirectSumTPS(TensorProductSpace):
             ]
             if len(otherspaces) == 0:
                 continue
-            elif len(otherspaces) == 1:
-                assert len(bcspaces) == 1
+            elif len(otherspaces) == 1 and len(bcspaces) == 1:
                 bcspace = bcspaces[0]
                 otherspace = otherspaces[0]
                 uh: list[Array] = []
@@ -916,11 +914,60 @@ class DirectSumTPS(TensorProductSpace):
                         )
                         bco.bcs = bcall[bcsindex[0]][j]
                         otherspace: DirectSum = cast(Composite, otherspace) + bco
+
                     uh.append(project1D(bc, otherspace))
                 if bcsindex[0] == 0:
                     self.bndvals[tensorspace] = jnp.array(uh)
                 else:
                     self.bndvals[tensorspace] = jnp.array(uh).T
+
+            elif len(otherspaces) == 2 and len(bcspaces) == 1:
+                # find BCGeneric index. 1 or 2.
+                isbc = [isinstance(space, BCGeneric) for space in tensorspace]
+                bcind = isbc.index(True)
+                ind_other = 1 if bcind == 2 else 2
+                bcspace = bcspaces[0]
+                uh: list[Array] = []
+                for j, bc in enumerate(bcspace.bcs.orderedvals()):
+                    otherbc = tensorspace[ind_other]
+                    if two_inhomogeneous:
+                        bco: BCGeneric = copy.deepcopy(
+                            two_inhomogeneous[0 if bcind == 2 else 1]
+                        )
+                        bco.bcs = bcall[bcind - 1][j]
+                        otherbc: DirectSum = (
+                            cast(Composite, tensorspace[ind_other]) + bco
+                        )
+
+                    othertpspace = TensorProduct(
+                        *[copy.deepcopy(space) for space in [otherspaces[0], otherbc]],
+                        system=CartCoordSys(
+                            "T",
+                            (
+                                otherspaces[0].system.base_scalars()[0],
+                                otherbc.system.base_scalars()[0],
+                            ),
+                        ),
+                    )
+                    uh.append(project(bc, othertpspace))
+
+                if bcind == 2:
+                    self.bndvals[tensorspace] = jnp.array(uh).transpose(1, 2, 0)
+                else:
+                    self.bndvals[tensorspace] = jnp.array(uh).transpose(1, 0, 2)
+
+            elif len(otherspaces) == 1 and len(bcspaces) == 2:
+                uh: list[Array] = []
+                for i, bc0 in enumerate(bcspaces[0].bcs.orderedvals()):
+                    x0 = bcspaces[0].system.base_scalars()[0]
+                    for j, bc1 in enumerate(bcspaces[1].bcs.orderedvals()):
+                        x1 = bcspaces[1].system.base_scalars()[0]
+                        bx = bc0.subs(x1, bcspaces[0].domain[i])
+                        by = bc1.subs(x0, bcspaces[1].domain[j])
+                        uh.append(project(bx * by, otherspaces[0]))
+
+                self.bndvals[tensorspace] = jnp.array(uh).T.reshape((-1, 2, 2))
+
         self.orthogonal = self.get_orthogonal()
 
     def split(
@@ -941,17 +988,11 @@ class DirectSumTPS(TensorProductSpace):
 
     def get_homogeneous(self) -> TensorProductSpace:
         """Return tensor space built from homogeneous components only."""
-        a0 = (
-            self.basespaces[0].basespaces[0]
-            if isinstance(self.basespaces[0], DirectSum)
-            else self.basespaces[0]
-        )
-        a1 = (
-            self.basespaces[1].basespaces[0]
-            if isinstance(self.basespaces[1], DirectSum)
-            else self.basespaces[1]
-        )
-        return self.tpspaces[(a0, a1)]
+        ai = [
+            space[0] if isinstance(space, DirectSum) else space
+            for space in self.basespaces
+        ]
+        return self.tpspaces[tuple(ai)]
 
     def backward(
         self,

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -802,6 +802,8 @@ class DirectSumTPS(TensorProductSpace):
         system: CoordSys,
         name: str = "DSTPS",
     ) -> None:
+        import numpy as np
+
         from jaxfun.galerkin.inner import project, project1D
 
         self.basespaces: list[OrthogonalSpace | DirectSum] = basespaces
@@ -848,11 +850,14 @@ class DirectSumTPS(TensorProductSpace):
             bc0bcs = copy.deepcopy(bc0.bcs)
             bc1bcs = copy.deepcopy(bc1.bcs)
 
-            def lr(bcz: BCGeneric, z: str) -> sp.Number | float:
-                return {"left": bcz.domain.lower, "right": bcz.domain.upper}[z]
+            def lr(bcz: BCGeneric, z: str) -> float:
+                return {
+                    "left": float(bcz.domain.lower),
+                    "right": float(bcz.domain.upper),
+                }[z]
 
             for bcthis, bcother, zother in zip(
-                [bc0bcs, bc1bcs], [bc1bcs, bc0bcs], [bc1, bc0], strict=True
+                [bc0bcs, bc1bcs], [bc1bcs, bc0bcs], [bc1, bc0], strict=False
             ):
                 assert isinstance(bcthis, BoundaryConditions)
                 assert isinstance(bcother, BoundaryConditions)
@@ -867,25 +872,26 @@ class DirectSumTPS(TensorProductSpace):
                         z = lr(zother, lr_other)
                         for key in bco:
                             if key == "D":
-                                fun = sp.sympify(bcval).subs(s, z)
-                                if len(fun.free_symbols) == 0:
-                                    bco[key] = float(fun)
+                                f = sp.sympify(bcval).subs(s, z)
+                                if len(f.free_symbols) == 0:
+                                    bco[key] = complex(f) if f.has(sp.I) else float(f)
                                 else:
-                                    bco[key] = fun
+                                    bco[key] = f
                             elif key[0] == "N":
-                                # Neumann bcs must be normalized.
                                 nd = 1 if len(key) == 1 else int(key[1])
-                                dt = sp.sympify(bcval).diff(s, nd) / df**nd
-                                fun = dt.subs(s, z)
-                                if len(fun.free_symbols) == 0:
-                                    bco[key] = float(fun)
+                                f = (sp.sympify(bcval).diff(s, nd) / df**nd).subs(s, z)
+                                if len(f.free_symbols) == 0:
+                                    bco[key] = complex(f) if f.has(sp.I) else float(f)
                                 else:
-                                    bco[key] = fun
+                                    bco[key] = f
+
                     bcall[-1].append(bcs)
 
+            # Use np because orderedvals may contain sympy expressions.
+            bvals = np.array([z.orderedvals() for z in bcall[0]])
+
             if len(basespaces) == 2:
-                # Here values from bcall[1] are transposed of bcall[0], so using only bcall[0]  # noqa: E501
-                self.bndvals[bcspaces] = jnp.array([z.orderedvals() for z in bcall[0]])
+                self.bndvals[bcspaces] = jnp.array(bvals)
 
         self.tpspaces: dict[tuple[OrthogonalSpace, ...], TensorProductSpace] = (
             self.split(basespaces)
@@ -917,7 +923,6 @@ class DirectSumTPS(TensorProductSpace):
                         )
                         bco.bcs = bcall[bcsindex[0]][j]
                         otherspace: DirectSum = cast(Composite, otherspace) + bco
-
                     uh.append(project1D(bc, otherspace))
 
                 if bcsindex[0] == 0:
@@ -965,12 +970,11 @@ class DirectSumTPS(TensorProductSpace):
 
             elif len(otherspaces) == 1 and len(bcspaces) == 2:
                 uh: list[Array] = []
-                for bc0 in bcall[0][0].orderedvals():
-                    for bc1 in bcall[0][1].orderedvals():
-                        uh.append(project(bc0 * bc1, otherspaces[0]))
-
+                for bci in bcall[0]:
+                    for bc0 in bci.orderedvals():
+                        uh.append(project(bc0, otherspaces[0]))
                 self.bndvals[tensorspace] = jnp.array(uh).T.reshape(
-                    (-1, bcall[0][0].num_bcs(), bcall[0][1].num_bcs())
+                    (-1, len(bcall[0]), len(bcall[1]))
                 )
 
         self.orthogonal = self.get_orthogonal()

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -802,8 +802,6 @@ class DirectSumTPS(TensorProductSpace):
         system: CoordSys,
         name: str = "DSTPS",
     ) -> None:
-        import numpy as np
-
         from jaxfun.galerkin.inner import project, project1D
 
         self.basespaces: list[OrthogonalSpace | DirectSum] = basespaces
@@ -887,11 +885,10 @@ class DirectSumTPS(TensorProductSpace):
 
                     bcall[-1].append(bcs)
 
-            # Use np because orderedvals may contain sympy expressions.
-            bvals = np.array([z.orderedvals() for z in bcall[0]])
-
             if len(basespaces) == 2:
-                self.bndvals[bcspaces] = jnp.array(bvals)
+                self.bndvals[bcspaces] = jnp.array(
+                    [z.orderedvals() for z in bcall[0]], dtype=float
+                )
 
         self.tpspaces: dict[tuple[OrthogonalSpace, ...], TensorProductSpace] = (
             self.split(basespaces)

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -873,9 +873,10 @@ class DirectSumTPS(TensorProductSpace):
                                 else:
                                     bco[key] = fun
                             elif key[0] == "N":
+                                # Neumann bcs must be normalized.
                                 nd = 1 if len(key) == 1 else int(key[1])
-                                df = sp.sympify(bcval).diff(s, nd) / df**nd
-                                fun = df.subs(s, z)
+                                dt = sp.sympify(bcval).diff(s, nd) / df**nd
+                                fun = dt.subs(s, z)
                                 if len(fun.free_symbols) == 0:
                                     bco[key] = float(fun)
                                 else:
@@ -883,6 +884,7 @@ class DirectSumTPS(TensorProductSpace):
                     bcall[-1].append(bcs)
 
             if len(basespaces) == 2:
+                # Here values from bcall[1] are transposed of bcall[0], so using only bcall[0]  # noqa: E501
                 self.bndvals[bcspaces] = jnp.array([z.orderedvals() for z in bcall[0]])
 
         self.tpspaces: dict[tuple[OrthogonalSpace, ...], TensorProductSpace] = (
@@ -900,6 +902,7 @@ class DirectSumTPS(TensorProductSpace):
             bcsindex: list[int] = [
                 i for i, p in enumerate(tensorspace) if isinstance(p, BCGeneric)
             ]
+
             if len(otherspaces) == 0:
                 continue
             elif len(otherspaces) == 1 and len(bcspaces) == 1:
@@ -916,6 +919,7 @@ class DirectSumTPS(TensorProductSpace):
                         otherspace: DirectSum = cast(Composite, otherspace) + bco
 
                     uh.append(project1D(bc, otherspace))
+
                 if bcsindex[0] == 0:
                     self.bndvals[tensorspace] = jnp.array(uh)
                 else:
@@ -939,13 +943,16 @@ class DirectSumTPS(TensorProductSpace):
                             cast(Composite, tensorspace[ind_other]) + bco
                         )
 
+                    newspaces = [
+                        copy.deepcopy(space) for space in [otherspaces[0], otherbc]
+                    ]
                     othertpspace = TensorProduct(
-                        *[copy.deepcopy(space) for space in [otherspaces[0], otherbc]],
+                        *newspaces,
                         system=CartCoordSys(
                             "T",
                             (
-                                otherspaces[0].system.base_scalars()[0],
-                                otherbc.system.base_scalars()[0],
+                                newspaces[0].system.base_scalars()[0],
+                                newspaces[1].system.base_scalars()[0],
                             ),
                         ),
                     )
@@ -958,15 +965,13 @@ class DirectSumTPS(TensorProductSpace):
 
             elif len(otherspaces) == 1 and len(bcspaces) == 2:
                 uh: list[Array] = []
-                for i, bc0 in enumerate(bcspaces[0].bcs.orderedvals()):
-                    x0 = bcspaces[0].system.base_scalars()[0]
-                    for j, bc1 in enumerate(bcspaces[1].bcs.orderedvals()):
-                        x1 = bcspaces[1].system.base_scalars()[0]
-                        bx = bc0.subs(x1, bcspaces[0].domain[i])
-                        by = bc1.subs(x0, bcspaces[1].domain[j])
-                        uh.append(project(bx * by, otherspaces[0]))
+                for bc0 in bcall[0][0].orderedvals():
+                    for bc1 in bcall[0][1].orderedvals():
+                        uh.append(project(bc0 * bc1, otherspaces[0]))
 
-                self.bndvals[tensorspace] = jnp.array(uh).T.reshape((-1, 2, 2))
+                self.bndvals[tensorspace] = jnp.array(uh).T.reshape(
+                    (-1, bcall[0][0].num_bcs(), bcall[0][1].num_bcs())
+                )
 
         self.orthogonal = self.get_orthogonal()
 

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -774,7 +774,7 @@ def TensorProduct(
     if any(isinstance(s, DirectSum) for s in basespaces_list):
         return DirectSumTPS(basespaces_list, system, name)
 
-    assert all(isinstance(s, OrthogonalSpace | DirectSum) for s in basespaces_list)
+    assert all(isinstance(s, OrthogonalSpace) for s in basespaces_list)
     return TensorProductSpace(
         cast(list[OrthogonalSpace], basespaces_list), system, name
     )

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -833,9 +833,9 @@ class DirectSumTPS(TensorProductSpace):
                         if len(sp.sympify(v).free_symbols) > 0:
                             val[key] = system.expr_psi_to_base_scalar(v)
 
-        two_inhomogeneous = False
-        bcall: list[list[BoundaryConditions]] = []
-        if len(bcindices) == 2:
+        has_two_inhomogeneous = len(bcindices) == 2
+        projected_bcs: list[list[BoundaryConditions]] = []
+        if has_two_inhomogeneous:
             # If there are two DirectSums, we need to project to the other for each.
             # When projecting to the other space, we need to use the BC values
             # corresponding to the current space's BC values.
@@ -843,7 +843,7 @@ class DirectSumTPS(TensorProductSpace):
                 cast(DirectSum, basespaces[bcindices[0]]).basespaces[1],
                 cast(DirectSum, basespaces[bcindices[1]]).basespaces[1],
             )
-            two_inhomogeneous = bcspaces
+            bc_pair = bcspaces
             bc0, bc1 = bcspaces
             bc0bcs = copy.deepcopy(bc0.bcs)
             bc1bcs = copy.deepcopy(bc1.bcs)
@@ -857,11 +857,7 @@ class DirectSumTPS(TensorProductSpace):
             for bcthis, bcother, zother in zip(
                 [bc0bcs, bc1bcs], [bc1bcs, bc0bcs], [bc1, bc0], strict=False
             ):
-                assert isinstance(bcthis, BoundaryConditions)
-                assert isinstance(bcother, BoundaryConditions)
-                assert isinstance(zother, BCGeneric)
-
-                bcall.append([])
+                projected_bcs.append([])
                 df = 2.0 / (zother.domain.upper - zother.domain.lower)
                 s = zother.system.base_scalars()[0]
                 for bcval in bcthis.orderedvals():
@@ -883,12 +879,7 @@ class DirectSumTPS(TensorProductSpace):
                                 else:
                                     bco[key] = f
 
-                    bcall[-1].append(bcs)
-
-            if len(basespaces) == 2:
-                self.bndvals[bcspaces] = jnp.array(
-                    [z.orderedvals() for z in bcall[0]], dtype=float
-                )
+                    projected_bcs[-1].append(bcs)
 
         self.tpspaces: dict[tuple[OrthogonalSpace, ...], TensorProductSpace] = (
             self.split(basespaces)
@@ -907,18 +898,18 @@ class DirectSumTPS(TensorProductSpace):
             ]
 
             if len(otherspaces) == 0:
-                continue
+                self.bndvals[tensorspace] = jnp.array(
+                    [z.orderedvals() for z in projected_bcs[0]], dtype=float
+                )
+
             elif len(otherspaces) == 1 and len(bcspaces) == 1:
                 bcspace = bcspaces[0]
-                otherspace = otherspaces[0]
                 uh: list[Array] = []
                 for j, bc in enumerate(bcspace.bcs.orderedvals()):
                     otherspace: OrthogonalSpace = otherspaces[0]
-                    if two_inhomogeneous:
-                        bco: BCGeneric = copy.deepcopy(
-                            two_inhomogeneous[(bcsindex[0] + 1) % 2]
-                        )
-                        bco.bcs = bcall[bcsindex[0]][j]
+                    if has_two_inhomogeneous:
+                        bco: BCGeneric = copy.deepcopy(bc_pair[(bcsindex[0] + 1) % 2])
+                        bco.bcs = projected_bcs[bcsindex[0]][j]
                         otherspace: DirectSum = cast(Composite, otherspace) + bco
                     uh.append(project1D(bc, otherspace))
 
@@ -936,11 +927,9 @@ class DirectSumTPS(TensorProductSpace):
                 uh: list[Array] = []
                 for j, bc in enumerate(bcspace.bcs.orderedvals()):
                     otherbc = tensorspace[ind_other]
-                    if two_inhomogeneous:
-                        bco: BCGeneric = copy.deepcopy(
-                            two_inhomogeneous[0 if bcind == 2 else 1]
-                        )
-                        bco.bcs = bcall[bcind - 1][j]
+                    if has_two_inhomogeneous:
+                        bco: BCGeneric = copy.deepcopy(bc_pair[0 if bcind == 2 else 1])
+                        bco.bcs = projected_bcs[bcind - 1][j]
                         otherbc: DirectSum = (
                             cast(Composite, tensorspace[ind_other]) + bco
                         )
@@ -967,11 +956,11 @@ class DirectSumTPS(TensorProductSpace):
 
             elif len(otherspaces) == 1 and len(bcspaces) == 2:
                 uh: list[Array] = []
-                for bci in bcall[0]:
+                for bci in projected_bcs[0]:
                     for bc0 in bci.orderedvals():
                         uh.append(project(bc0, otherspaces[0]))
                 self.bndvals[tensorspace] = jnp.array(uh).T.reshape(
-                    (-1, len(bcall[0]), len(bcall[1]))
+                    (-1, len(projected_bcs[0]), len(projected_bcs[1]))
                 )
 
         self.orthogonal = self.get_orthogonal()

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -460,17 +460,11 @@ class TensorProductSpace:
         Returns:
             Array of coefficients in the orthogonal basis.
         """
-        dim = len(self)
         sharding = self._spectral_sharding
-        if dim == 2:
-            S = [s.S for s in self.basespaces]
-            z = S[0].T @ c @ S[1]
-        else:
-            S = [s.S for s in self.basespaces]
-            # z = jnp.einsum("is,jp,kl,ijk->spl", *S, c)
-            z = c
-            for i, Si in enumerate(S):
-                z = Si.rmatvec(z, axis=i)
+        S = [s.S for s in self.basespaces]
+        z = c
+        for i, Si in enumerate(S):
+            z = Si.rmatvec(z, axis=i)
 
         if sharding:  # return sharded if possible, otherwise fallback to replicated
             try:
@@ -483,15 +477,19 @@ class TensorProductSpace:
         """Return coefficients c mapped from underlying orthogonal basis.
 
         Args:
-            c: Coefficient array.
+            c: Coefficient array in orthogonal basis.
 
         Returns:
             Array of coefficients in the original basis.
         """
+        from jaxfun.la import Matrix
+
         sharding = self._spectral_sharding
-        S = [s.get_inverse_stencil() for s in self.basespaces]
-        dim = len(self)
-        z = S[0].T @ c @ S[1] if dim == 2 else jnp.einsum("is,jp,kl,ijk->spl", *S, c)
+        S = [Matrix(s.get_inverse_stencil()) for s in self.basespaces]
+        z = c
+        for i, Si in enumerate(S):
+            z = Si.rmatvec(z, axis=i)
+
         if sharding:  # return sharded if possible, otherwise fallback to replicated
             try:
                 return jax.device_put(z, sharding)
@@ -748,7 +746,7 @@ def TensorProduct(
         name: Base name for the tensor product space(s).
 
     Returns:
-        TensorProductSpace or DirectSumTPS.
+        Instance of TensorProductSpace or DirectSumTPS.
     """
     from jaxfun.coordinates import CartCoordSys, x, y, z
 
@@ -790,6 +788,11 @@ class DirectSumTPS(TensorProductSpace):
     contributions needed to evaluate / transform functions with
     inhomogeneous boundary conditions in one or two dimensions.
 
+    Args:
+        basespaces: List of 1D spaces, some of which may be DirectSums.
+        system: Global coordinate system.
+        name: Base name for the tensor product space.
+
     Attributes:
         tpspaces: Mapping from tuples of 1D spaces -> TensorProductSpace.
         bndvals: Dict storing boundary lifting coefficient arrays.
@@ -812,14 +815,6 @@ class DirectSumTPS(TensorProductSpace):
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
 
         # Normalize symbolic BC expressions to base scalar form
-        bcindices = [
-            i for i, space in enumerate(basespaces) if isinstance(space, DirectSum)
-        ]
-        if len(basespaces) == 3 and bcindices[0] == 0:
-            raise ValueError(
-                "DirectSum cannot be the first space in a 3D tensor product."
-            )
-
         for space in basespaces:
             if space.bcs is None:
                 continue
@@ -832,7 +827,15 @@ class DirectSumTPS(TensorProductSpace):
                         if len(sp.sympify(v).free_symbols) > 0:
                             val[key] = system.expr_psi_to_base_scalar(v)
 
+        bcindices = [
+            i for i, space in enumerate(basespaces) if isinstance(space, DirectSum)
+        ]
+        if len(basespaces) == 3 and bcindices[0] == 0:
+            raise ValueError(
+                "DirectSum cannot be the first space in a 3D tensor product."
+            )
         has_two_inhomogeneous = len(bcindices) == 2
+
         projected_bcs: list[list[BoundaryConditions]] = []
         if has_two_inhomogeneous:
             # If there are two DirectSums, we need to project to the other for each.

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -738,7 +738,6 @@ def TensorProduct(
 
     Handles:
       * Deep copy of bases to assign distinct coordinate subsystems
-      * Name disambiguation for repeated space names
       * Propagation of subsystem coordinates into Composite / DirectSum
 
     If any axis is a DirectSum (inhomogeneous BC), returns DirectSumTPS.
@@ -774,7 +773,7 @@ def TensorProduct(
             space.basespaces[1].system = space.system
             space.basespaces[1].orthogonal.system = space.system
 
-    if jnp.any(jnp.array([isinstance(s, DirectSum) for s in basespaces_list])):
+    if any(isinstance(s, DirectSum) for s in basespaces_list):
         return DirectSumTPS(basespaces_list, system, name)
 
     assert all(isinstance(s, OrthogonalSpace | DirectSum) for s in basespaces_list)

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -117,6 +117,24 @@ class Matrix(BaseMatrix):
         y_moved = y2d.reshape((n,) + rest_shape)
         return jnp.moveaxis(y_moved, 0, axis)
 
+    def rmatvec(self, x: Array, axis: int = 0) -> Array:
+        """Multiply ``x`` along ``axis`` by the transpose ``A^T``.
+
+        Args:
+            x:    Input array.  ``x.shape[axis]`` must equal ``n``.
+            axis: The axis of ``x`` along which the matrix acts.  The output
+                  has the same shape as ``x`` except ``shape[axis]`` becomes
+                  ``m``.
+
+        Examples::
+
+            A.rmatvec(x)  # x shape (n,)      → (m,)
+            A.rmatvec(X, axis=0)  # X shape (n, k)    → (m, k)
+            A.rmatvec(X, axis=1)  # X shape (k, n)    → (k, m)
+            A.rmatvec(T, axis=2)  # T shape (a, b, n) → (a, b, m)
+        """
+        return self.T.matvec(x, axis=axis)
+
     def lu_factor(self) -> LUFactors:
         """Compute the LU factorisation of this (square) matrix.
 

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -5,10 +5,12 @@ import jax.numpy as jnp
 import pytest
 import sympy as sp
 
+from jaxfun.coordinates import x, y, z
 from jaxfun.galerkin import (
     Chebyshev,
     ChebyshevU,
     DirectSum,
+    Fourier,
     FunctionSpace,
     Legendre,
     TensorProduct,
@@ -17,16 +19,16 @@ from jaxfun.galerkin import (
     Ultraspherical,
     VectorTensorProductSpace,
 )
-from jaxfun.galerkin.inner import inner, inner_items
+from jaxfun.galerkin.inner import inner, inner_items, project
 from jaxfun.galerkin.tensorproductspace import DirectSumTPS
 from jaxfun.la import TPMatrix
-from jaxfun.utils.common import ulp
+from jaxfun.operators import Div, Grad
+from jaxfun.utils.common import lambdify, ulp
 
 pytestmark = pytest.mark.integration
 
 
 def test_directsum_two_inhomogeneous_bnd_assembly_and_backward():
-    # Exercise two_inhomogeneous branch lines 211-233 etc.
     bcs1 = {"left": {"D": 1}, "right": {"D": 2}}
     bcs2 = {"left": {"D": 3}, "right": {"D": 4}}
     F1 = FunctionSpace(5, Legendre.Legendre, bcs=bcs1)
@@ -39,9 +41,91 @@ def test_directsum_two_inhomogeneous_bnd_assembly_and_backward():
     # Coefficient array for homogeneous parts
     hom0 = F1[0]
     hom1 = F2[0]
-    c = jnp.zeros((hom0.dim, hom1.dim))
+    c = jnp.ones((hom0.dim, hom1.dim))
     u = T.backward(c)  # triggers boundary reconstruction path
     assert u.shape[0] == hom0.num_quad_points and u.shape[1] == hom1.num_quad_points
+
+
+def test_directsumtps_poisson_3d():
+    global x, y, z
+
+    N = 20
+    ue = sp.sin(2 * x) * sp.exp(2 * y + z * sp.I)
+    bcsy = {
+        "left": {"D": ue.subs(y, -1)},
+        "right": {"D": ue.subs(y, 1)},
+    }
+    bcsz = {
+        "left": {"D": ue.subs(z, -1)},
+        "right": {"D": ue.subs(z, 1)},
+    }
+
+    F = Fourier.Fourier(N)
+    Dy = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsy)
+    Dz = FunctionSpace(N + 2, Chebyshev.Chebyshev, bcs=bcsz)
+    T = TensorProduct(F, Dy, Dz)
+    v = TestFunction(T)
+    u = TrialFunction(T)
+    ue = T.system.expr_psi_to_base_scalar(ue)
+    x, y, z = T.system.base_scalars()
+
+    A, b = inner(Div(Grad(u)) * v - Div(Grad(ue)) * v, kind="system")
+
+    uh = A.solve(b, method="lu")
+    uj = T.backward(uh)
+    uej = lambdify((x, y, z), ue)(*T.mesh())
+    error = jnp.linalg.norm(uj - uej)
+    assert error < jnp.sqrt(ulp(1))
+
+    f = T.forward(uj)
+    error = jnp.linalg.norm(f - uh)
+    assert error < ulp(1000)
+
+
+def test_directsumtps_biharmonic_dirichlet_3d():
+    global x, y, z
+
+    N = 20
+    ue = sp.sin(2 * x) * sp.exp(4 * y + z * sp.I)
+    bcsy = {
+        "left": {"D": ue.subs(y, -1)},
+        "right": {"D": ue.subs(y, 1)},
+    }
+    bcsz = {
+        "left": {"D": ue.subs(z, -1), "N": ue.diff(z, 1).subs(z, -1)},
+        "right": {"D": ue.subs(z, 1), "N": ue.diff(z, 1).subs(z, 1)},
+    }
+
+    F = Fourier.Fourier(N)
+    Dy = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsy)
+    Dz = FunctionSpace(N + 2, Chebyshev.Chebyshev, bcs=bcsz)
+    T = TensorProduct(F, Dy, Dz)
+    v = TestFunction(T)
+    u = TrialFunction(T)
+    x, y, z = T.system.base_scalars()
+    ue = T.system.expr_psi_to_base_scalar(ue)
+
+    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+        A, b = inner(
+            (Div(Grad(u)) + u.diff(z, 4)) * v - (Div(Grad(ue)) + ue.diff(z, 4)) * v,
+            kind="system",
+        )
+
+        uh = A.solve(b, method="lu")
+        uj = T.backward(uh)
+        uej = lambdify((x, y, z), ue)(*T.mesh())
+        error = jnp.linalg.norm(uj - uej)
+        assert error < jnp.sqrt(ulp(1))
+
+        f = T.forward(uj)
+        error = jnp.linalg.norm(f - uh)
+        assert error < ulp(1000)
+    else:
+        uh = project(ue, T)
+        uj = T.backward(uh)
+        f = T.forward(uj)
+        error = jnp.linalg.norm(f - uh)
+        assert error < ulp(1000)
 
 
 def test_tensorproduct_get_homogeneous():

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -5,7 +5,6 @@ import jax.numpy as jnp
 import pytest
 import sympy as sp
 
-from jaxfun.coordinates import x, y, z
 from jaxfun.galerkin import (
     Chebyshev,
     ChebyshevU,
@@ -47,7 +46,7 @@ def test_directsum_two_inhomogeneous_bnd_assembly_and_backward():
 
 
 def test_directsumtps_poisson_3d():
-    global x, y, z
+    from jaxfun.coordinates import x, y, z
 
     N = 20
     ue = sp.sin(2 * x) * sp.exp(2 * y + z * sp.I)
@@ -83,7 +82,7 @@ def test_directsumtps_poisson_3d():
 
 
 def test_directsumtps_biharmonic_dirichlet_3d():
-    global x, y, z
+    from jaxfun.coordinates import x, y, z
 
     N = 20
     ue = sp.sin(2 * x) * sp.exp(4 * y + z * sp.I)

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -22,7 +22,7 @@ from jaxfun.galerkin.inner import inner, inner_items, project
 from jaxfun.galerkin.tensorproductspace import DirectSumTPS
 from jaxfun.la import TPMatrix
 from jaxfun.operators import Div, Grad
-from jaxfun.utils.common import lambdify, ulp
+from jaxfun.utils.common import Domain, lambdify, ulp
 
 pytestmark = pytest.mark.integration
 
@@ -86,18 +86,25 @@ def test_directsumtps_biharmonic_dirichlet_3d():
 
     N = 20
     ue = sp.sin(2 * x) * sp.exp(4 * y + z * sp.I)
+    domain = Domain(-0.5, 0.5)
     bcsy = {
-        "left": {"D": ue.subs(y, -1)},
-        "right": {"D": ue.subs(y, 1)},
+        "left": {"D": ue.subs(y, domain.lower)},
+        "right": {"D": ue.subs(y, domain.upper)},
     }
     bcsz = {
-        "left": {"D": ue.subs(z, -1), "N": ue.diff(z, 1).subs(z, -1)},
-        "right": {"D": ue.subs(z, 1), "N": ue.diff(z, 1).subs(z, 1)},
+        "left": {
+            "D": ue.subs(z, domain.lower),
+            "N": ue.diff(z, 1).subs(z, domain.lower),
+        },
+        "right": {
+            "D": ue.subs(z, domain.upper),
+            "N": ue.diff(z, 1).subs(z, domain.upper),
+        },
     }
 
     F = Fourier.Fourier(N)
-    Dy = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsy)
-    Dz = FunctionSpace(N + 2, Chebyshev.Chebyshev, bcs=bcsz)
+    Dy = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsy, domain=domain)
+    Dz = FunctionSpace(N + 2, Chebyshev.Chebyshev, bcs=bcsz, domain=domain)
     T = TensorProduct(F, Dy, Dz)
     v = TestFunction(T)
     u = TrialFunction(T)


### PR DESCRIPTION
## Summary

Code was previously only working in 2D. Now it works in 3D.

## Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Build / CI
- [x] Other (describe):

## Description of Changes

Just adding the logic for 3D spaces. 

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [x] Coverage does not decrease
- [x] Git history is clean (squash/fixup before merge)
