### PR TITLE
Add CartesianProductSpace for mixed / composite function spaces

### DIFF
--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -1,0 +1,65 @@
+# ruff: noqa: E402
+import jax
+import matplotlib.pyplot as plt
+
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+from jaxfun.coordinates import x
+from jaxfun.galerkin import (
+    CartesianProduct,
+    FunctionSpace,
+    Legendre,
+    TensorProduct,
+    TestFunction,
+    TrialFunction,
+    inner,
+)
+from jaxfun.la.blocktpmatrix import BlockArray
+from jaxfun.operators import Constant, Div, Dot, Grad
+
+f = (1 - x) ** 2 * (1 + x) ** 2
+N = 24
+bcsx = {"left": {"D": 0}, "right": {"D": 0}}
+bcsy = {"left": {"D": 0}, "right": {"D": f}}
+nu = Constant("nu", 0.01)
+D0 = FunctionSpace(N, Legendre.Legendre, bcs=bcsx, name="D0")
+D1 = FunctionSpace(N, Legendre.Legendre, bcs=bcsy, name="D1")
+P0 = FunctionSpace(N - 2, Legendre.Legendre, name="P0")
+T0 = TensorProduct(D0, D1, name="T0")
+T1 = TensorProduct(D0, D0, name="T1")
+Q = TensorProduct(P0, P0, name="Q")
+V = CartesianProduct(T0, T1, name="V", rank=1)  # Vector
+W = CartesianProduct(V, Q, name="W")
+
+u, p = TrialFunction(W, name="up")
+v, q = TestFunction(W, name="vq")
+
+A, a = inner(
+    Dot(nu * Div(Grad(u)), v), sparse=True, kind="system", num_quad_points=(N, N)
+)
+B, b = inner(q * Div(u), sparse=True, kind="system", num_quad_points=(N, N))
+D = inner(p * Div(v), sparse=True, num_quad_points=(N, N))
+
+C = A + B + D
+c = a + b  # ty:ignore[unsupported-operator]
+
+CC = C.todense()
+blocks = jnp.array(C.test_block_sizes)
+r0 = jnp.sum(blocks[:2])
+CC = CC.at[r0].set(jnp.zeros(C.shape[0]))
+CC = CC.at[r0, r0].set(1.0)
+
+d = jnp.linalg.solve(CC, c.flatten())
+
+plt.spy(CC)
+
+D = BlockArray(W, flat_array=d)
+up_ = W.backward(D.array, N=(None, None, (N, N)))
+xj = W.mesh()
+shape = up_[0].shape
+x0, y0 = jnp.broadcast_to(xj[0], shape), jnp.broadcast_to(xj[1], shape)
+plt.figure()
+plt.contourf(x0, y0, jnp.sqrt(up_[0] ** 2 + up_[1] ** 2))
+plt.quiver(x0, y0, up_[0], up_[1])
+plt.show()

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -29,7 +29,9 @@ bcsy = {"left": {"D": 0}, "right": {"D": f}}
 nu = Constant("nu", 0.01)
 D0 = FunctionSpace(N, Legendre.Legendre, bcs=bcsx, name="D0")
 D1 = FunctionSpace(N, Legendre.Legendre, bcs=bcsy, name="D1")
-P0 = FunctionSpace(N - 2, Legendre.Legendre, name="P0")
+P0 = FunctionSpace(
+    N - 2, Legendre.Legendre, name="P0"
+)  # Need to use N - 2 to escape several nullspaces and excessive pinning  # noqa: E501
 T0 = TensorProduct(D0, D1, name="T0")
 T1 = TensorProduct(D0, D0, name="T1")
 Q = TensorProduct(P0, P0, name="Q")
@@ -48,6 +50,7 @@ D = inner(p * Div(v), sparse=True, num_quad_points=(N, N))
 C = A + B + D
 c = a + b  # ty:ignore[unsupported-operator]
 
+# pin pressure dof 0 - not yet implemented on BlockTPMatrix
 CC = C.todense()
 blocks = jnp.array(C.test_block_sizes)
 r0 = jnp.sum(blocks[:2])
@@ -56,14 +59,15 @@ CC = CC.at[r0, r0].set(1.0)
 
 d = jnp.linalg.solve(CC, c.flatten())
 
-plt.spy(CC)
-
 D = BlockArray(W, flat_array=d)
 up_ = W.backward(D.array, N=(None, None, (N, N)))
 xj = W.mesh()
 shape = up_[0].shape
 x0, y0 = jnp.broadcast_to(xj[0], shape), jnp.broadcast_to(xj[1], shape)
 plt.figure()
+plt.spy(CC)
+plt.figure()
 plt.contourf(x0, y0, jnp.sqrt(up_[0] ** 2 + up_[1] ** 2))
 plt.quiver(x0, y0, up_[0], up_[1])
+
 plt.show()

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -1,5 +1,6 @@
 # ruff: noqa: E402
 import os
+import sys
 
 import jax
 import matplotlib.pyplot as plt
@@ -50,24 +51,24 @@ D = inner(p * Div(v), sparse=True, num_quad_points=(N, N))
 C = A + B + D
 c = a + b  # ty:ignore[unsupported-operator]
 
-# pin pressure dof 0 - not yet implemented on BlockTPMatrix
-CC = C.todense()
-blocks = jnp.array(C.test_block_sizes)
-r0 = jnp.sum(blocks[:2])
-CC = CC.at[r0].set(jnp.zeros(C.shape[0]))
-CC = CC.at[r0, r0].set(1.0)
-
-d = jnp.linalg.solve(CC, c.flatten())
+# pin pressure dof 0
+C_pin = C.tosparse().pin({2 * (N - 2) ** 2: 0})
+d = C_pin.lu_solve(c.flatten(), method="rcm", pivot=True)
 
 D = BlockArray(W, flat_array=d)
 up_ = W.backward(D.array, N=(None, None, (N, N)))
+
+if "PYTEST" in os.environ:
+    for i in range(3):
+        assert jnp.all(jnp.isfinite(up_[i]))
+    sys.exit(0)
+
 xj = W.mesh()
 shape = up_[0].shape
 x0, y0 = jnp.broadcast_to(xj[0], shape), jnp.broadcast_to(xj[1], shape)
 plt.figure()
-plt.spy(CC)
+plt.spy(C_pin.todense())
 plt.figure()
 plt.contourf(x0, y0, jnp.sqrt(up_[0] ** 2 + up_[1] ** 2))
 plt.quiver(x0, y0, up_[0], up_[1])
-
 plt.show()

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -46,17 +46,17 @@ A, a = inner(
     Dot(nu * Div(Grad(u)), v), sparse=True, kind="system", num_quad_points=(N, N)
 )
 B, b = inner(q * Div(u), sparse=True, kind="system", num_quad_points=(N, N))
-D = inner(p * Div(v), sparse=True, kind="bilinear", num_quad_points=(N, N))
+Dp = inner(p * Div(v), sparse=True, kind="bilinear", num_quad_points=(N, N))
 
-C = A + B + D
+C = A + B + Dp
 c = a + b  # ty:ignore[unsupported-operator]
 
 # pin pressure dof 0
 C_pin = C.tosparse().pin({2 * (N - 2) ** 2: 0})
 d = C_pin.lu_solve(c.flatten(), method="rcm", pivot=True)
 
-D = BlockArray(W, flat_array=d)
-up_ = W.backward(D.array, N=(None, None, (N, N)))
+sol = BlockArray(W, flat_array=d)
+up_ = W.backward(sol.array, N=(None, None, (N, N)))
 
 if "PYTEST" in os.environ:
     for i in range(3):

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -46,7 +46,7 @@ A, a = inner(
     Dot(nu * Div(Grad(u)), v), sparse=True, kind="system", num_quad_points=(N, N)
 )
 B, b = inner(q * Div(u), sparse=True, kind="system", num_quad_points=(N, N))
-D = inner(p * Div(v), sparse=True, num_quad_points=(N, N))
+D = inner(p * Div(v), sparse=True, kind="bilinear", num_quad_points=(N, N))
 
 C = A + B + D
 c = a + b  # ty:ignore[unsupported-operator]

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -1,8 +1,12 @@
 # ruff: noqa: E402
+import os
+
 import jax
 import matplotlib.pyplot as plt
 
-jax.config.update("jax_enable_x64", True)
+if "PYTEST" not in os.environ:
+    jax.config.update("jax_enable_x64", True)
+
 import jax.numpy as jnp
 
 from jaxfun.coordinates import x

--- a/examples/biharmonic2D.py
+++ b/examples/biharmonic2D.py
@@ -43,7 +43,7 @@ A, b = inner(
     sparse=True,
     kind="system",
 )
-uh = A.solve(b)
+uh = A.solve(b, kron_method="rcm")
 
 N = 100
 xj = T.mesh(kind="uniform", N=(N, N))

--- a/examples/helmholtz2D.py
+++ b/examples/helmholtz2D.py
@@ -42,7 +42,7 @@ A, L = inner(
     v * (Div(Grad(u)) + u) - v * (Div(Grad(ue)) + ue), sparse=True, kind="system"
 )
 
-un = A.solve(L, method="kron", kron_method="banded")
+un = A.solve(L, method="kron", kron_method="banded", auto_threshold=10000)
 
 N = 100
 uj = T.evaluate_mesh(un, kind="uniform", N=(N, N))

--- a/examples/notebooks/formlanguage.py
+++ b/examples/notebooks/formlanguage.py
@@ -45,19 +45,19 @@ def _():
     import jax.numpy as jnp
 
     from jaxfun.galerkin import (
+        CartesianProduct,
         JAXFunction,
         Legendre,
         TensorProduct,
         TestFunction,
         TrialFunction,
-        VectorTensorProductSpace,
         inner,
     )
 
     N = 20
     V = Legendre.Legendre(N, name="V", fun_str="phi")
     T = TensorProduct(V, V, name="T")
-    W = VectorTensorProductSpace(T, name="W")
+    W = CartesianProduct(T, T, name="W", rank=1)  # Vector space
     v = TestFunction(V, name="v")
     f = TestFunction(T, name="f")
     w = TestFunction(W, name="w")

--- a/examples/notebooks/polar.py
+++ b/examples/notebooks/polar.py
@@ -21,6 +21,7 @@ def _():
 
     from jaxfun.coordinates import get_CoordSys
     from jaxfun.galerkin import (
+        CartesianProduct,
         FunctionSpace,
         Legendre,
         TensorProduct,
@@ -79,7 +80,19 @@ def _():
             20, Legendre.Legendre, domain=Domain(0, 1), name="Z", fun_str="L"
         )
         P = TensorProduct(R, T, Z, system=C, name="P")
-    return C, Cross, Curl, Div, Dot, Grad, P, TestFunction, TrialFunction, sp
+    return (
+        C,
+        CartesianProduct,
+        Cross,
+        Curl,
+        Div,
+        Dot,
+        Grad,
+        P,
+        TestFunction,
+        TrialFunction,
+        sp,
+    )
 
 
 @app.cell
@@ -172,10 +185,8 @@ def _(mo):
 
 
 @app.cell
-def _(P):
-    from jaxfun.galerkin import VectorTensorProductSpace
-
-    V = VectorTensorProductSpace(P, name="V")
+def _(CartesianProduct, P):
+    V = CartesianProduct(P, P, name="V", rank=1)
     V.tensorname
     return (V,)
 

--- a/examples/notebooks/polar.py
+++ b/examples/notebooks/polar.py
@@ -186,7 +186,10 @@ def _(mo):
 
 @app.cell
 def _(CartesianProduct, P):
-    V = CartesianProduct(P, P, name="V", rank=1)
+    if P.dims == 3:
+        V = CartesianProduct(P, P, P, name="V", rank=1)
+    else:
+        V = CartesianProduct(P, P, name="V", rank=1)
     V.tensorname
     return (V,)
 

--- a/examples/poisson1D_periodic.py
+++ b/examples/poisson1D_periodic.py
@@ -6,6 +6,7 @@ from typing import cast
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import sympy as sp
+from jax import Array
 
 from jaxfun.galerkin.arguments import TestFunction, TrialFunction
 from jaxfun.galerkin.Fourier import Fourier
@@ -26,7 +27,7 @@ ue = sp.cos(2 * x) + sp.I * sp.sin(1 * x)
 
 A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True, kind="system")
 A_pin = cast(DiaMatrix, A).pin({0: 0.0})
-uh = A_pin.solve(b)
+uh = A_pin.solve(cast(Array, b))
 
 uj = D.backward(uh)
 xj = D.mesh()

--- a/examples/poisson2D_curv.py
+++ b/examples/poisson2D_curv.py
@@ -38,7 +38,7 @@ ue = (1 - r) * (sp.S.Half - r) * theta * (sp.pi / 2 - theta)
 # A, b = inner(-Dot(Grad(u), Grad(v)) + v * Div(Grad(ue)), sparse=False)
 A, b = inner((v * Div(Grad(u)) - v * Div(Grad(ue))), sparse=True, kind="system")
 
-uh = A.solve(b)
+uh = A.solve(b, kron_method="rcm")
 
 rj, tj = T.mesh(kind="uniform", N=(100, 100))
 xc, yc = T.cartesian_mesh(kind="uniform", N=(100, 100))

--- a/examples/poisson2D_parabolic.py
+++ b/examples/poisson2D_parabolic.py
@@ -42,7 +42,7 @@ ue = (tau * (1 - tau)) ** 2 * (1 - sigma**2) ** 1 * sp.sin(4 * sp.pi * sigma)
 # Assemble linear system of equations
 A, b = inner((v * Div(Grad(u)) - v * Div(Grad(ue))) * C.sg, sparse=True, kind="system")
 
-un = A.solve(b)
+un = A.solve(b, kron_method="rcm")
 
 N = 100
 rj, tj = T.mesh(kind="uniform", N=(N, N))

--- a/src/jaxfun/coordinates.py
+++ b/src/jaxfun/coordinates.py
@@ -663,6 +663,13 @@ class CoordSys(Basic):
         # Return the instance
         return obj
 
+    def __deepcopy__(self, memo: dict) -> Self:
+        memo[id(self)] = self
+        return self
+
+    def __copy__(self) -> Self:
+        return self
+
     def sub_system(self, index: int = 0) -> SubCoordSys:
         return SubCoordSys(self, index)
 

--- a/src/jaxfun/galerkin/Chebyshev.py
+++ b/src/jaxfun/galerkin/Chebyshev.py
@@ -294,7 +294,7 @@ class Chebyshev(Jacobi):
             return self.derivative_coeffs(self.derivative_coeffs(c, k - 1), 1)
 
         N: int = c.shape[0] - 1
-        x0: Array = jnp.array(0.0, dtype=float)
+        x0: Array = jnp.zeros((), dtype=c.dtype)
         if N == 0:
             return jnp.array([x0])
         x1: Array = c[-1] * N * 2

--- a/src/jaxfun/galerkin/Jacobi.py
+++ b/src/jaxfun/galerkin/Jacobi.py
@@ -229,7 +229,7 @@ class Jacobi(OrthogonalSpace):
         if self.alpha != self.beta:
             bb = sp.lambdify(n, self.b(n + 1, n + 1), modules="jax")(jnp.arange(N))
 
-        x0: Array = jnp.array(0.0)
+        x0: Array = jnp.zeros((), dtype=c.dtype)
         if N == 0:
             return x0
         x1: Array = c[-1] / bm[-1]

--- a/src/jaxfun/galerkin/Legendre.py
+++ b/src/jaxfun/galerkin/Legendre.py
@@ -196,7 +196,7 @@ class Legendre(Jacobi):
             return self.derivative_coeffs(self.derivative_coeffs(c, k - 1), 1)
 
         N: int = c.shape[0] - 1
-        x0: Array = jnp.array(0.0)
+        x0: Array = jnp.zeros((), dtype=c.dtype)
         if N == 0:
             return jnp.array([x0])
         x1: Array = c[-1] * (2 * N - 1)

--- a/src/jaxfun/galerkin/__init__.py
+++ b/src/jaxfun/galerkin/__init__.py
@@ -14,6 +14,11 @@ from .arguments import (
     TestFunction as TestFunction,
     TrialFunction as TrialFunction,
 )
+from .cartesianproductspace import (
+    CartesianProduct as CartesianProduct,
+    CartesianProductSpace as CartesianProductSpace,
+    VectorTensorProductSpace as VectorTensorProductSpace,
+)
 from .composite import Composite as Composite, DirectSum as DirectSum
 from .functionspace import FunctionSpace as FunctionSpace
 from .inner import inner as inner, inner_items as inner_items
@@ -21,5 +26,4 @@ from .tensorproductspace import (
     DirectSumTPS as DirectSumTPS,
     TensorProduct as TensorProduct,
     TensorProductSpace as TensorProductSpace,
-    VectorTensorProductSpace as VectorTensorProductSpace,
 )

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -197,7 +197,9 @@ def _get_computational_function(
             for a, v in zip(base_scalars, V.basespaces, strict=False)
         )
 
-    assert isinstance(V, VectorTensorProductSpace)
+    assert isinstance(V, VectorTensorProductSpace), (
+        f"expected VectorTensorProductSpace, got {type(V).__name__}"
+    )
     b = V.system.base_vectors()
     return VectorAdd.fromiter(
         sp.Mul.fromiter(
@@ -820,7 +822,8 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         """Evaluate the JAXFunction at given points x in the physical domain.
 
         Args:
-            x: Coordinates (N, d). Created by calling self.functionspace.flatmesh().
+            x: Coordinates (N, d). Created, e.g., by calling
+                self.functionspace.flatmesh().
         """
         V = cast(FunctionSpaceType, self.functionspace)
         if isinstance(V, OrthogonalSpace | DirectSum):

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -10,11 +10,12 @@ Key constructs:
     * JAXFunction: Galerkin functions with JAX-backed coefficients.
 """
 
-import itertools
+from __future__ import annotations
+
 from abc import abstractmethod
 from enum import Enum, unique
 from functools import partial
-from typing import Any, Literal, Self, cast
+from typing import Any, Literal, Self, TypeVar, cast, overload
 
 import jax
 import jax.numpy as jnp
@@ -27,21 +28,26 @@ from sympy.vector import VectorAdd
 
 from jaxfun.basespace import BaseSpace
 from jaxfun.coordinates import BaseScalar, CoordSys, Vector, latex_symbols
+from jaxfun.galerkin.cartesianproductspace import (
+    CartesianProductSpace,
+    VectorTensorProductSpace,
+)
 from jaxfun.typing import (
+    ComputationalSpaceType,
     FunctionSpaceType,
     MeshKind,
     Padding,
+    ScalarSpaceType,
     TestSpaceType,
     TrialSpaceType,
 )
 
 from .composite import DirectSum
 from .orthogonal import OrthogonalSpace
-from .tensorproductspace import (
-    DirectSumTPS,
-    TensorProductSpace,
-    VectorTensorProductSpace,
-)
+from .tensorproductspace import DirectSumTPS, TensorProductSpace
+
+_CompositeSpaceT = TypeVar("_CompositeSpaceT", bound=CartesianProductSpace)
+_ScalarSpaceT = TypeVar("_ScalarSpaceT", bound=ScalarSpaceType)
 
 t, x, y, z = sp.symbols("t,x,y,z", real=True)
 
@@ -63,8 +69,9 @@ def get_arg(p: Any) -> ArgumentTag:
 def get_BasisFunction(
     name: str,
     *,
-    global_index: int,
+    vector_index: int,
     local_index: int,
+    global_index: int,
     rank: int,
     offset: int,
     functionspace: BaseSpace,
@@ -78,8 +85,9 @@ def get_BasisFunction(
 
     Args:
         name: Base name (usually space.fun_str).
-        global_index: Global component index for vector-valued spaces.
+        vector_index: Component index for vector-valued spaces.
         local_index: Local index within a 1D factor space.
+        global_index: Global index for scalar functionspace.
         rank: Tensor rank of the overall function space (0 or 1).
         offset: Shift applied to index selection (test vs trial).
         functionspace: Parent function space object.
@@ -101,7 +109,7 @@ def get_BasisFunction(
         if cls.rank == 0:
             return lhs + rhs
         elif cls.rank == 1:
-            sup = "^{(" + str(cls.global_index) + ")}"
+            sup = "^{(" + str(cls.vector_index) + ")}"
             return lhs + sup + rhs
         raise NotImplementedError("Rank > 1 basis functions not supported.")
 
@@ -118,7 +126,7 @@ def get_BasisFunction(
         if cls.rank == 0:
             s = lhs + rhs
         elif cls.rank == 1:
-            sup = "^{(" + str(cls.global_index) + ")}"
+            sup = "^{(" + str(cls.vector_index) + ")}"
             s = lhs + sup + rhs
         else:
             raise NotImplementedError("Rank > 1 basis functions not supported.")
@@ -126,8 +134,9 @@ def get_BasisFunction(
 
     b: AppliedUndef = sp.Function(
         name,
-        global_index=global_index,
+        vector_index=vector_index,
         local_index=local_index,
+        global_index=global_index,
         rank=rank,
         offset=offset,
         functionspace=functionspace,
@@ -141,7 +150,9 @@ def get_BasisFunction(
     return b
 
 
-def _get_computational_function(arg: str, V: TestSpaceType) -> Expr | AppliedUndef:
+def _get_computational_function(
+    arg: str, V: ComputationalSpaceType
+) -> Expr | AppliedUndef:
     """Return symbolic test or trial function in computational coordinates.
 
     Dispatches on space type and builds a product (scalar) or VectorAdd
@@ -160,8 +171,9 @@ def _get_computational_function(arg: str, V: TestSpaceType) -> Expr | AppliedUnd
         assert base_scalars[0].is_Symbol
         return get_BasisFunction(
             V.fun_str,
-            global_index=0,
+            vector_index=0,
             local_index=0,
+            global_index=getattr(V, "global_index", 0),
             rank=0,
             offset=offset,
             functionspace=V,
@@ -173,8 +185,9 @@ def _get_computational_function(arg: str, V: TestSpaceType) -> Expr | AppliedUnd
         return sp.Mul.fromiter(
             get_BasisFunction(
                 v.fun_str,
-                global_index=0,
+                vector_index=0,
                 local_index=getattr(a, "_id", [0])[0],
+                global_index=getattr(V, "global_index", 0),
                 rank=0,
                 offset=offset,
                 functionspace=v,
@@ -184,25 +197,26 @@ def _get_computational_function(arg: str, V: TestSpaceType) -> Expr | AppliedUnd
             for a, v in zip(base_scalars, V.basespaces, strict=False)
         )
 
-    elif isinstance(V, VectorTensorProductSpace):
-        b = V.system.base_vectors()
-        return VectorAdd.fromiter(
-            sp.Mul.fromiter(
-                get_BasisFunction(
-                    v.fun_str,
-                    global_index=i,
-                    local_index=getattr(a, "_id", [0])[0],
-                    rank=1,
-                    offset=offset,
-                    functionspace=v,
-                    argument=ArgumentTag.TEST if arg == "test" else ArgumentTag.TRIAL,
-                    arg=a,
-                )
-                for a, v in zip(base_scalars, Vi, strict=False)
+    assert isinstance(V, VectorTensorProductSpace)
+    b = V.system.base_vectors()
+    return VectorAdd.fromiter(
+        sp.Mul.fromiter(
+            get_BasisFunction(
+                v.fun_str,
+                vector_index=i,
+                local_index=getattr(a, "_id", [0])[0],
+                global_index=getattr(Vi, "global_index", 0),
+                rank=1,
+                offset=offset,
+                functionspace=v,
+                argument=ArgumentTag.TEST if arg == "test" else ArgumentTag.TRIAL,
+                arg=a,
             )
-            * b[i]
-            for i, Vi in enumerate(V)
+            for a, v in zip(base_scalars, Vi, strict=False)
         )
+        * b[i]
+        for i, Vi in enumerate(V)
+    )
 
 
 class BaseFunction(Function):
@@ -263,6 +277,10 @@ class ExpansionFunction(BaseFunction):
                 name = r"\mathbf{ {%s} }" % (name,)  # noqa: UP031
         return f"{name}({self.c_names}; {self.functionspace.name})"
 
+    def __getitem__(self, i: int) -> sp.Expr:
+        assert isinstance(self.functionspace, CartesianProductSpace)
+        return self.__class__(self.functionspace[i], name=self.name[i])
+
 
 # NOTE
 # Need a unique Symbol in order to create a new TestFunction/TrialFunction for a new
@@ -287,37 +305,26 @@ class TestFunction(ExpansionFunction):
         coors = V.system
         obj: Self = Function.__new__(cls, *(list(coors._cartesian_xyz) + [sp.Dummy()]))
         obj.argument = ArgumentTag.TEST
-        if isinstance(V, DirectSum):
-            obj.functionspace = V[0]
-        elif isinstance(V, TensorProductSpace | DirectSumTPS):
-            f = []
-            vname = V.name
-            for space in V.basespaces:
-                if isinstance(space, DirectSum):
-                    f.append(space[0])
-                else:
-                    f.append(space)
-            obj.functionspace = TensorProductSpace(f, name=vname, system=V.system)
-        elif isinstance(V, VectorTensorProductSpace):
-            f = []
-            vname = V.name
-            for space in V:
-                g = []
-                for s in space:
-                    if isinstance(s, DirectSum):
-                        g.append(s[0])
-                    else:
-                        g.append(s)
-                f.append(TensorProductSpace(g, name=vname, system=V.system))
-            obj.functionspace = VectorTensorProductSpace(tuple(f), name=V.name)
-        else:
+
+        if isinstance(V, DirectSum | DirectSumTPS | CartesianProductSpace):
+            obj.functionspace = V.get_homogeneous()
+        elif isinstance(V, OrthogonalSpace | TensorProductSpace):
             obj.functionspace = V
+        else:
+            raise ValueError("Unknown test space")
+
         obj.name = name if name is not None else "TestFunction"
         obj.own_name = "TestFunction"
         return obj
 
     def doit(self, **hints: Any) -> Expr | AppliedUndef:
-        return _get_computational_function("test", self.functionspace)
+        if self.functionspace.rank < 0:
+            raise ValueError(
+                "TestFunction expansion not possible for CartesianProductSpace"
+            )
+        return _get_computational_function(
+            "test", cast(ComputationalSpaceType, self.functionspace)
+        )
 
 
 class TrialFunction(ExpansionFunction):
@@ -359,40 +366,33 @@ class TrialFunction(ExpansionFunction):
         comp_fun = partial(_get_computational_function, "trial")
         if isinstance(fspace, DirectSum):
             return sp.Add.fromiter(comp_fun(f) for f in fspace.basespaces)
-        elif isinstance(fspace, TensorProductSpace):
-            spaces = fspace.basespaces
-            f = []
-            for space in spaces:
-                if isinstance(space, DirectSum):
-                    f.append(space)
-                else:
-                    f.append([space])
-            tensorspaces = itertools.product(*f)
-            return sp.Add.fromiter(
-                comp_fun(TensorProductSpace(s, fspace.system, f"{fspace.name}{i}"))
-                for i, s in enumerate(tensorspaces)
-            )
+
+        elif isinstance(fspace, DirectSumTPS):
+            return sp.Add.fromiter(comp_fun(f) for f in fspace.tpspaces.values())
+
         elif isinstance(fspace, VectorTensorProductSpace):
             vector = []
-            for i, (bi, tpspaces) in enumerate(
-                zip(fspace.system.base_vectors(), fspace.tensorspaces, strict=True)
+            for i, (bi, tpspace) in enumerate(
+                zip(
+                    fspace.system.base_vectors(),
+                    fspace.flatten(),
+                    strict=True,
+                )
             ):
-                fi = []
-                spaces = tpspaces.basespaces
-                for space in spaces:
-                    if isinstance(space, DirectSum):
-                        fi.append(space)
-                    else:
-                        fi.append([space])
-                tpspaces = itertools.product(*fi)
+                tpspaces = (
+                    tpspace.tpspaces.values()
+                    if isinstance(tpspace, DirectSumTPS)
+                    else [tpspace]
+                )
+
                 for Vi in tpspaces:
-                    T = TensorProductSpace(Vi, fspace.system, f"{fspace.name}{i}")
-                    f = (
+                    vector.append(
                         sp.Mul.fromiter(
                             get_BasisFunction(
                                 v.fun_str,
-                                global_index=i,
+                                vector_index=i,
                                 local_index=getattr(a, "_id", [0])[0],
+                                global_index=getattr(Vi, "global_index", 0),
                                 rank=1,
                                 offset=fspace.dims,
                                 functionspace=v,
@@ -400,15 +400,14 @@ class TrialFunction(ExpansionFunction):
                                 arg=a,
                             )
                             for a, v in zip(
-                                fspace.system.base_scalars(), T, strict=True
+                                fspace.system.base_scalars(), Vi, strict=True
                             )
                         )
                         * bi
                     )
-                    vector.append(f)
             return VectorAdd.fromiter(vector)
 
-        return comp_fun(fspace)
+        return comp_fun(cast(ComputationalSpaceType, fspace))
 
 
 class ScalarFunction(BaseFunction):
@@ -662,103 +661,143 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         name: Optional name for the JAXFunction object.
     """
 
-    array: Array
+    array: Array | tuple[Array, ...]
     argument: Literal[ArgumentTag.JAXFUNC]
     functionspace: SpaceT
 
     def __new__(
         cls,
-        array: Array | sp.Expr,
+        array: Array | tuple[Array, ...] | sp.Expr | sp.Tuple,
         V: SpaceT,
         name: str | None = None,
     ) -> Self:
+        from .inner import project
+
         coors: CoordSys = V.system
         obj: Self = Function.__new__(cls, *(list(coors._cartesian_xyz) + [sp.Dummy()]))
         if isinstance(array, sp.Expr):
-            from .inner import project
+            array = project(array, cast(ScalarSpaceType, V))
 
-            array = project(array, V)
+        elif isinstance(array, sp.Tuple):
+            array = project(array, cast(CartesianProductSpace, V))
+
         obj.array = array
-        dof_shape = V.num_dofs if V.dims > 1 else (V.num_dofs,)
-        assert array.shape == dof_shape, (
-            f"Array shape {array.shape} does not match number of DOFs {V.num_dofs} for function space {V.name}"  # noqa: E501
-        )
-
         obj.functionspace = V
         obj.argument = ArgumentTag.JAXFUNC
         obj.name = name if name is not None else "JAXFunction"
         obj.own_name = "JAXFunction"
         return obj
 
+    @overload
     def backward(
-        self,
-        N: Padding = None,
-    ) -> Array:
+        self: JAXFunction[_CompositeSpaceT], N: Padding = None
+    ) -> tuple[Array, ...]: ...
+    @overload
+    def backward(self: JAXFunction[_ScalarSpaceT], N: Padding = None) -> Array: ...
+    def backward(self, N: Padding = None) -> Array | tuple[Array, ...]:
         return self.functionspace.backward(self.array, N=N)  # ty: ignore[invalid-argument-type]
 
     def doit(self, **hints: Any) -> Expr | AppliedUndef:
         hints["linear"] = hints.get("linear", False)
-        fs = self.functionspace
-        rank = getattr(fs, "rank", 0)
+        V = self.functionspace
 
         if hints.get("linear", True):
-            trial = TrialFunction(fs).doit()
-            offset = 1 if isinstance(fs, OrthogonalSpace | DirectSum) else fs.dims
+            trial = TrialFunction(V).doit()
+            offset = 1 if isinstance(V, OrthogonalSpace | DirectSum) else V.dims
             local_indices = slice(offset, 2 * offset)
             global_index = 0
             hat = f"\\hat{{{self.name}}}"
-            if rank == 0:
+            if V.rank == 0:
                 name = "".join((hat, "_{", indices[local_indices], "}"))
-                return Jaxc(self.array, fs, name=name) * trial
+                return Jaxc(cast(Array, self.array), V, name=name) * trial
 
-            assert rank == 1
-            assert isinstance(fs, VectorTensorProductSpace)
-            s = []
-            for k, v in cast(Vector, trial).components.items():
-                global_index = k._id[0]
-                name = "".join(
-                    (hat, "_{", indices[local_indices], "}^{(", str(global_index), ")}")
+            elif V.rank == 1:
+                assert isinstance(V, VectorTensorProductSpace)
+                s = []
+                for k, v in cast(Vector, trial).components.items():
+                    global_index = k._id[0]
+                    name = "".join(
+                        (
+                            hat,
+                            "_{",
+                            indices[local_indices],
+                            "}^{(",
+                            str(global_index),
+                            ")}",
+                        )
+                    )
+                    s.append(
+                        Jaxc(self.array[global_index], V[global_index], name=name)
+                        * k
+                        * v
+                    )
+                return trial.func(*s)
+
+            else:
+                raise ValueError(
+                    "Unranked Composite space not supported for linear expansion."
                 )
-                s.append(
-                    Jaxc(self.array[global_index], fs[global_index], name=name) * k * v
-                )
-            return trial.func(*s)
 
         # Nonlinear case, return a multivar function.
-        if rank == 0:
+        if V.rank == 0:
             return get_JAXFunction(
                 self.name,
-                array=self.array,
+                array=cast(Array, self.array),
                 global_index=0,
                 rank=0,
-                functionspace=fs,
+                functionspace=V,
                 argument=ArgumentTag.JAXFUNC,
-                args=fs.system.base_scalars(),
+                args=V.system.base_scalars(),
             )
 
-        assert rank == 1
-        assert isinstance(fs, VectorTensorProductSpace)
+        elif V.rank == 1:
+            assert isinstance(V, VectorTensorProductSpace)
 
-        return VectorAdd.fromiter(
-            get_JAXFunction(
-                "".join((self.name, "^{(", str(i), ")}")),
-                array=self.array[i],
-                global_index=i,
-                rank=0,
-                functionspace=fs[i],
-                argument=ArgumentTag.JAXFUNC,
-                args=fs.system.base_scalars(),
+            return VectorAdd.fromiter(
+                get_JAXFunction(
+                    "".join((self.name, "^{(", str(i), ")}")),
+                    array=self.array[i],
+                    global_index=i,
+                    rank=0,
+                    functionspace=V[i],
+                    argument=ArgumentTag.JAXFUNC,
+                    args=V.system.base_scalars(),
+                )
+                * bi
+                for i, bi in enumerate(V.system.base_vectors())
             )
-            * bi
-            for i, bi in enumerate(fs.system.base_vectors())
-        )
 
+        else:
+            raise ValueError(
+                "Unranked Composite space not supported for nonlinear expansion."
+            )
+
+    @overload
+    def __matmul__(
+        self: JAXFunction[_CompositeSpaceT], a: tuple[Array, ...]
+    ) -> tuple[Array, ...]: ...
+    @overload
+    def __matmul__(self: JAXFunction[_ScalarSpaceT], a: Array) -> Array: ...
     @jax.jit(static_argnums=0)
-    def __matmul__(self, a: Array) -> Array:
+    def __matmul__(self, a: Array | tuple[Array, ...]) -> Array | tuple[Array, ...]:
+        if isinstance(self.array, tuple):
+            assert isinstance(a, tuple) and len(self.array) == len(a)
+            return tuple(ai @ ai_ for ai, ai_ in zip(self.array, a))
+        assert isinstance(a, Array)
         return self.array @ a
 
+    @overload
+    def __rmatmul__(
+        self: JAXFunction[_CompositeSpaceT], a: tuple[Array, ...]
+    ) -> tuple[Array, ...]: ...
+    @overload
+    def __rmatmul__(self: JAXFunction[_ScalarSpaceT], a: Array) -> Array: ...
     @jax.jit(static_argnums=0)
-    def __rmatmul__(self, a: Array) -> Array:
+    def __rmatmul__(self, a: Array | tuple[Array, ...]) -> Array | tuple[Array, ...]:
+        if isinstance(self.array, tuple):
+            assert isinstance(a, tuple) and len(self.array) == len(a)
+            return tuple(ai_ @ ai for ai, ai_ in zip(a, self.array))
+        assert isinstance(a, Array)
         return a @ self.array
 
     @jax.jit(static_argnums=0)
@@ -768,14 +807,12 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         Args:
             x: Coordinates (N, d). Created by calling self.functionspace.flatmesh().
         """
-        functionspace = self.functionspace
-        if isinstance(functionspace, OrthogonalSpace | DirectSum):
-            return functionspace.evaluate(x, self.array)
-        assert isinstance(
-            functionspace, TensorProductSpace | VectorTensorProductSpace | DirectSumTPS
-        )
-        z = functionspace.evaluate(x, self.array)
-        if functionspace.rank == 0:
+        V = cast(FunctionSpaceType, self.functionspace)
+        if isinstance(V, OrthogonalSpace | DirectSum | TensorProductSpace):
+            return V.evaluate(x, cast(Array, self.array))
+
+        z = V.evaluate(x, cast(tuple[Array, ...], self.array))
+        if V.rank == 0:
             return jnp.expand_dims(z, -1)
         return z
 
@@ -793,19 +830,64 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
 
 def evaluate_jaxfunction_expr_quad(
     a: Basic,
-    jaxf: JAXFunction | None = None,
     N: int | tuple[int | None, ...] | None = None,
 ) -> Array:
-    """Evaluate a symbolic JAXFunction expression on the quadrature mesh."""
+    """Evaluate a symbolic JAXFunction expression on the quadrature mesh.
+
+    Args:
+        a: SymPy expression potentially containing JAXFunction objects.
+        N: Optional padding for the number of quadrature points in each dimension.
+    """
     from jaxfun.integrators.nonlinear import compile_nonlinear_evaluator
 
-    if jaxf is None:
-        from .forms import get_jaxfunctions
+    from .forms import get_jaxfunctions
 
-        jaxf: set[JAXFunction] = get_jaxfunctions(a)
-        assert len(jaxf) == 1, "Single JAXFunction not found in expression."
-        jaxf: JAXFunction = jaxf.pop()
+    jaxfs: set[JAXFunction] = get_jaxfunctions(a)
 
+    if len(jaxfs) > 1:
+        # Multiple JAXFunction components present.  Split into
+        # per-component sub-expressions and evaluate each independently.
+
+        if isinstance(a, sp.Add):
+            result = jnp.asarray(0.0)
+            for arg in a.args:
+                result = result + evaluate_jaxfunction_expr_quad(arg, N=N)
+            return result
+
+        if not isinstance(a, sp.Mul):
+            raise NotImplementedError(
+                f"Multiple JAXFunctions in non-Mul expression not supported: {a}"
+            )
+        # Partition args by the identity of the single JAXFunction they
+        # depend on.  Args that share the same JAXFunction (e.g.
+        # U^(0) and d(U^(0))/dx) are grouped together so the nonlinear
+        # compiler can handle them as a single sub-expression.
+        groups: dict[int, sp.Expr] = {}
+        for arg in a.args:
+            arg_jaxfs = get_jaxfunctions(arg)
+            if len(arg_jaxfs) == 0:
+                # Static/numeric factor: attach to an arbitrary group so it
+                # is folded in; use key -1 to signal "no JAXFunction".
+                key = -1
+            elif len(arg_jaxfs) == 1:
+                key = id(next(iter(arg_jaxfs)))
+            else:
+                # arg itself has multiple JAXFunctions — treat as its own
+                # group and let the recursion resolve it.
+                key = id(arg)
+            groups[key] = cast(sp.Expr, groups.get(key, sp.Integer(1)) * arg)
+
+        result = jnp.asarray(1.0)
+        for key, sub_expr in groups.items():
+            if key == -1:
+                # Pure numeric/symbolic constant — evaluate to a scalar.
+                result = result * float(sub_expr)
+            else:
+                result = result * evaluate_jaxfunction_expr_quad(sub_expr, N=N)
+        return result
+
+    assert len(jaxfs) == 1, "Single JAXFunction not found in expression."
+    jaxf = jaxfs.pop()
     V = jaxf.functionspace
     fun = compile_nonlinear_evaluator(cast(sp.Expr, a), V, cast(AppliedUndef, jaxf))
-    return fun(jaxf.array, N)
+    return fun(cast(Array, jaxf.array), N)

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -46,12 +46,12 @@ from .composite import DirectSum
 from .orthogonal import OrthogonalSpace
 from .tensorproductspace import DirectSumTPS, TensorProductSpace
 
-_CompositeSpaceT = TypeVar("_CompositeSpaceT", bound=CartesianProductSpace)
-_ScalarSpaceT = TypeVar("_ScalarSpaceT", bound=ScalarSpaceType)
-
 t, x, y, z = sp.symbols("t,x,y,z", real=True)
 
 indices = "ijklmn"
+
+_CompositeSpaceT = TypeVar("_CompositeSpaceT", bound=CartesianProductSpace)
+_ScalarSpaceT = TypeVar("_ScalarSpaceT", bound=ScalarSpaceType)
 
 
 @unique
@@ -689,6 +689,13 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         return obj
 
     @overload
+    def get_array(self: JAXFunction[_CompositeSpaceT]) -> tuple[Array, ...]: ...
+    @overload
+    def get_array(self: JAXFunction[_ScalarSpaceT]) -> Array: ...
+    def get_array(self) -> Array | tuple[Array, ...]:
+        return self.array
+
+    @overload
     def backward(
         self: JAXFunction[_CompositeSpaceT], N: Padding = None
     ) -> tuple[Array, ...]: ...
@@ -808,10 +815,14 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
             x: Coordinates (N, d). Created by calling self.functionspace.flatmesh().
         """
         V = cast(FunctionSpaceType, self.functionspace)
-        if isinstance(V, OrthogonalSpace | DirectSum | TensorProductSpace):
+        if isinstance(V, OrthogonalSpace | DirectSum):
             return V.evaluate(x, cast(Array, self.array))
 
-        z = V.evaluate(x, cast(tuple[Array, ...], self.array))
+        if isinstance(V, TensorProductSpace):
+            z = V.evaluate(x, cast(Array, self.array))
+        else:
+            z = V.evaluate(x, cast(tuple[Array, ...], self.array))
+
         if V.rank == 0:
             return jnp.expand_dims(z, -1)
         return z

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -279,7 +279,15 @@ class ExpansionFunction(BaseFunction):
 
     def __getitem__(self, i: int) -> sp.Expr:
         assert isinstance(self.functionspace, CartesianProductSpace)
-        return self.__class__(self.functionspace[i], name=self.name[i])
+        result = self.__class__(self.functionspace[i], name=self.name[i])
+        parent = self.functionspace
+        if isinstance(result.functionspace, CartesianProductSpace):
+            result.functionspace.leaf = parent
+            for space in result.functionspace.flatten():
+                space.leaf = parent
+        elif isinstance(result.functionspace, TensorProductSpace):
+            result.functionspace.leaf = parent
+        return result
 
 
 # NOTE

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -706,9 +706,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         return self.array
 
     @overload
-    def backward(
-        self: JAXFunction[_CompositeSpaceT], N: Padding = None
-    ) -> tuple[Array, ...]: ...
+    def backward(self: JAXFunction[_CompositeSpaceT], N: Padding = None) -> Array: ...
     @overload
     def backward(self: JAXFunction[_ScalarSpaceT], N: Padding = None) -> Array: ...
     def backward(self, N: Padding = None) -> Array | tuple[Array, ...]:

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -279,7 +279,7 @@ class ExpansionFunction(BaseFunction):
                 name = r"\mathbf{ {%s} }" % (name,)  # noqa: UP031
         return f"{name}({self.c_names}; {self.functionspace.name})"
 
-    def __getitem__(self, i: int) -> sp.Expr:
+    def __getitem__(self, i: int) -> Self:
         assert isinstance(self.functionspace, CartesianProductSpace)
         result = self.__class__(self.functionspace[i], name=self.name[i])
         parent = self.functionspace

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -705,11 +705,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
     def get_array(self) -> Array | tuple[Array, ...]:
         return self.array
 
-    @overload
-    def backward(self: JAXFunction[_CompositeSpaceT], N: Padding = None) -> Array: ...
-    @overload
-    def backward(self: JAXFunction[_ScalarSpaceT], N: Padding = None) -> Array: ...
-    def backward(self, N: Padding = None) -> Array | tuple[Array, ...]:
+    def backward(self, N: Padding = None) -> Array:
         return self.functionspace.backward(self.array, N=N)  # ty: ignore[invalid-argument-type]
 
     def doit(self, **hints: Any) -> Expr | AppliedUndef:

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -281,7 +281,21 @@ class ExpansionFunction(BaseFunction):
 
     def __getitem__(self, i: int) -> Self:
         assert isinstance(self.functionspace, CartesianProductSpace)
-        result = self.__class__(self.functionspace[i], name=self.name[i])
+        name = self.name
+        if (
+            isinstance(self.functionspace, VectorTensorProductSpace)
+            and len(self.name) == 1
+        ):
+            # use indices
+            name = self.name + "_" + str(i)
+        elif len(name) == len(self.functionspace):
+            name = name[i]
+        else:
+            raise ValueError(
+                f"Lenght of self.name {self.name} != "
+                f"len(self.functionspace) = {len(self.functionspace)}"
+            )
+        result = self.__class__(self.functionspace[i], name=name)
         parent = self.functionspace
         if isinstance(result.functionspace, CartesianProductSpace):
             result.functionspace.leaf = parent
@@ -323,6 +337,15 @@ class TestFunction(ExpansionFunction):
         else:
             raise ValueError("Unknown test space")
 
+        if isinstance(V, CartesianProductSpace):
+            if name is None:
+                name = "abcdefg"[len(V)]
+            elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
+                raise ValueError(
+                    f"Lenght of name str must equal the length of basespaces in "
+                    f"CartesianProductSpace. Got {len(V)} basespaces and "
+                    f"len({name}) == {len(name)}"
+                )
         obj.name = name if name is not None else "TestFunction"
         obj.own_name = "TestFunction"
         return obj
@@ -360,6 +383,15 @@ class TrialFunction(ExpansionFunction):
             cls, *(list(coors._cartesian_xyz) + time_arg + [sp.Dummy()])
         )
         obj.functionspace = V
+        if isinstance(V, CartesianProductSpace):
+            if name is None:
+                name = "abcdefg"[len(V)]
+            elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
+                raise ValueError(
+                    f"Lenght of name str must equal the length of basespaces in "
+                    f"CartesianProductSpace. Got {len(V)} basespaces and "
+                    f"len({name}) == {len(name)}"
+                )
         obj.name = name if name is not None else "TrialFunction"
         obj.own_name = "TrialFunction"
         obj.argument = ArgumentTag.TRIAL

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterator
+from typing import Any, cast
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from jaxfun.coordinates import CoordSys
+from jaxfun.galerkin.tensorproductspace import TensorProductSpace, multiplication_sign
+from jaxfun.sharding import physical_sharding, spectral_sharding
+from jaxfun.typing import MeshKind
+
+
+def CartesianProduct(
+    *basespaces: TensorProductSpace | CartesianProductSpace,
+    name: str = "T",
+    rank: int = -1,
+) -> CartesianProductSpace:
+    """Factory returning CartesianProductSpace.
+
+    Args:
+
+    Returns:
+        Instance of CartesianProductSpace
+    """
+    basespaces_list: list[TensorProductSpace | CartesianProductSpace] = [
+        copy.deepcopy(space) for space in basespaces
+    ]
+    if rank == 1:
+        return VectorTensorProductSpace(*basespaces_list, name=name)
+    return CartesianProductSpace(*basespaces_list, name=name, rank=rank)
+
+
+class CartesianProductSpace:
+    """Composite tensor product space.
+
+    Represents a tuple of identical (or differing in boundary conditions)
+    TensorProductSpace objects.
+
+    Attributes:
+        tensorspaces: Tuple of component tensor spaces.
+        system: Shared coordinate system.
+        name: Label.
+        tensorname: Joined printable representation.
+    """
+
+    is_transient = False
+
+    def __init__(
+        self,
+        *basespaces: TensorProductSpace | CartesianProductSpace,
+        name: str = "CTPS",
+        rank: int = -1,
+    ) -> None:
+        from jaxfun.galerkin import DirectSumTPS
+
+        self.basespaces: list[TensorProductSpace | CartesianProductSpace] = [
+            copy.deepcopy(space) for space in basespaces
+        ]
+        self.system: CoordSys = self.basespaces[0].system
+        self.name = name
+        self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])
+        self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
+        self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
+        self.leaf: CartesianProductSpace = self
+
+        for space in self.basespaces:
+            space.leaf = self
+
+        for i, space in enumerate(self.flatten()):
+            space.global_index = i
+            space.leaf = self
+            if isinstance(space, DirectSumTPS):
+                for tpspace in space.tpspaces.values():
+                    tpspace.global_index = i
+                    tpspace.leaf = self
+
+        self.mesh = self.basespaces[0].mesh
+        self.num_quad_points = self.basespaces[0].num_quad_points
+
+    def __len__(self) -> int:
+        """Return number of subspaces."""
+        return len(self.basespaces)
+
+    def __iter__(self) -> Iterator[CartesianProductSpace | TensorProductSpace]:
+        """Iterate over component spaces."""
+        return iter(self.basespaces)
+
+    def __getitem__(self, i: int) -> CartesianProductSpace | TensorProductSpace:
+        """Return component space i."""
+        return self.basespaces[i]
+
+    def flatten(self) -> list[TensorProductSpace]:
+        """Return flattened list of all component tensor spaces."""
+        spaces: list[TensorProductSpace] = []
+        for space in self.basespaces:
+            if isinstance(space, CartesianProductSpace):
+                spaces.extend(space.flatten())
+            else:
+                spaces.append(space)
+        return spaces
+
+    @property
+    def num_components(self) -> int:
+        """Return total number of scalar components."""
+        return len(self.flatten())
+
+    @property
+    def rank(self) -> int:
+        """Return tensor rank (1 for vector fields, 0 for scalars and -1
+        for composite)."""
+        return -1
+
+    @property
+    def dims(self) -> int:
+        """Return spatial dimension."""
+        return self.basespaces[0].dims
+
+    @property
+    def dim(self) -> int:
+        """Return total number of modes."""
+        return sum([space.dim for space in self.basespaces])
+
+    @property
+    def block_sizes(self) -> tuple[int, ...]:
+        """Return tuple of component space dimensions."""
+        return tuple(space.dim for space in self.flatten())
+
+    @property
+    def num_dofs(self) -> tuple[tuple[int, ...], ...]:
+        """Return tuple of active degrees of freedom per axis."""
+        return tuple(space.num_dofs for space in self.flatten())
+
+    @property
+    def is_orthogonal(self) -> bool:
+        """Return True if underlying bases are all orthogonal."""
+        return all(space.is_orthogonal for space in self.basespaces)
+
+    def shape(self) -> Any:
+        """Return modal shape for each subspace."""
+        return tuple(space.shape() for space in self.basespaces)
+
+    def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
+        """Evaluate vector expansion at scattered points.
+
+        Args:
+            x: Array of per-axis coordinates stacked (N, d).
+            c: Sequence of Coefficient arrays.
+
+        Returns:
+            Evaluated values with shape determined by leading dims of x.
+        """
+        vals = []
+        for i, space in enumerate(self.flatten()):
+            ci = c[i]
+            vi = space.evaluate(x, ci)
+            vals.append(vi)
+        return jnp.sum(jnp.stack(vals), axis=0)
+
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> Array:
+        """Evaluate vector expansion on a mesh with optional padding.
+
+        Args:
+            u: Sequence of input arrays.
+            kind: Type of mesh to evaluate on.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of evaluated values on the mesh.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
+            coeffs.append(ci)
+        return jnp.sum(jnp.stack(coeffs), axis=0)
+
+    def forward(self, u: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Forward transform with optional truncation.
+
+        Args:
+            u: Input array.
+
+        Returns:
+            Array of forward transform values.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.forward(u[i])
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def scalar_product(self, u: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Return tensor of inner products along each axis (separable).
+        Args:
+            u: Sequence of input arrays.
+
+        Returns:
+            Sequence of array of inner products for all components.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.scalar_product(u[i])
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> tuple[Array, ...]:
+        """Backward transform with optional padding.
+
+        Args:
+            u: Input array.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward transform values.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.backward(u[i], N=N[i] if N is not None else None)
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: tuple[int, ...],
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> tuple[Array, ...]:
+        """Backward primitive transform with optional padding.
+
+        Args:
+            u: Sequence of input arrays.
+            k: Tuple of derivative orders.
+            N: Optional per-axis counts (defaults each to space.num_quad_points).
+
+        Returns:
+            Array of backward primitive transform values.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients to orthogonal basis.
+
+        Args:
+            c: Input array of coefficients.
+
+        Returns:
+            Array of coefficients in orthogonal basis.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.to_orthogonal(c[i])
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients from orthogonal basis.
+
+        Args:
+            c: Input array of coefficients.
+
+        Returns:
+            Array of coefficients in the original basis.
+        """
+        coeffs = []
+        for i, space in enumerate(self.flatten()):
+            ci = space.from_orthogonal(c[i])
+            coeffs.append(ci)
+        return tuple(coeffs)
+
+    def get_homogeneous(self) -> CartesianProductSpace:
+        from .tensorproductspace import DirectSumTPS
+
+        f = []
+        for space in self.basespaces:
+            f.append(
+                space.get_homogeneous()
+                if isinstance(space, DirectSumTPS | CartesianProductSpace)
+                else space
+            )
+        return CartesianProduct(*f, name=self.name + "o", rank=self.rank)
+
+    def get_orthogonal(self) -> CartesianProductSpace:
+        orthogonal_spaces = [space.get_orthogonal() for space in self.basespaces]
+        return CartesianProduct(
+            *orthogonal_spaces, name=self.name + "o", rank=self.rank
+        )
+
+
+class VectorTensorProductSpace(CartesianProductSpace):
+    @property
+    def rank(self) -> int:
+        """Return tensor rank (1 for vector fields)."""
+        return 1
+
+    def __iter__(self) -> Iterator[TensorProductSpace]:
+        """Iterate over component spaces."""
+        return iter(cast(list[TensorProductSpace], self.basespaces))
+
+    def __getitem__(self, i: int) -> TensorProductSpace:
+        """Return component space i."""
+        return cast(list[TensorProductSpace], self.basespaces)[i]

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -16,12 +16,15 @@ from jaxfun.typing import MeshKind
 
 def CartesianProduct(
     *basespaces: TensorProductSpace | CartesianProductSpace,
-    name: str = "T",
+    name: str = "CP",
     rank: int = -1,
 ) -> CartesianProductSpace:
     """Factory returning CartesianProductSpace.
 
     Args:
+        *basespaces: TensorProductSpace or CartesianProductSpace objects.
+        name: Label for the Cartesian product space.
+        rank: Rank of the Cartesian product space.
 
     Returns:
         Instance of CartesianProductSpace
@@ -30,7 +33,7 @@ def CartesianProduct(
         copy.deepcopy(space) for space in basespaces
     ]
     if rank == 1:
-        return VectorTensorProductSpace(*basespaces_list, name=name)
+        return VectorTensorProductSpace(*basespaces_list, name=name, rank=1)
     return CartesianProductSpace(*basespaces_list, name=name, rank=rank)
 
 
@@ -63,6 +66,7 @@ class CartesianProductSpace:
         self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])
         self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
+        self._rank = rank
         self.leaf: CartesianProductSpace = self
 
         for space in self.basespaces:
@@ -110,7 +114,7 @@ class CartesianProductSpace:
     def rank(self) -> int:
         """Return tensor rank (1 for vector fields, 0 for scalars and -1
         for composite)."""
-        return -1
+        return self._rank
 
     @property
     def dims(self) -> int:
@@ -212,7 +216,7 @@ class CartesianProductSpace:
     def backward(
         self,
         u: tuple[Array, ...],
-        N: tuple[tuple[int | None, ...], ...] | None = None,
+        N: tuple[tuple[int | None, ...] | None, ...] | None = None,
     ) -> tuple[Array, ...]:
         """Backward transform with optional padding.
 
@@ -301,11 +305,6 @@ class CartesianProductSpace:
 
 
 class VectorTensorProductSpace(CartesianProductSpace):
-    @property
-    def rank(self) -> int:
-        """Return tensor rank (1 for vector fields)."""
-        return 1
-
     def __iter__(self) -> Iterator[TensorProductSpace]:
         """Iterate over component spaces."""
         return iter(cast(list[TensorProductSpace], self.basespaces))

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -300,12 +300,12 @@ class CartesianProductSpace:
                 if isinstance(space, DirectSumTPS | CartesianProductSpace)
                 else space
             )
-        return CartesianProduct(*f, name=self.name + "o", rank=self.rank)
+        return CartesianProduct(*f, name=self.name + "H", rank=self.rank)
 
     def get_orthogonal(self) -> CartesianProductSpace:
         orthogonal_spaces = [space.get_orthogonal() for space in self.basespaces]
         return CartesianProduct(
-            *orthogonal_spaces, name=self.name + "o", rank=self.rank
+            *orthogonal_spaces, name=self.name + "O", rank=self.rank
         )
 
 

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -57,9 +57,7 @@ class CartesianProductSpace:
     ) -> None:
         from jaxfun.galerkin import DirectSumTPS
 
-        self.basespaces: list[TensorProductSpace | CartesianProductSpace] = [
-            copy.deepcopy(space) for space in basespaces
-        ]
+        self.basespaces = list(basespaces)
         self.system: CoordSys = self.basespaces[0].system
         self.name = name
         self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -185,14 +185,14 @@ class CartesianProductSpace:
             ]
         )
 
-    def forward(self, u: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Forward transform with optional truncation.
+    def forward(self, u: Array) -> tuple[Array, ...]:
+        """Forward transform each physical component into spectral space.
 
         Args:
-            u: Input array.
+            u: Stacked physical array of shape (n_components, *mesh_shape).
 
         Returns:
-            Array of forward transform values.
+            Per-component spectral coefficient arrays (shapes may differ).
         """
         coeffs = []
         for i, space in enumerate(self.flatten()):
@@ -200,13 +200,14 @@ class CartesianProductSpace:
             coeffs.append(ci)
         return tuple(coeffs)
 
-    def scalar_product(self, u: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Return tensor of inner products along each axis (separable).
+    def scalar_product(self, u: Array) -> tuple[Array, ...]:
+        """Return scalar products along each axis for all components.
+
         Args:
-            u: Sequence of input arrays.
+            u: Stacked physical array of shape (n_components, *mesh_shape).
 
         Returns:
-            Sequence of array of inner products for all components.
+            Per-component scalar product arrays (shapes may differ).
         """
         coeffs = []
         for i, space in enumerate(self.flatten()):
@@ -218,43 +219,46 @@ class CartesianProductSpace:
         self,
         u: tuple[Array, ...],
         N: tuple[tuple[int | None, ...] | None, ...] | None = None,
-    ) -> tuple[Array, ...]:
-        """Backward transform with optional padding.
+    ) -> Array:
+        """Backward transform per-component spectral coefficients to physical space.
+
+        All components are evaluated on the same mesh, so the outputs have equal
+        shape and are returned as a single stacked array.
 
         Args:
-            u: Input array.
+            u: Per-component spectral coefficient arrays.
             N: Optional per-axis counts (defaults each to space.num_quad_points).
 
         Returns:
-            Array of backward transform values.
+            Stacked physical array of shape (n_components, *mesh_shape).
         """
         coeffs = []
         for i, space in enumerate(self.flatten()):
             ci = space.backward(u[i], N=N[i] if N is not None else None)
             coeffs.append(ci)
-        return tuple(coeffs)
+        return jnp.stack(coeffs)
 
     def backward_primitive(
         self,
         u: tuple[Array, ...],
         k: tuple[int, ...],
         N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> tuple[Array, ...]:
-        """Backward primitive transform with optional padding.
+    ) -> Array:
+        """Backward primitive transform for all components.
 
         Args:
-            u: Sequence of input arrays.
+            u: Per-component spectral coefficient arrays.
             k: Tuple of derivative orders.
             N: Optional per-axis counts (defaults each to space.num_quad_points).
 
         Returns:
-            Array of backward primitive transform values.
+            Stacked physical array of shape (n_components, *mesh_shape).
         """
         coeffs = []
         for i, space in enumerate(self.flatten()):
             ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
             coeffs.append(ci)
-        return tuple(coeffs)
+        return jnp.stack(coeffs)
 
     def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
         """Convert coefficients to orthogonal basis.

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -146,21 +146,21 @@ class CartesianProductSpace:
         return tuple(space.shape() for space in self.basespaces)
 
     def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
-        """Evaluate vector expansion at scattered points.
+        """Evaluate each component at scattered points and stack into one Array.
+
+        All components are evaluated at the same points so outputs have equal
+        leading shape and can be stacked.
 
         Args:
             x: Array of per-axis coordinates stacked (N, d).
             c: Sequence of Coefficient arrays.
 
         Returns:
-            Evaluated values with shape determined by leading dims of x.
+            Stacked array of shape (n_components, N).
         """
-        vals = []
-        for i, space in enumerate(self.flatten()):
-            ci = c[i]
-            vi = space.evaluate(x, ci)
-            vals.append(vi)
-        return jnp.sum(jnp.stack(vals), axis=0)
+        return jnp.array(
+            [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
+        )
 
     def evaluate_mesh(
         self,
@@ -168,7 +168,7 @@ class CartesianProductSpace:
         kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
-        """Evaluate vector expansion on a mesh with optional padding.
+        """Evaluate each component on a mesh and stack into one Array.
 
         Args:
             u: Sequence of input arrays.
@@ -176,13 +176,14 @@ class CartesianProductSpace:
             N: Optional per-axis counts (defaults each to space.num_quad_points).
 
         Returns:
-            Array of evaluated values on the mesh.
+            Stacked array of shape (n_components, ...).
         """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
-            coeffs.append(ci)
-        return jnp.sum(jnp.stack(coeffs), axis=0)
+        return jnp.stack(
+            [
+                space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
+                for i, space in enumerate(self.flatten())
+            ]
+        )
 
     def forward(self, u: tuple[Array, ...]) -> tuple[Array, ...]:
         """Forward transform with optional truncation.

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -557,8 +557,8 @@ class DirectSum:
 
     @property
     def dim(self) -> int:
-        """Return total dimension (homogeneous + boundary)."""
-        return self[0].dim + self[1].dim
+        """Return dimension of unknown (homogeneous) part only."""
+        return self[0].dim
 
     @property
     def num_dofs(self) -> int:

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -141,6 +141,7 @@ class Composite(OrthogonalSpace):
         stencil: Ordered dict of diagonal shift -> expression / scaling.
         S: Sparse (DiaMatrix) stencil matrix.
         ST: Pre-computed transpose of S for efficiency.
+        P: Sparse (DiaMatrix) representing S @ S.T.
         scaling: Scaling expression applied to user stencil.
     """
 
@@ -438,7 +439,7 @@ class BCGeneric(Composite):
         self.orthogonal.N = S.shape[1]
         self.orthogonal._num_quad_points = num_quad_points
         self.S = DiaMatrix.from_dense(S.__array__().astype(float))
-        self.ST: DiaMatrix = self.S.T  # pre-computed transpose; avoids creating
+        self.ST: DiaMatrix = self.S.T
 
     @property
     def dim(self) -> int:

--- a/src/jaxfun/galerkin/forms.py
+++ b/src/jaxfun/galerkin/forms.py
@@ -145,25 +145,30 @@ def check_if_nonlinear_in_jaxfunction(a: sp.Basic) -> bool:
         True if expression is nonlinear in any JAXFunction, False otherwise.
     """
     jaxfunctions = get_jaxfunctions(a)
-    have_jaxfunctions = len(jaxfunctions) > 0 or len(a.atoms(Jaxc)) > 0
+    have_jaxfunctions = len(jaxfunctions)
     if not have_jaxfunctions:
         return False
-    assert len(jaxfunctions) <= 1, "Multiple JAXFunctions found"
-    ad = a.doit(linear=True)  # assume linear
-    if ad.is_Vector:
-        for comp in ad.components.values():
-            jf = comp.atoms(Jaxc)
-            if len(jf) > 1:
-                return True
-            jf = jf.pop()
-            if sp.diff(comp, jf, 2) != 0:
-                return True
-        return False
-    jf = ad.atoms(Jaxc)
-    if len(jf) > 1:
-        return True
-    jf = jf.pop()
-    return sp.diff(ad, jf, 2) != 0
+
+    def _is_nonlinear_in_jaxfunction(a: sp.Basic) -> bool:
+        ad = a.doit(linear=True)  # assume linear
+        if ad.is_Vector:
+            for comp in ad.components.values():
+                jf = get_jaxfunctions(comp)
+                if len(jf) > 1:
+                    return True
+                jf = jf.pop()
+                if sp.diff(comp, jf, 2) != 0:
+                    return True
+            return False
+        jf = get_jaxfunctions(ad)
+        if len(jf) > 1:
+            return True
+        jf = jf.pop()
+        return sp.diff(ad, jf, 2) != 0
+
+    if len(jaxfunctions) > 1:
+        return any(_is_nonlinear_in_jaxfunction(s) for s in a.args)
+    return _is_nonlinear_in_jaxfunction(a)
 
 
 def split_coeff(c0: sp.Expr | float) -> CoeffDict:
@@ -250,7 +255,9 @@ def split(forms: sp.Expr) -> ResultDict:
     """
     v, _ = get_basisfunctions(forms)
     assert v is not None, "A test function is required"
-    assert not isinstance(v, set), "Multiple test functions not supported"
+    if isinstance(v, set):
+        assert len(v) == 1, "Multiple test functions not supported"
+        v = v.pop()
     assert _has_functionspace(v)
     V = v.functionspace
 
@@ -332,14 +339,19 @@ def add_result(
     found_d: bool = False
     for g in res:
         if jnp.all(jnp.array([g[s] == d[s] for s in system.base_scalars()])):
-            if "multivar" not in d:
+            if "multivar" not in d and "jaxfunction" not in d:
                 g["coeff"] += d["coeff"]
-            elif "multivar" not in g:
+            elif "multivar" not in g and "jaxfunction" not in g:
                 g["multivar"] = d["coeff"] * d["multivar"]
                 g["coeff"] = 1
-            else:
+            elif "multivar" in g and "multivar" in d:
                 g["multivar"] = (
                     g["coeff"] * g["multivar"] + d["coeff"] * d["multivar"]
+                ).factor()
+                g["coeff"] = 1
+            elif "jaxfunction" in g and "jaxfunction" in d:
+                g["jaxfunction"] = (
+                    g["coeff"] * g["jaxfunction"] + d["coeff"] * d["jaxfunction"]
                 ).factor()
                 g["coeff"] = 1
             found_d = True

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -683,9 +683,11 @@ def _finalize_inner_result(
     """
     assert test_space is not None
     dims: int = test_space.dims
-    rank: int = test_space.rank
+    test_leaf = getattr(test_space, "leaf", None)
+    rank: int = 0 if test_leaf is None else test_leaf.rank
 
     bresult: Array | BlockArray | None = None
+
     if len(bresults) > 0:
         if rank == 0:
             bresult = jnp.sum(jnp.array([d.data for d in bresults]), axis=0)
@@ -729,7 +731,7 @@ def _finalize_inner_result(
 
             if rank == 0:
                 aresult = tpresults[0] if len(tpresults) == 1 else TPMatrices(tpresults)
-            elif rank == 1:
+            else:
                 aresult = BlockTPMatrix(
                     tpresults,
                     cast(CartesianProductSpace, test_space.leaf),

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -1061,7 +1061,7 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
                 assert isinstance(V, CartesianProductSpace)
                 assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
                 uj = (lambdify(s, (uei).doit())(*V.mesh()) for uei in ue)
-            uj = tuple([jnp.broadcast_to(ui, V.num_quad_points) for ui in uj])
+            uj = jnp.stack([jnp.broadcast_to(ui, V.num_quad_points) for ui in uj])
         return V.forward(jax.device_put(uj, V._physical_sharding))
 
     u = TrialFunction(V)

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -10,8 +10,10 @@ from jax import Array
 
 from jaxfun.la import (
     BaseMatrix,
+    BlockArray,
     BlockTPMatrix,
     DiaMatrix,
+    IndexedArray,
     Matrix,
     TensorMatrix,
     TPMatrices,
@@ -61,8 +63,8 @@ from .tensorproductspace import (
 type _NumQuadPoints = int | tuple[int | None, ...]
 type _BilinearFactor = tuple[Array, Array] | Matrix | DiaMatrix
 type _BilinearMat = tuple[_BilinearFactor, tuple[int, int]]
-type _InnerTerm = tuple[BaseMatrix | None, Array | None]
-type _LinearFactor = Array | tuple[Array]
+type _InnerTerm = tuple[BaseMatrix | None, IndexedArray | None]
+type _LinearFactor = Array | tuple[Array, ...]
 
 
 @dataclass(frozen=True)
@@ -94,7 +96,7 @@ def inner(
     use_precomputed_matrices: bool = True,
     *,
     kind: Literal[InnerKind.LINEAR, "linear"],
-) -> Array: ...
+) -> Array | BlockArray: ...
 @overload
 def inner(
     expr: sp.Expr,
@@ -104,7 +106,7 @@ def inner(
     use_precomputed_matrices: bool = True,
     *,
     kind: Literal[InnerKind.SYSTEM, "system"],
-) -> tuple[BaseMatrix, Array]: ...
+) -> tuple[BaseMatrix, Array | BlockArray]: ...
 @overload
 def inner(
     expr: sp.Expr,
@@ -206,10 +208,10 @@ def _coerce_inner_kind(kind: InnerKind | str) -> InnerKind:
 
 def _validate_inner_kind(
     result: GalerkinAssembledForm, kind: InnerKind
-) -> BaseMatrix | Array | tuple[BaseMatrix, Array]:
+) -> BaseMatrix | Array | BlockArray | tuple[BaseMatrix, Array | BlockArray]:
     if isinstance(result, BaseMatrix):
         actual = InnerKind.BILINEAR
-    elif isinstance(result, Array):
+    elif isinstance(result, Array | BlockArray):
         actual = InnerKind.LINEAR
     else:
         actual = InnerKind.SYSTEM
@@ -218,7 +220,7 @@ def _validate_inner_kind(
         raise ValueError(
             f"inner(..., kind={kind!r}) assembled {actual.value}; expected {kind}"
         )
-    return result  # ty:ignore[invalid-return-type]
+    return result
 
 
 def inner_items(
@@ -285,7 +287,7 @@ def _assemble_inner_items(
     use_precomputed_matrices: bool,
 ) -> InnerItems:
     aresults: list[BaseMatrix] = []
-    bresults: list[Array] = []
+    bresults: list[IndexedArray] = []
 
     for a0 in context.a_forms:
         aitem, bitem = _assemble_bilinear_form(a0, context, use_precomputed_matrices)
@@ -360,7 +362,7 @@ def _assemble_bilinear_form(
     sc = coeffs.get("bilinear", 1)
 
     aresult: BaseMatrix | None = None
-    bresult: Array | None = None
+    bresult: IndexedArray | None = None
     trial: list[OrthogonalSpace] = []
     has_bcs = False
 
@@ -382,12 +384,17 @@ def _assemble_bilinear_form(
             continue
         if isinstance(uf, BCGeneric) and context.test_space.dims == 1:
             sign = _linear_sign(context.all_linear)
-            bresult = sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=float))
+            bresult = IndexedArray(  # global_indices currently not used in 1D, but kept here for future developments  # noqa: E501
+                global_indices[0],
+                sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=float)),
+            )
             continue
         if "linear" in coeffs and context.test_space.dims == 1:
             sign = _linear_sign(context.all_linear)
             scale = coeffs["linear"].get("scale", 1) * sign
-            bresult = scale * (z @ coeffs["linear"]["jaxcoeff"].array)
+            bresult = IndexedArray(
+                global_indices[0], scale * (z @ coeffs["linear"]["jaxcoeff"].array)
+            )
 
         sc = 1
         mats.append((z, global_indices))
@@ -434,7 +441,7 @@ def _assemble_multivar_bilinear_form(
     context: _InnerContext,
 ) -> _InnerTerm:
     aresult: BaseMatrix | None = None
-    bresult: Array | None = None
+    bresult: IndexedArray | None = None
     assert len(mats) == 2
     assert isinstance(context.test_space, TensorProductSpace)
     mats_ = [
@@ -456,7 +463,7 @@ def _assemble_multivar_bilinear_form(
         sign = _linear_sign(context.all_linear)
         fun = _multivar_boundary_values(context.trial_space, trial, gi)
         res = sign * jnp.einsum("ikjl,kl->ij", Am, fun)
-        bresult = vectorize_bresult(res, context.test_space, gi[0][0])
+        bresult = IndexedArray(gi[0][0], res)
 
     else:
         if "linear" in coeffs:
@@ -464,7 +471,7 @@ def _assemble_multivar_bilinear_form(
             res = sign * jnp.einsum(
                 "ikjl,kl->ij", Am, coeffs["linear"]["jaxcoeff"].array
             )
-            bresult = vectorize_bresult(res, context.test_space, gi[0][0])
+            bresult = IndexedArray(gi[0][0], res)
 
         if "bilinear" in coeffs:
             assert isinstance(context.trial_space, TensorProductSpace)
@@ -507,7 +514,7 @@ def _assemble_separable_bilinear_form(
     context: _InnerContext,
 ) -> _InnerTerm:
     aresult: BaseMatrix | None = None
-    bresult: Array | None = None
+    bresult: IndexedArray | None = None
     mats_: list[Matrix | DiaMatrix] = [cast(Matrix | DiaMatrix, m[0]) for m in mats]
     gi = [m[1] for m in mats]
 
@@ -516,7 +523,7 @@ def _assemble_separable_bilinear_form(
         fun = _separable_boundary_values(context.trial_space, coeffs, trial, gi)
         sign = _linear_sign(context.all_linear)
         res = TPMatrix(mats_, sign) @ fun
-        bresult = vectorize_bresult(res, context.test_space, gi[0][0])
+        bresult = IndexedArray(gi[0][0], res)
 
     else:
         if "linear" in coeffs:
@@ -528,8 +535,7 @@ def _assemble_separable_bilinear_form(
             )
             for i, mat in enumerate(mats_):
                 res = mat.matvec(res, axis=i)
-
-            bresult = vectorize_bresult(res, context.test_space, gi[0][0])
+            bresult = IndexedArray(gi[0][0], res)
 
         if "bilinear" in coeffs:
             assert isinstance(
@@ -560,7 +566,7 @@ def _assemble_linear_factor(
     scale: float | complex,
     is_multivar: bool,
     num_quad_points: _NumQuadPoints,
-) -> tuple[Array | tuple[Array], int]:
+) -> tuple[Array | tuple[Array, ...], int]:
     v, _ = get_basisfunctions(bi)
     assert v is not None, "Test function required in linear form"
     assert _has_functionspace(v)
@@ -572,7 +578,9 @@ def _assemble_linear_factor(
     return z, v.global_index
 
 
-def _assemble_linear_form(b0: InnerResultDict, context: _InnerContext) -> Array | None:
+def _assemble_linear_form(
+    b0: InnerResultDict, context: _InnerContext
+) -> IndexedArray | None:
     scale = _linear_form_scale(b0, len(context.a_forms) > 0)
     bs: list[_LinearFactor] = []
     global_index = 0
@@ -586,7 +594,7 @@ def _assemble_linear_form(b0: InnerResultDict, context: _InnerContext) -> Array 
 
     test_space = context.test_space
     if isinstance(test_space, OrthogonalSpace):
-        return cast(Array, bs[0])
+        return IndexedArray(0, cast(Array, bs[0]))
     if (
         isinstance(test_space, TensorProductSpace | VectorTensorProductSpace)
         and len(test_space) == 2
@@ -606,7 +614,7 @@ def _assemble_linear_tensor2d(
     test_space: TensorProductSpace | VectorTensorProductSpace,
     num_quad_points: _NumQuadPoints,
     global_index: int,
-) -> Array:
+) -> IndexedArray:
     if isinstance(bs[0], tuple):
         assert isinstance(num_quad_points, tuple)
         uj = jnp.array(1.0)
@@ -620,10 +628,10 @@ def _assemble_linear_tensor2d(
         if "jaxfunction" not in b0 and "multivar" not in b0:
             raise ValueError("Expected multivar or jaxfunction key in b0")
         res = bs[0][0].T @ uj @ bs[1][0]
-        return vectorize_bresult(res, test_space, global_index)
+        return IndexedArray(global_index, res)
 
     res = jnp.multiply.outer(cast(Array, bs[0]), cast(Array, bs[1]))
-    return vectorize_bresult(res, test_space, global_index)
+    return IndexedArray(global_index, res)
 
 
 def _assemble_linear_tensor3d(
@@ -632,7 +640,7 @@ def _assemble_linear_tensor3d(
     test_space: TensorProductSpace | VectorTensorProductSpace,
     num_quad_points: _NumQuadPoints,
     global_index: int,
-) -> Array:
+) -> IndexedArray:
     if isinstance(bs[0], tuple):
         assert isinstance(num_quad_points, tuple)
         if "multivar" in b0:
@@ -645,26 +653,17 @@ def _assemble_linear_tensor3d(
         else:
             raise ValueError("Expected multivar or jaxfunction key in b0")
         res = jnp.einsum("il,jm,kn,ijk->lmn", bs[0][0], bs[1][0], bs[2][0], uj)
-        return vectorize_bresult(res, test_space, global_index)
+        return IndexedArray(global_index, res)
 
     res = jnp.multiply.outer(
         jnp.multiply.outer(cast(Array, bs[0]), cast(Array, bs[1])), cast(Array, bs[2])
     )
-    return vectorize_bresult(res, test_space, global_index)
-
-
-def vectorize_bresult(
-    res: Array, space: TensorProductSpace | VectorTensorProductSpace, global_index: int
-) -> Array:
-    if not isinstance(space, VectorTensorProductSpace):
-        return res
-    out = jnp.zeros((space.dims,) + res.shape, dtype=res.dtype)
-    return out.at[global_index].set(res)
+    return IndexedArray(global_index, res)
 
 
 def _finalize_inner_result(
     aresults: list[BaseMatrix],
-    bresults: list[Array],
+    bresults: list[IndexedArray],
     test_space: RankedTestSpaceType,
     trial_space: TrialSpaceType | None,
     sparse: bool,
@@ -682,12 +681,18 @@ def _finalize_inner_result(
     Returns:
         Matrix, vector, (matrix, vector), tensor-product operator, or None.
     """
+    assert test_space is not None
     dims: int = test_space.dims
     rank: int = test_space.rank
 
-    bresult: Array | None = None
+    bresult: Array | BlockArray | None = None
     if len(bresults) > 0:
-        bresult = jnp.sum(jnp.array(bresults), axis=0)
+        if rank == 0:
+            bresult = jnp.sum(jnp.array([d.data for d in bresults]), axis=0)
+        else:
+            bresult = BlockArray(
+                cast(CartesianProductSpace, test_space).leaf, indexed_arrays=bresults
+            )
 
     aresult: BaseMatrix | None = None
 
@@ -699,11 +704,11 @@ def _finalize_inner_result(
             aresult = sum(amats[1:], amats[0])
 
         if aresult is None:
-            return bresult
+            return cast(Array, bresult)
         if bresult is None:
             return aresult
 
-        return aresult, bresult
+        return aresult, cast(Array, bresult)
 
     assert not isinstance(test_space, OrthogonalSpace)
     if len(jax.devices()) > 1 and bresult is not None:
@@ -749,6 +754,8 @@ def _finalize_inner_result(
             return bresult
         case aresult, bresult:
             return aresult, bresult
+
+    raise ValueError("Something wrong in _finalize_inner_result")
 
 
 @overload
@@ -1070,6 +1077,6 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
         assert isinstance(V, CartesianProductSpace)
         assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
         spaces = V.flatten()
-        return tuple(project(cast(sp.Expr, uei), spaces[i]) for i, uei in enumerate(ue))
+        uh = tuple(project(cast(sp.Expr, uei), spaces[i]) for i, uei in enumerate(ue))
 
     return uh

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -19,12 +19,14 @@ from jaxfun.la import (
 )
 from jaxfun.typing import (
     CoeffDict,
+    FunctionSpaceType,
     GalerkinAssembledForm,
     InnerItems,
     InnerKind,
     InnerKindLike,
     InnerResultDict,
-    TestSpaceType,
+    RankedTestSpaceType,
+    ScalarSpaceType,
     TrialSpaceType,
 )
 from jaxfun.utils.common import lambdify, matmat
@@ -35,6 +37,10 @@ from .arguments import (
     TrialFunction,
     evaluate_jaxfunction_expr_quad,
     get_arg,
+)
+from .cartesianproductspace import (
+    CartesianProductSpace,
+    VectorTensorProductSpace,
 )
 from .composite import BCGeneric, Composite, DirectSum
 from .forms import (
@@ -50,7 +56,6 @@ from .orthogonal import OrthogonalSpace
 from .tensorproductspace import (
     DirectSumTPS,
     TensorProductSpace,
-    VectorTensorProductSpace,
 )
 
 type _NumQuadPoints = int | tuple[int | None, ...]
@@ -62,7 +67,7 @@ type _LinearFactor = Array | tuple[Array]
 
 @dataclass(frozen=True)
 class _InnerContext:
-    test_space: TestSpaceType
+    test_space: RankedTestSpaceType
     trial_space: TrialSpaceType | None
     a_forms: list[InnerResultDict]
     b_forms: list[InnerResultDict]
@@ -237,9 +242,20 @@ def _prepare_inner_context(
 ) -> _InnerContext:
     V, U = get_basisfunctions(expr)
     assert V is not None, "No TestFunction found in expression"
+    if isinstance(V, set):
+        assert len(V) == 1, "More than one testfunction found in expression"
+        V = V.pop()
     assert _has_testspace(V), "TestFunction has no associated function space"
-    test_space = V.functionspace
-    trial_space: TrialSpaceType | None = getattr(U, "functionspace", None)
+    test_space = cast(RankedTestSpaceType, V.functionspace)
+    if isinstance(U, set):
+        leaf = set(
+            cast(CartesianProductSpace, cast(TrialFunction, u).functionspace).leaf
+            for u in U
+        )
+        assert len(leaf) == 1
+        trial_space = leaf.pop()
+    else:
+        trial_space: TrialSpaceType | None = getattr(U, "functionspace", None)
     measure = test_space.system.sg
     allforms = split(expr * measure)
     a_forms = allforms["bilinear"]
@@ -318,6 +334,9 @@ def _assemble_bilinear_factor(
     assert v is not None and u is not None, (
         "Both test and trial functions required in bilinear form"
     )
+    if isinstance(v, set) and isinstance(u, set):
+        raise ValueError("Too many test/trial functions found in bilinear form")
+
     assert _has_testspace(v), "TestFunction has no associated function space"
     assert _has_functionspace(u), "TrialFunction has no associated function space"
     vf = v.functionspace
@@ -397,10 +416,11 @@ def _multivar_boundary_values(
     trial: list[OrthogonalSpace],
     gi: list[tuple[int, int]],
 ) -> Array:
-    assert isinstance(trial_space, DirectSumTPS | VectorTensorProductSpace)
+    assert isinstance(trial_space, DirectSumTPS | CartesianProductSpace)
     if isinstance(trial_space, DirectSumTPS):
         return trial_space.bndvals[tuple(trial)]
-    dsspace = trial_space[gi[1][1]]
+    assert isinstance(trial_space, CartesianProductSpace)
+    dsspace = trial_space.flatten()[gi[1][1]]
     assert isinstance(dsspace, DirectSumTPS)
     return dsspace.bndvals[tuple(trial)]
 
@@ -424,6 +444,7 @@ def _assemble_multivar_bilinear_form(
     gi = [m[1] for m in mats]
 
     scales = []
+
     if "multivar" in a0:
         scales.append(a0["multivar"])
     if "jaxfunction" in a0:
@@ -461,19 +482,19 @@ def _separable_boundary_values(
     if trial_space is not None:
         if isinstance(trial_space, DirectSumTPS):
             return trial_space.bndvals[tuple(trial)]
-        if isinstance(trial_space, VectorTensorProductSpace):
-            dsspace = trial_space[gi[1][1]]
+        if isinstance(trial_space, CartesianProductSpace):
+            dsspace = trial_space.flatten()[gi[1][1]]
             assert isinstance(dsspace, DirectSumTPS)
             return dsspace.bndvals[tuple(trial)]
         raise NotImplementedError(
-            "BCs only implemented for TensorProductSpace and VectorTensorProductSpace"
+            "BCs only implemented for TensorProductSpace and CartesianProductSpace"
         )
 
     jfs = coeffs["linear"]["jaxcoeff"].functionspace
-    assert isinstance(jfs, DirectSumTPS | VectorTensorProductSpace)
+    assert isinstance(jfs, DirectSumTPS | CartesianProductSpace)
     if isinstance(jfs, DirectSumTPS):
         return jfs.bndvals[tuple(trial)]
-    dsspace = jfs.tensorspaces[gi[1][1]]
+    dsspace = jfs.flatten()[gi[1][1]]
     assert isinstance(dsspace, DirectSumTPS)
     return dsspace.bndvals[tuple(trial)]
 
@@ -515,7 +536,7 @@ def _assemble_separable_bilinear_form(
                 context.test_space, TensorProductSpace | VectorTensorProductSpace
             )
             assert isinstance(
-                context.trial_space, TensorProductSpace | VectorTensorProductSpace
+                context.trial_space, TensorProductSpace | CartesianProductSpace
             )
             aresult = TPMatrix(
                 [cast(BaseMatrix, m[0]) for m in mats], 1, global_indices=gi[0]
@@ -572,7 +593,7 @@ def _assemble_linear_form(b0: InnerResultDict, context: _InnerContext) -> Array 
     ):
         return _assemble_linear_tensor2d(b0, bs, test_space, quads, global_index)
     if (
-        isinstance(test_space, TensorProductSpace | VectorTensorProductSpace)
+        isinstance(test_space, TensorProductSpace | CartesianProductSpace)
         and len(test_space) == 3
     ):
         return _assemble_linear_tensor3d(b0, bs, test_space, quads, global_index)
@@ -644,7 +665,7 @@ def vectorize_bresult(
 def _finalize_inner_result(
     aresults: list[BaseMatrix],
     bresults: list[Array],
-    test_space: TestSpaceType,
+    test_space: RankedTestSpaceType,
     trial_space: TrialSpaceType | None,
     sparse: bool,
     sparse_tol: int,
@@ -690,6 +711,8 @@ def _finalize_inner_result(
 
     if len(aresults) > 0:
         # aresults is an empty list or a list of TPMatrix/TensorMatrix objects.
+        assert trial_space is not None
+        assert not isinstance(trial_space, OrthogonalSpace | DirectSum)
 
         if all(isinstance(a, TPMatrix) for a in aresults):
             tpresults = cast(list[TPMatrix], aresults)
@@ -704,8 +727,8 @@ def _finalize_inner_result(
             elif rank == 1:
                 aresult = BlockTPMatrix(
                     tpresults,
-                    cast(VectorTensorProductSpace, test_space),
-                    cast(VectorTensorProductSpace, trial_space),
+                    cast(CartesianProductSpace, test_space.leaf),
+                    cast(CartesianProductSpace, trial_space.leaf),
                 )
 
         elif all(isinstance(a, TensorMatrix) for a in aresults):
@@ -801,8 +824,8 @@ def inner_bilinear(
             continue
 
         jaxfunction = get_jaxfunctions(aii)
-        if len(jaxfunction) == 1:
-            scale *= evaluate_jaxfunction_expr_quad(aii, jaxfunction.pop(), N=N)
+        if len(jaxfunction) >= 1:
+            scale *= evaluate_jaxfunction_expr_quad(aii, N=N)
             continue
         elif len(jaxfunction) > 1:
             raise ValueError("Multiple JAXFunctions found in single bilinear form")
@@ -901,12 +924,12 @@ def inner_linear(
                 continue
 
             jaxfunction = get_jaxfunctions(bii)
-            if len(jaxfunction) == 1:
-                jaxf = jaxfunction.pop()
-                assert jaxf.functionspace.orthogonal.__class__ == vo.__class__, (
-                    "JAXFunction space must match test function space"
-                )
-                uj *= evaluate_jaxfunction_expr_quad(bii, jaxf, N=N)
+            if len(jaxfunction) >= 1:
+                for jaxf in jaxfunction:
+                    assert jaxf.functionspace.orthogonal.__class__ == vo.__class__, (
+                        "JAXFunction space must match test function space"
+                    )
+                uj *= evaluate_jaxfunction_expr_quad(bii, N=N)
                 continue
             # bii contains coordinates in the domain of v, e.g., (r, theta) for polar
             # Need to compute bii as bii(x(X)), since we use quadrature points
@@ -990,7 +1013,13 @@ def project1D(ue: sp.Expr, V: OrthogonalSpace | Composite | DirectSum) -> Array:
     return uh
 
 
-def project(ue: sp.Expr, V: TrialSpaceType) -> Array:
+@overload
+def project(ue: sp.Expr, V: VectorTensorProductSpace) -> tuple[Array, ...]: ...
+@overload
+def project(ue: sp.Tuple, V: CartesianProductSpace) -> tuple[Array, ...]: ...
+@overload
+def project(ue: sp.Expr, V: ScalarSpaceType) -> Array: ...
+def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array, ...]:
     """Project expression onto (possibly tensor) space V.
 
     Args:
@@ -1003,23 +1032,27 @@ def project(ue: sp.Expr, V: TrialSpaceType) -> Array:
     from jaxfun.operators import Dot
 
     if V.dims == 1:
-        assert isinstance(V, OrthogonalSpace | Composite | DirectSum)
+        assert isinstance(V, OrthogonalSpace | DirectSum)
+        assert isinstance(ue, sp.Expr)
         return project1D(ue, V)
 
-    if len(get_jaxfunctions(ue)) == 0:
-        assert not isinstance(V, OrthogonalSpace | Composite | DirectSum)
+    if len(get_jaxfunctions(ue if isinstance(ue, sp.Expr) else sum(ue))) == 0:
+        assert not isinstance(V, OrthogonalSpace | DirectSum)
         if V.rank == 0:
+            assert isinstance(ue, sp.Expr)
             uj = lambdify(V.system.base_scalars(), ue)(*V.mesh())
             uj = jnp.broadcast_to(uj, V.num_quad_points)
-        elif V.rank == 1:
-            assert isinstance(V, VectorTensorProductSpace)
+        else:
             s = V.system.base_scalars()
             bv = V.system.base_vectors()
-            uj = (lambdify(s, Dot(ue, n).doit())(*V.mesh()) for n in bv)
-            uj = jnp.stack(
-                [jnp.broadcast_to(ui, V.tensorspaces[0].num_quad_points) for ui in uj],
-                axis=0,
-            )
+            if V.rank == 1:  # VectorTensorProductSpace
+                assert isinstance(ue, sp.Expr)
+                uj = (lambdify(s, Dot(ue, n).doit())(*V.mesh()) for n in bv)
+            else:
+                assert isinstance(V, CartesianProductSpace)
+                assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
+                uj = (lambdify(s, (uei).doit())(*V.mesh()) for uei in ue)
+            uj = tuple([jnp.broadcast_to(ui, V.num_quad_points) for ui in uj])
         return V.forward(jax.device_put(uj, V._physical_sharding))
 
     u = TrialFunction(V)
@@ -1032,5 +1065,11 @@ def project(ue: sp.Expr, V: TrialSpaceType) -> Array:
         assert isinstance(V, VectorTensorProductSpace)
         A, b = inner(Dot(v, (u - ue)), kind=InnerKind.SYSTEM)
         uh = A.solve(b)
+
+    else:
+        assert isinstance(V, CartesianProductSpace)
+        assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
+        spaces = V.flatten()
+        return tuple(project(cast(sp.Expr, uei), spaces[i]) for i, uei in enumerate(ue))
 
     return uh

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -116,7 +116,7 @@ class TensorProductSpace:
         return all(space.is_orthogonal for space in self.basespaces)
 
     def shape(self) -> tuple[int, ...]:
-        """Return ."""
+        """Return raw modal shape (N0, N1, ...)."""
         return tuple([space.N for space in self.basespaces])
 
     @property

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -4,13 +4,13 @@ import copy
 import itertools
 from collections.abc import Iterable, Iterator, Sequence
 from functools import partial
-from typing import NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 import jax
 import jax.numpy as jnp
 import sympy as sp
 from jax import Array, shard_map
-from jax.sharding import NamedSharding, PartitionSpec as P
+from jax.sharding import PartitionSpec as P
 
 from jaxfun.coordinates import CartCoordSys, CoordSys
 from jaxfun.sharding import (
@@ -18,7 +18,6 @@ from jaxfun.sharding import (
     _build_local_apply_fn,
     physical_sharding,
     spectral_sharding,
-    spmd_mesh,
 )
 from jaxfun.typing import MeshKind
 from jaxfun.utils.common import jit_vmap, lambdify
@@ -28,6 +27,10 @@ from .orthogonal import OrthogonalSpace
 
 tensor_product_symbol = "\u2297"
 multiplication_sign = "\u00d7"
+
+if TYPE_CHECKING:
+    from jaxfun.galerkin import CartesianProductSpace
+
 
 IndivisibleError = ValueError
 
@@ -65,6 +68,8 @@ class TensorProductSpace:
         basespaces: Sequence[OrthogonalSpace],
         system: CoordSys | None = None,
         name: str = "TPS",
+        leaf: CartesianProductSpace | None = None,
+        global_index: int = 0,
     ) -> None:
         from jaxfun.coordinates import CartCoordSys, x, y, z
 
@@ -80,6 +85,8 @@ class TensorProductSpace:
         self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
         self._spmd_local_fn_cache: dict = {}
+        self.global_index = global_index
+        self.leaf = leaf
 
     def __len__(self) -> int:
         """Return number of spatial dimensions."""
@@ -109,7 +116,7 @@ class TensorProductSpace:
         return all(space.is_orthogonal for space in self.basespaces)
 
     def shape(self) -> tuple[int, ...]:
-        """Return raw modal shape (N0, N1, ...)."""
+        """Return ."""
         return tuple([space.N for space in self.basespaces])
 
     @property
@@ -496,235 +503,6 @@ class TensorProductSpace:
         return z
 
 
-class VectorTensorProductSpace:
-    """Vector-valued tensor product space.
-
-    Represents a tuple of identical (or differing in boundary conditions)
-    TensorProductSpace objects corresponding to vector components.
-
-    Attributes:
-        tensorspaces: Tuple of component tensor spaces.
-        system: Shared coordinate system.
-        name: Label.
-        tensorname: Joined printable representation.
-    """
-
-    is_transient = False
-
-    def __init__(
-        self,
-        tensorspace: TensorProductSpace | tuple[TensorProductSpace, ...],
-        name: str = "VTPS",
-    ) -> None:
-        if isinstance(tensorspace, TensorProductSpace):
-            n = len(tensorspace)
-            tensorspaces: tuple[TensorProductSpace, ...] = (tensorspace,) * n
-        else:
-            tensorspaces = tensorspace
-        self.tensorspaces = tensorspaces
-        self.system: CoordSys = self.tensorspaces[0].system
-        self.name = name
-        self.tensorname = multiplication_sign.join([b.name for b in self.tensorspaces])
-        self.mesh = self.tensorspaces[0].mesh
-        self.num_quad_points = self.tensorspaces[0].num_quad_points
-        # Slab decomposition for vector spaces
-        # First index is vector component, which is not sharded.
-        self._spectral_sharding: NamedSharding | None = (
-            None if len(jax.devices()) == 1 else NamedSharding(spmd_mesh, P(None, "k"))
-        )
-        # Sharding of arrays in physical space.
-        self._physical_sharding: NamedSharding | None = (
-            None
-            if len(jax.devices()) == 1
-            else NamedSharding(spmd_mesh, P(None, None, "k"))
-        )
-
-    def __len__(self) -> int:
-        """Return number of vector components."""
-        return len(self.tensorspaces)
-
-    def __iter__(self) -> Iterator[TensorProductSpace]:
-        """Iterate over component tensor spaces."""
-        return iter(self.tensorspaces)
-
-    def __getitem__(self, i: int) -> TensorProductSpace:
-        """Return component tensor space i."""
-        return self.tensorspaces[i]
-
-    @property
-    def rank(self) -> int:
-        """Return tensor rank (1 for vector fields)."""
-        return 1
-
-    @property
-    def dims(self) -> int:
-        """Return spatial dimension of each component space."""
-        return len(self.tensorspaces[0])
-
-    @property
-    def dim(self) -> int:
-        """Return total number of modes."""
-        return sum([space.dim for space in self.tensorspaces])
-
-    @property
-    def num_dofs(self) -> tuple[int, ...]:
-        """Return tuple of active degrees of freedom per axis."""
-        return (self.dims,) + self.tensorspaces[0].num_dofs
-
-    @property
-    def is_orthogonal(self) -> bool:
-        """Return True if underlying bases are all orthogonal."""
-        return all(space.is_orthogonal for space in self.tensorspaces)
-
-    def shape(self) -> tuple[int, ...]:
-        """Return raw modal shape (N0, N1, ...)."""
-        return (self.dims,) + self.tensorspaces[0].shape()
-
-    def evaluate(self, x: Array, c: Array) -> Array:
-        """Evaluate vector expansion at scattered points.
-
-        Args:
-            x: Array of per-axis coordinates stacked (N, d).
-            c: Coefficient array shaped (dims, N0, N1, ...).
-
-        Returns:
-            Evaluated values with shape determined by leading dims of x.
-        """
-        vals = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = c[i]
-            vi = space.evaluate(x, ci)
-            vals.append(vi)
-        return jnp.array(vals)
-
-    def evaluate_mesh(
-        self,
-        u: Array,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Evaluate vector expansion on a mesh with optional padding.
-
-        Args:
-            u: Input array.
-            kind: Type of mesh to evaluate on.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Array of evaluated values on the mesh.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def forward(self, u: Array) -> Array:
-        """Forward transform with optional truncation.
-
-        Args:
-            u: Input array.
-
-        Returns:
-            Array of forward transform values.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.forward(u[i])
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def scalar_product(self, u: Array) -> Array:
-        """Return tensor of inner products along each axis (separable).
-        Args:
-            u: Input array.
-
-        Returns:
-            Array of inner products along each axis.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.scalar_product(u[i])
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def backward(
-        self,
-        u: Array,
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Backward transform with optional padding.
-
-        Args:
-            u: Input array.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Array of backward transform values.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.backward(u[i], N=N[i] if N is not None else None)
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def backward_primitive(
-        self,
-        u: Array,
-        k: tuple[int, ...],
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Backward primitive transform with optional padding.
-
-        Args:
-            u: Input array.
-            k: Tuple of derivative orders.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Array of backward primitive transform values.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def to_orthogonal(self, c: Array) -> Array:
-        """Convert coefficients to orthogonal basis.
-
-        Args:
-            c: Input array of coefficients.
-
-        Returns:
-            Array of coefficients in orthogonal basis.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.to_orthogonal(c[i])
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def from_orthogonal(self, c: Array) -> Array:
-        """Convert coefficients from orthogonal basis.
-
-        Args:
-            c: Input array of coefficients.
-
-        Returns:
-            Array of coefficients in the original basis.
-        """
-        coeffs = []
-        for i, space in enumerate(self.tensorspaces):
-            ci = space.from_orthogonal(c[i])
-            coeffs.append(ci)
-        return jnp.stack(coeffs)
-
-    def get_orthogonal(self) -> VectorTensorProductSpace:
-        orthogonal_spaces = [space.get_orthogonal() for space in self.tensorspaces]
-        return VectorTensorProductSpace(tuple(orthogonal_spaces), name=self.name + "o")
-
-
 def TensorProduct(
     *basespaces: OrthogonalSpace | DirectSum,
     system: CoordSys | None = None,
@@ -801,6 +579,8 @@ class DirectSumTPS(TensorProductSpace):
         basespaces: list[OrthogonalSpace | DirectSum],
         system: CoordSys,
         name: str = "DSTPS",
+        global_index: int = 0,
+        leaf: CartesianProductSpace | None = None,
     ) -> None:
         from jaxfun.galerkin.inner import project, project1D
 
@@ -811,6 +591,8 @@ class DirectSumTPS(TensorProductSpace):
         self.tensorname = tensor_product_symbol.join([b.name for b in basespaces])
         self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
+        self.global_index = global_index
+        self.leaf = leaf
 
         # Normalize symbolic BC expressions to base scalar form
         for space in basespaces:
@@ -977,7 +759,13 @@ class DirectSumTPS(TensorProductSpace):
                 f.append([space])
         tensorspaces = itertools.product(*f)
         return {
-            s: TensorProductSpace(s, self.system, f"{self.name}{i}")
+            s: TensorProductSpace(
+                s,
+                self.system,
+                f"{self.name}{i}",
+                leaf=self.leaf,
+                global_index=self.global_index,
+            )
             for i, s in enumerate(tensorspaces)
         }
 

--- a/src/jaxfun/integrators/base.py
+++ b/src/jaxfun/integrators/base.py
@@ -15,9 +15,9 @@ from jaxfun.galerkin import TestFunction, TrialFunction
 from jaxfun.galerkin.arguments import JAXFunction
 from jaxfun.galerkin.forms import get_basisfunctions
 from jaxfun.galerkin.inner import project
-from jaxfun.la import IdentityMatrix, ZeroMatrix
+from jaxfun.la import BaseMatrix, IdentityMatrix, ZeroMatrix
 from jaxfun.la.matrixprotocol import SolverNotApplicable
-from jaxfun.typing import Array, FunctionSpaceType, GalerkinOperator, Padding
+from jaxfun.typing import Array, Padding, ScalarSpaceType
 from jaxfun.utils import split_linear_nonlinear_terms, split_time_derivative_terms
 from jaxfun.utils.operator_tools import assemble_linear_term
 from jaxfun.utils.sympy_factoring import time_derivative_as_operator
@@ -29,7 +29,7 @@ from .nonlinear import (
 )
 
 
-def _warm_operator_solve_cache(op: GalerkinOperator) -> None:
+def _warm_operator_solve_cache(op: BaseMatrix) -> None:
     """Warm native solver caches for operators that support factorization."""
     lu_factor = getattr(op, "lu_factor", None)
     if lu_factor is None:
@@ -51,7 +51,7 @@ class BaseIntegrator(ABC, nnx.Module):
 
     def __init__(
         self,
-        V: FunctionSpaceType,
+        V: ScalarSpaceType,
         equation: sp.Expr,
         *,
         initial: sp.Expr | Array,
@@ -96,7 +96,7 @@ class BaseIntegrator(ABC, nnx.Module):
             raise ValueError("Time-derivative operator assembly produced forcing")
         if mass_operator is None:
             mass_operator = IdentityMatrix(self._state_shape)
-        self.mass_operator: GalerkinOperator = nnx.data(mass_operator)
+        self.mass_operator: BaseMatrix = nnx.data(mass_operator)
         self.mass_diag: Array | None = nnx.data(self.mass_operator.diagonal_or_none())
         if self.mass_diag is None:
             _warm_operator_solve_cache(self.mass_operator)
@@ -106,7 +106,7 @@ class BaseIntegrator(ABC, nnx.Module):
         )
         if linear_operator is None:
             linear_operator = ZeroMatrix(self._state_shape)
-        self.linear_operator: GalerkinOperator = nnx.data(linear_operator)
+        self.linear_operator: BaseMatrix = nnx.data(linear_operator)
         self.linear_forcing: Array | None = nnx.data(linear_forcing)
         self.linear_diag: Array | None = nnx.data(
             self.linear_operator.diagonal_or_none()
@@ -118,7 +118,7 @@ class BaseIntegrator(ABC, nnx.Module):
             self._setup_nonlinear_evaluator(trial)
 
     @staticmethod
-    def _coefficient_shape(V: FunctionSpaceType) -> tuple[int, ...]:
+    def _coefficient_shape(V: ScalarSpaceType) -> tuple[int, ...]:
         """Return the coefficient-array shape for the given space."""
         num_dofs = V.num_dofs
         return num_dofs if isinstance(num_dofs, tuple) else (num_dofs,)
@@ -173,7 +173,7 @@ class BaseIntegrator(ABC, nnx.Module):
             nonlinear_expr, self.functionspace, jaxfunction
         )
 
-    def _dense_matrix(self, operator: GalerkinOperator) -> Array:
+    def _dense_matrix(self, operator: BaseMatrix) -> Array:
         """Return a dense matrix representation of a linear operator."""
         return operator.todense()
 

--- a/src/jaxfun/integrators/etdrk4.py
+++ b/src/jaxfun/integrators/etdrk4.py
@@ -10,7 +10,7 @@ from flax import nnx
 from jax.scipy.linalg import expm as _expm
 
 from jaxfun.la import DiagonalMatrix, Matrix
-from jaxfun.typing import Array, FunctionSpaceType, Padding
+from jaxfun.typing import Array, Padding, ScalarSpaceType
 
 from .base import BaseIntegrator
 
@@ -69,7 +69,7 @@ class ETDRK4(BaseIntegrator):
 
     def __init__(
         self,
-        V: FunctionSpaceType,
+        V: ScalarSpaceType,
         equation: sp.Expr,
         *,
         initial: sp.Expr | Array,

--- a/src/jaxfun/integrators/nonlinear.py
+++ b/src/jaxfun/integrators/nonlinear.py
@@ -10,7 +10,7 @@ from sympy.core.function import AppliedUndef
 
 from jaxfun.galerkin import TestFunction, TrialFunction
 from jaxfun.galerkin.arguments import ArgumentTag, JAXFunction, get_arg
-from jaxfun.typing import Array, FunctionSpaceType, Padding
+from jaxfun.typing import Array, Padding, ScalarSpaceType
 from jaxfun.utils import lambdify
 
 type NodeValueCache = dict[sp.Basic, Array]
@@ -22,7 +22,7 @@ class NonlinearCompileContext:
     """Static data required to compile nonlinear SymPy expressions."""
 
     spatial_symbols: tuple[sp.Symbol, ...]
-    functionspace: FunctionSpaceType
+    functionspace: ScalarSpaceType
     jaxfunction: AppliedUndef
 
 
@@ -106,14 +106,14 @@ class NonlinearCompiler:
     def compile_primitive(self, node: sp.Basic) -> NodeEvaluator:
         """Compile a primitive field or spatial derivative evaluation."""
         space = self.context.functionspace
-        jaxf = cast(JAXFunction, self.context.jaxfunction)
+        jaxf = cast(JAXFunction[ScalarSpaceType], self.context.jaxfunction)
         if _is_jaxfunction_leaf(node):
 
             def evaluate_leaf(
                 _cache: NodeValueCache,
                 N: Padding = None,
-                space: FunctionSpaceType = space,
-                jaxf: JAXFunction = jaxf,
+                space: ScalarSpaceType = space,
+                jaxf: JAXFunction[ScalarSpaceType] = jaxf,
             ) -> Array:
                 return space.backward(jaxf.array, N=N)  # ty: ignore[invalid-argument-type]
 
@@ -141,8 +141,8 @@ class NonlinearCompiler:
         def evaluate_derivative(
             _cache: NodeValueCache,
             N: Padding = None,
-            space: FunctionSpaceType = space,
-            jaxf: JAXFunction = jaxf,
+            space: ScalarSpaceType = space,
+            jaxf: JAXFunction[ScalarSpaceType] = jaxf,
             derivative_order: int | tuple[int, ...] = derivative_order,
         ) -> Array:
             return space.backward_primitive(jaxf.array, k=derivative_order, N=N)  # ty: ignore[invalid-argument-type]
@@ -310,7 +310,7 @@ def _is_jaxfunction_primitive(expr: sp.Basic) -> bool:
 
 def compile_nonlinear_evaluator(
     expr: sp.Expr,
-    functionspace: FunctionSpaceType,
+    functionspace: ScalarSpaceType,
     jaxfunction: AppliedUndef,
 ) -> Callable[[Array, Padding], Array]:
     """Compile a nonlinear physical-space evaluator for coefficient states."""
@@ -320,7 +320,9 @@ def compile_nonlinear_evaluator(
         jaxfunction=jaxfunction,
     )
     compiled = NonlinearCompiler(context).compile(expr)
-    jaxfunction: JAXFunction = cast(JAXFunction, jaxfunction)
+    jaxfunction: JAXFunction[ScalarSpaceType] = cast(
+        JAXFunction[ScalarSpaceType], jaxfunction
+    )
 
     def evaluate(uh: Array, N: Padding = None) -> Array:
         jaxfunction.array = uh

--- a/src/jaxfun/la/__init__.py
+++ b/src/jaxfun/la/__init__.py
@@ -1,4 +1,4 @@
-from .blocktpmatrix import BlockTPMatrix as BlockTPMatrix
+from .blocktpmatrix import BlockArray as BlockArray, BlockTPMatrix as BlockTPMatrix
 from .diamatrix import (
     DiagonalMatrix as DiagonalMatrix,
     DiaMatrix as DiaMatrix,
@@ -6,7 +6,7 @@ from .diamatrix import (
     diakron as diakron,
 )
 from .matrix import Matrix as Matrix
-from .matrixprotocol import BaseMatrix as BaseMatrix
+from .matrixprotocol import BaseMatrix as BaseMatrix, IndexedArray as IndexedArray
 from .operators import (
     IdentityMatrix as IdentityMatrix,
     SpecialMatrix as SpecialMatrix,

--- a/src/jaxfun/la/__init__.py
+++ b/src/jaxfun/la/__init__.py
@@ -12,7 +12,7 @@ from .operators import (
     SpecialMatrix as SpecialMatrix,
     ZeroMatrix as ZeroMatrix,
 )
-from .pinned import PinnedSystem as PinnedSystem
+from .pinned import PinnedDiaMatrix as PinnedDiaMatrix, PinnedMatrix as PinnedMatrix
 from .tensormatrix import TensorMatrix as TensorMatrix
 from .tpmatrix import (
     TPMatrices as TPMatrices,

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -13,8 +13,10 @@ from jaxfun.la.matrixprotocol import BaseMatrix, _CacheBox
 from jaxfun.la.tpmatrix import TPMatrices, TPMatrix, tpmats_to_kron
 
 if TYPE_CHECKING:
-    from jaxfun.galerkin import JAXFunction
-    from jaxfun.galerkin.tensorproductspace import VectorTensorProductSpace
+    from jaxfun.galerkin import (
+        CartesianProductSpace,
+        JAXFunction,
+    )
 
 type _SparseMatrixCache = _CacheBox[DiaMatrix]
 
@@ -24,8 +26,8 @@ class BlockTPMatrix(BaseMatrix):
 
     Args:
         tpmats: List of TPMatrix objects.
-        test_space: VectorTensorProductSpace descriptor for the test space.
-        trial_space: VectorTensorProductSpace descriptor for the trial space.
+        test_space: descriptor for the (leaf) test space.
+        trial_space: descriptor for the (leaf) trial space.
 
     Attributes:
         blocks: list of TPMatrix objects.
@@ -35,19 +37,16 @@ class BlockTPMatrix(BaseMatrix):
     def __init__(
         self,
         tpmats: list[TPMatrix],
-        test_space: VectorTensorProductSpace,
-        trial_space: VectorTensorProductSpace,
+        test_space: CartesianProductSpace,
+        trial_space: CartesianProductSpace,
     ) -> None:
         self.tpmats = nnx.List(tpmats)
         self.test_space = test_space
         self.trial_space = trial_space
         self.shape = (self.test_space.dim, self.trial_space.dim)
-        self.test_block_sizes: tuple[int, ...] = tuple(
-            int(self.test_space[i].dim) for i in range(self.test_space.dims)
-        )
-        self.trial_block_sizes: tuple[int, ...] = tuple(
-            int(self.trial_space[i].dim) for i in range(self.trial_space.dims)
-        )
+        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
+        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
+
         # Pre-compute one combined matrix per (test_block, trial_block) pair so
         # that matvec, todense and tosparse each iterate over at most one entry
         # per block instead of one entry per contributing TPMatrix.
@@ -77,12 +76,13 @@ class BlockTPMatrix(BaseMatrix):
         )
 
     @jax.jit
-    def _matmul_array(self, w: Array) -> Array:
-        out = jnp.zeros_like(w)
+    def _matmul_array(self, w: tuple[Array]) -> tuple[Array]:
+        out = []
+        flat_spaces = self.test_space.flatten()
         for s, block_mat in self._combined_blocks.items():
             bi, bj = map(int, s.split(","))
-            out = out.at[bi].add((block_mat @ w[bj].ravel()).reshape(out[bi].shape))
-        return out
+            out.append((block_mat @ w[bj].ravel()).reshape(flat_spaces[bi].num_dofs))
+        return tuple(out)
 
     def slice(self, indices: tuple[int, ...]) -> tuple[slice, ...]:  # ty:ignore[invalid-type-form]
         """Return slice object for block matrix indices."""
@@ -200,7 +200,7 @@ class BlockTPMatrix(BaseMatrix):
         """Return number of rows (test space dimension)."""
         return self.shape[0]
 
-    def solve(self, b: Array) -> Array:
+    def solve(self, b: BlockArray) -> BlockArray:  # ty:ignore[invalid-method-override]
         """Solve ``M x = b``.
 
         When all factor matrices are :class:`~jaxfun.la.DiaMatrix` instances,
@@ -213,9 +213,82 @@ class BlockTPMatrix(BaseMatrix):
         :class:`~jaxfun.la.Matrix`.
         """
         all_dia = all(isinstance(m, DiaMatrix) for m in self._combined_blocks.values())
+        x = b.flatten()
         if all_dia:
             A_perm, perm, inv_perm = self.tosparse().rcm()
-            x_perm = A_perm.solve(b.ravel()[perm])
-            return x_perm[inv_perm].reshape(b.shape)
+            x_perm = A_perm.solve(x[perm])
+            return BlockArray(b.cartspace, flat_array=x_perm[inv_perm])
         M = self.to_matrix()
-        return M.solve(b.ravel()).reshape(b.shape)
+        return BlockArray(b.cartspace, flat_array=M.solve(x))
+
+
+class IndexedArray(nnx.Pytree):
+    def __init__(self, i: int, data: Array):
+        self.data = data
+        self.i = i
+
+
+class BlockArray(nnx.Pytree):
+    """Block of Array objects.
+
+    Args:
+        cartspace: descriptor for the (leaf) space.
+        indexed_arrays: List of IndexedArray objects.
+        flat_array: 1D Array of length cartspace.dim.
+
+    Attributes:
+        data: nnx.List of Arrays representing each block.
+        block_sizes: tuple of ints, dim of each block.
+        num_dofs: tuple of tuple of ints, num_dof of each block.
+        cartspace: CartesianProductSpace.
+    """
+
+    def __init__(
+        self,
+        cartspace: CartesianProductSpace,
+        indexed_arrays: list[IndexedArray] | None = None,
+        flat_array: Array | None = None,
+    ) -> None:
+        self.data: nnx.List[Array] = nnx.List([])
+        self.cartspace = cartspace
+        self.block_sizes: tuple[int, ...] = self.cartspace.block_sizes
+        self.num_dofs: tuple[tuple[int, ...], ...] = self.cartspace.num_dofs
+        for _ in range(cartspace.num_components):
+            self.data.append(jnp.zeros(()))
+        if indexed_arrays is not None:
+            self += indexed_arrays
+        if flat_array is not None:
+            self += self.from_flat_array(flat_array)
+
+    def _broadcast_data(self) -> tuple[Array, ...]:
+        return tuple(
+            d if d.shape != () else jnp.broadcast_to(d, self.num_dofs[i])
+            for i, d in enumerate(self.data)
+        )
+
+    def array(self) -> tuple[Array, ...]:
+        return tuple(self._broadcast_data())
+
+    def flatten(self) -> Array:
+        a = [d.ravel() for d in self._broadcast_data()]
+        return jnp.concatenate(tuple(a))
+
+    def from_flat_array(self, x: Array) -> list[IndexedArray]:
+        s0: int = 0
+        d: list[IndexedArray] = []
+        for i, s1 in enumerate(self.block_sizes):
+            d.append(IndexedArray(i, x[slice(s0, s0 + s1)].reshape(self.num_dofs[i])))
+            s0 = s1
+        return d
+
+    def __add__(self, b: IndexedArray | list[IndexedArray]):
+        b: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
+        for bi in b:
+            self.data[bi.i] += bi.data
+        return self
+
+    def __sub__(self, b: IndexedArray | list[IndexedArray]):
+        b: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
+        for bi in b:
+            self.data[bi.i] -= bi.data
+        return self

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -75,6 +75,20 @@ class BlockTPMatrix(BaseMatrix):
             self.trial_space,
         )
 
+    def __add__(self, other: BlockTPMatrix) -> BlockTPMatrix:
+        return BlockTPMatrix(
+            list(self.tpmats) + list(other.tpmats),
+            self.test_space,
+            self.trial_space,
+        )
+
+    def __sub__(self, other: BlockTPMatrix) -> BlockTPMatrix:
+        return BlockTPMatrix(
+            list(self.tpmats) + [mat.scale(-1) for mat in other.tpmats],
+            self.test_space,
+            self.trial_space,
+        )
+
     @jax.jit
     def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:
         out = []
@@ -260,9 +274,9 @@ class BlockArray(nnx.Pytree):
         if indexed_arrays is not None:
             self.accumulate(indexed_arrays)
         if flat_array is not None:
-            self.accumulate(self.from_flat_array(flat_array))
+            self.accumulate(self._list_from_flat_array(flat_array))
         if tuple_array is not None:
-            self.accumulate(self.from_tuple_array(tuple_array))
+            self.accumulate(self._list_from_tuple_array(tuple_array))
 
     def _broadcast_data(self) -> tuple[Array, ...]:
         return tuple(
@@ -282,7 +296,7 @@ class BlockArray(nnx.Pytree):
         a = [d.ravel() for d in self._broadcast_data()]
         return jnp.concatenate(tuple(a))
 
-    def from_flat_array(self, x: Array) -> list[IndexedArray]:
+    def _list_from_flat_array(self, x: Array) -> list[IndexedArray]:
         s0: int = 0
         d: list[IndexedArray] = []
         for i, s1 in enumerate(self.block_sizes):
@@ -290,11 +304,8 @@ class BlockArray(nnx.Pytree):
             s0 = s1
         return d
 
-    def from_tuple_array(self, x: tuple[Array, ...]) -> list[IndexedArray]:
-        d: list[IndexedArray] = []
-        for i, xi in enumerate(x):
-            d.append(IndexedArray(i, xi))
-        return d
+    def _list_from_tuple_array(self, x: tuple[Array, ...]) -> list[IndexedArray]:
+        return [IndexedArray(i, xi) for i, xi in enumerate(x)]
 
     def accumulate(self, b: IndexedArray | list[IndexedArray]) -> None:
         b_list: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -208,7 +208,8 @@ class BlockTPMatrix(BaseMatrix):
             if getattr(sparse, "_rcm_cache", None) is not None:
                 A_perm, perm, inv_perm = sparse.rcm()
                 z = A_perm.matvec(wf[perm])[inv_perm]
-            z = sparse.matvec(wf)
+            else:
+                z = sparse.matvec(wf)
             return BlockArray(self.test_space, flat_array=z)
 
         return BlockArray(self.test_space, tuple_array=self._matmul_array(w.array))
@@ -301,7 +302,7 @@ class BlockArray(nnx.Pytree):
         d: list[IndexedArray] = []
         for i, s1 in enumerate(self.block_sizes):
             d.append(IndexedArray(i, x[slice(s0, s0 + s1)].reshape(self.num_dofs[i])))
-            s0 = s1
+            s0 += s1
         return d
 
     def _list_from_tuple_array(self, x: tuple[Array, ...]) -> list[IndexedArray]:

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -251,6 +251,9 @@ class BlockArray(nnx.Pytree):
         cartspace: descriptor for the (leaf) space.
         indexed_arrays: List of IndexedArray objects.
         flat_array: 1D Array of length cartspace.dim.
+        tuple_array: tuple of Arrays for flattened space, one item
+            for each TensorProductSpace in the flattened space. This
+            is, e.g., the output from forward/scalar_product.
 
     Attributes:
         data: nnx.List of Arrays representing each block.

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -188,7 +188,7 @@ class BlockTPMatrix(BaseMatrix):
         object.__setattr__(self, "_sparse_cache", _CacheBox(result))
         return result
 
-    def __call__(self, u: BlockArray | JAXFunction) -> BlockArray:  # ty:ignore[invalid-method-override]
+    def __call__(self, u: BlockArray | JAXFunction) -> BlockArray:
         """Apply block matrix to coefficient array u.
 
         Uses the RCM-permuted :class:`~jaxfun.la.DiaMatrix` for a single

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -9,7 +9,7 @@ from jax import Array
 
 from jaxfun.la.diamatrix import DiaMatrix
 from jaxfun.la.matrix import Matrix
-from jaxfun.la.matrixprotocol import BaseMatrix, _CacheBox
+from jaxfun.la.matrixprotocol import BaseMatrix, IndexedArray, _CacheBox
 from jaxfun.la.tpmatrix import TPMatrices, TPMatrix, tpmats_to_kron
 
 if TYPE_CHECKING:
@@ -76,7 +76,7 @@ class BlockTPMatrix(BaseMatrix):
         )
 
     @jax.jit
-    def _matmul_array(self, w: tuple[Array]) -> tuple[Array]:
+    def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:
         out = []
         flat_spaces = self.test_space.flatten()
         for s, block_mat in self._combined_blocks.items():
@@ -174,7 +174,7 @@ class BlockTPMatrix(BaseMatrix):
         object.__setattr__(self, "_sparse_cache", _CacheBox(result))
         return result
 
-    def __call__(self, u: Array | JAXFunction) -> Array:
+    def __call__(self, u: BlockArray | JAXFunction) -> BlockArray:  # ty:ignore[invalid-method-override]
         """Apply block matrix to coefficient array u.
 
         Uses the RCM-permuted :class:`~jaxfun.la.DiaMatrix` for a single
@@ -182,17 +182,24 @@ class BlockTPMatrix(BaseMatrix):
         :meth:`solve` or an explicit :meth:`tosparse` call); otherwise falls
         back to the per-block path.
         """
-        w = self._as_array(u)
+        if not isinstance(u, BlockArray):
+            w = BlockArray(self.test_space, tuple_array=u.get_array())
+        else:
+            w = u
+
         sparse_box: _SparseMatrixCache | None = getattr(self, "_sparse_cache", None)
         if sparse_box is not None:
+            wf = w.flatten()
             sparse = sparse_box.value
             if getattr(sparse, "_rcm_cache", None) is not None:
                 A_perm, perm, inv_perm = sparse.rcm()
-                return A_perm.matvec(w.ravel()[perm])[inv_perm].reshape(w.shape)
-            return sparse.matvec(w.ravel()).reshape(w.shape)
-        return self._matmul_array(w)
+                z = A_perm.matvec(wf[perm])[inv_perm]
+            z = sparse.matvec(wf)
+            return BlockArray(self.test_space, flat_array=z)
 
-    def __matmul__(self, u: Array | JAXFunction) -> Array:
+        return BlockArray(self.test_space, tuple_array=self._matmul_array(w.array))
+
+    def __matmul__(self, u: BlockArray | JAXFunction) -> BlockArray:
         """Alias to __call__ for @ operator."""
         return self.__call__(u)
 
@@ -222,12 +229,6 @@ class BlockTPMatrix(BaseMatrix):
         return BlockArray(b.cartspace, flat_array=M.solve(x))
 
 
-class IndexedArray(nnx.Pytree):
-    def __init__(self, i: int, data: Array):
-        self.data = data
-        self.i = i
-
-
 class BlockArray(nnx.Pytree):
     """Block of Array objects.
 
@@ -248,17 +249,20 @@ class BlockArray(nnx.Pytree):
         cartspace: CartesianProductSpace,
         indexed_arrays: list[IndexedArray] | None = None,
         flat_array: Array | None = None,
+        tuple_array: tuple[Array, ...] | None = None,
     ) -> None:
         self.data: nnx.List[Array] = nnx.List([])
-        self.cartspace = cartspace
-        self.block_sizes: tuple[int, ...] = self.cartspace.block_sizes
-        self.num_dofs: tuple[tuple[int, ...], ...] = self.cartspace.num_dofs
+        self.cartspace = nnx.static(cartspace)
+        self.block_sizes: tuple[int, ...] = nnx.static(self.cartspace.block_sizes)
+        self.num_dofs: tuple[tuple[int, ...], ...] = nnx.static(self.cartspace.num_dofs)
         for _ in range(cartspace.num_components):
             self.data.append(jnp.zeros(()))
         if indexed_arrays is not None:
-            self += indexed_arrays
+            self.accumulate(indexed_arrays)
         if flat_array is not None:
-            self += self.from_flat_array(flat_array)
+            self.accumulate(self.from_flat_array(flat_array))
+        if tuple_array is not None:
+            self.accumulate(self.from_tuple_array(tuple_array))
 
     def _broadcast_data(self) -> tuple[Array, ...]:
         return tuple(
@@ -266,8 +270,13 @@ class BlockArray(nnx.Pytree):
             for i, d in enumerate(self.data)
         )
 
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (self.cartspace.dim,)
+
+    @property
     def array(self) -> tuple[Array, ...]:
-        return tuple(self._broadcast_data())
+        return self._broadcast_data()
 
     def flatten(self) -> Array:
         a = [d.ravel() for d in self._broadcast_data()]
@@ -281,14 +290,41 @@ class BlockArray(nnx.Pytree):
             s0 = s1
         return d
 
-    def __add__(self, b: IndexedArray | list[IndexedArray]):
-        b: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
-        for bi in b:
-            self.data[bi.i] += bi.data
-        return self
+    def from_tuple_array(self, x: tuple[Array, ...]) -> list[IndexedArray]:
+        d: list[IndexedArray] = []
+        for i, xi in enumerate(x):
+            d.append(IndexedArray(i, xi))
+        return d
 
-    def __sub__(self, b: IndexedArray | list[IndexedArray]):
-        b: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
-        for bi in b:
-            self.data[bi.i] -= bi.data
-        return self
+    def accumulate(self, b: IndexedArray | list[IndexedArray]) -> None:
+        b_list: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
+        for bi in b_list:
+            self.data[bi.i] += bi.data
+
+    def __len__(self) -> int:
+        return self.cartspace.num_components
+
+    def __add__(self, b: BlockArray) -> BlockArray:
+        return BlockArray(
+            self.cartspace, tuple_array=tuple(x + y for x, y in zip(self, b))
+        )
+
+    def __sub__(self, b: BlockArray) -> BlockArray:
+        return BlockArray(
+            self.cartspace, tuple_array=tuple(x - y for x, y in zip(self, b))
+        )
+
+    def __neg__(self) -> BlockArray:
+        return BlockArray(self.cartspace, tuple_array=tuple(-x for x in self))
+
+    def __mul__(self, scalar: float | complex | Array) -> BlockArray:
+        return BlockArray(self.cartspace, tuple_array=tuple(scalar * x for x in self))
+
+    def __rmul__(self, scalar: float | complex | Array) -> BlockArray:
+        return BlockArray(self.cartspace, tuple_array=tuple(scalar * x for x in self))
+
+    def __iter__(self):
+        return iter(self._broadcast_data())
+
+    def __getitem__(self, i: int) -> Array:
+        return self._broadcast_data()[i]

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
     from jaxfun.la import Matrix
     from jaxfun.la.matrix import LUFactors as DenseLUFactors
-    from jaxfun.la.pinned import PinnedSystem
+    from jaxfun.la.pinned import PinnedDiaMatrix
 
 Array = jax.Array
 
@@ -458,11 +458,16 @@ class DiaMatrix(BaseMatrix):
 
             band_lu = _lu_banded_no_pivot_kernel(band, p, q, center)
 
-            if float(jnp.min(jnp.abs(band_lu[center]))) == 0.0:
+            diag_u = band_lu[center]
+            if (
+                not bool(jnp.all(jnp.isfinite(diag_u)))
+                or float(jnp.min(jnp.abs(diag_u))) == 0.0
+            ):
                 raise ValueError(
-                    "Matrix is singular: zero pivot in LU factorisation. "
-                    "Consider pinning (:meth:`DiaMatrix.pin`) additional DOFs or "
-                    "enabling pivoting for this matrix."
+                    "Matrix is singular or has a zero/non-finite pivot in LU "
+                    "factorisation without pivoting. Saddle-point systems (e.g. "
+                    "Stokes) have zero diagonal entries and require pivoting — "
+                    "use pivot=True."
                 )
 
             _lu_tol = (
@@ -527,7 +532,11 @@ class DiaMatrix(BaseMatrix):
         band_lu, perm_arr = _lu_banded_kernel(band, p, q_eff, center)
 
         # Singularity check: the main diagonal of U lives at band row `center`.
-        if float(jnp.min(jnp.abs(band_lu[center]))) == 0.0:
+        diag_u = band_lu[center]
+        if (
+            not bool(jnp.all(jnp.isfinite(diag_u)))
+            or float(jnp.min(jnp.abs(diag_u))) == 0.0
+        ):
             raise ValueError(
                 "Matrix is singular: zero pivot in LU factorisation. "
                 "Consider pinning (:meth:`DiaMatrix.pin`) additional DOFs "
@@ -650,10 +659,25 @@ class DiaMatrix(BaseMatrix):
         # "banded" path (and cache hit for banded)
         # ------------------------------------------------------------------
         _box: _CacheBox[_LUCache] | None = getattr(self, "_lu_cache", None)
-        if method == DiaMatrixSolveMethod.BANDED or (
-            method == DiaMatrixSolveMethod.AUTO
-            and _box is not None
-            and pivot in _box.value["banded"]
+        if method == DiaMatrixSolveMethod.BANDED:
+            if pivot not in (_box.value["banded"] if _box is not None else {}):
+                offsets_bw = self.offsets
+                p_bw = max((-k for k in offsets_bw if k < 0), default=0)
+                q_bw = max((k for k in offsets_bw if k > 0), default=0)
+                q_eff_bw = q_bw + p_bw if pivot else q_bw
+                bw_metric = p_bw * (q_eff_bw + 1)
+                if bw_metric > auto_threshold:
+                    warnings.warn(
+                        f"DiaMatrix.lu_solve(method='banded'): bandwidth metric "
+                        f"p*(q_eff+1)={bw_metric} (p={p_bw}, q_eff={q_eff_bw}) "
+                        f"exceeds {auto_threshold}. XLA compile and run time may "
+                        f"be very long. Consider method='rcm' or method='dense'.",
+                        stacklevel=2,
+                    )
+            return self.lu_factor(pivot=pivot).solve(b, axis=axis)
+
+        if method == DiaMatrixSolveMethod.AUTO and (
+            _box is not None and pivot in _box.value["banded"]
         ):
             return self.lu_factor(pivot=pivot).solve(b, axis=axis)
 
@@ -1364,9 +1388,9 @@ class DiaMatrix(BaseMatrix):
 
     def pin(
         self, constraints: dict[int, float] | tuple[tuple[int, float], ...]
-    ) -> PinnedSystem:
+    ) -> PinnedDiaMatrix:
         """Return a :class:`PinnedSystem` with the given DOFs fixed."""
-        from jaxfun.la.pinned import PinnedSystem
+        from jaxfun.la.pinned import PinnedDiaMatrix
 
         if isinstance(constraints, dict):
             constraints = tuple(sorted(constraints.items()))
@@ -1374,7 +1398,7 @@ class DiaMatrix(BaseMatrix):
         pinned_matrix = DiaMatrix(
             data=data, offsets=tuple(int(i) for i in new_offsets), shape=self.shape
         )
-        return PinnedSystem(
+        return PinnedDiaMatrix(
             pinned_matrix, tuple((int(i), float(j)) for i, j in norm_constraints)
         )
 
@@ -1401,7 +1425,7 @@ class DiaMatrix(BaseMatrix):
                 is raised.
 
         Returns:
-            :class:`PinnedSystem` whose :meth:`~PinnedSystem.solve` method
+            :class:`PinnedDiaMatrix` whose :meth:`~PinnedDiaMatrix.solve` method
             modifies the RHS and solves in one call.
 
         Example::
@@ -1798,8 +1822,6 @@ class LUFactors(nnx.Pytree):
         self.L = nnx.data(L)
         self.U = nnx.data(U)
         self.shape = shape
-        # perm[i] = original row index that was placed at row i after pivoting.
-        # None means the identity permutation (no row swaps occurred).
         self.perm = perm
 
     @jax.jit(static_argnums=(2,))

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -11,7 +11,7 @@ from jaxfun.la.matrixprotocol import BaseMatrix, _CacheBox
 if TYPE_CHECKING:
     from jaxfun.galerkin import JAXFunction
     from jaxfun.la import DiaMatrix
-    from jaxfun.la.pinned import PinnedSystem
+    from jaxfun.la.pinned import PinnedMatrix
 
 Array = jax.Array
 
@@ -233,6 +233,8 @@ class Matrix(BaseMatrix):
 
     def diagonal_or_none(self) -> Array | None:
         """Return the main diagonal only when this matrix is purely diagonal."""
+        from jaxfun.utils import ulp
+
         cached: _DiagonalCache | None = getattr(self, "_diagonal_cache", None)
         if cached is not None:
             return cached.value
@@ -240,7 +242,7 @@ class Matrix(BaseMatrix):
         if n != m:
             return None
         diag = jnp.diag(self.data)
-        if bool(jnp.allclose(self.data, jnp.diag(diag), atol=1e-12)):
+        if bool(jnp.allclose(self.data, jnp.diag(diag), atol=ulp(1000))):
             object.__setattr__(self, "_diagonal_cache", _CacheBox(diag))
             return diag
         return None
@@ -420,14 +422,14 @@ class Matrix(BaseMatrix):
 
     def pin(
         self, constraints: dict[int, float] | tuple[tuple[int, float], ...]
-    ) -> PinnedSystem:
+    ) -> PinnedMatrix:
         """Return a :class:`PinnedSystem` with the given DOFs fixed."""
-        from jaxfun.la.pinned import PinnedSystem
+        from jaxfun.la.pinned import PinnedMatrix
 
         if isinstance(constraints, dict):
             constraints = tuple(sorted(constraints.items()))
         norm_constraints, data = self._pin(constraints)
-        return PinnedSystem(
+        return PinnedMatrix(
             Matrix(data), tuple((int(i), float(j)) for i, j in norm_constraints)
         )
 

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -17,7 +17,6 @@ from flax import nnx
 Array = jax.Array
 
 if TYPE_CHECKING:
-    from jaxfun.galerkin import JAXFunction
     from jaxfun.la import DiaMatrix, Matrix
 
 
@@ -193,14 +192,12 @@ class BaseMatrix(ABC, nnx.Pytree):
         """Return total number of nonzero elements"""
         raise NotImplementedError
 
-    def _as_array(
-        self, u: Array | tuple[Array, ...] | JAXFunction
-    ) -> Array | tuple[Array, ...]:
+    def _as_array(self, u: Any) -> Any:
         from jaxfun.galerkin import JAXFunction
 
         return u.get_array() if isinstance(u, JAXFunction) else u
 
-    def __call__(self, u: Array | JAXFunction) -> Array:
+    def __call__(self, u: Any) -> Any:
         raise NotImplementedError
 
     def __getitem__(self, key: tuple[int, int], /) -> Array:

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol,
+    Self,
+    runtime_checkable,
+)
 
 import jax
 import jax.numpy as jnp
@@ -58,6 +64,12 @@ class _CacheBox[T]:
 
     def __repr__(self) -> str:
         return f"_CacheBox({self.value!r})"
+
+
+class IndexedArray(nnx.Pytree):
+    def __init__(self, i: int, data: Array):
+        self.data = data
+        self.i = i
 
 
 class BaseMatrix(ABC, nnx.Pytree):
@@ -181,10 +193,12 @@ class BaseMatrix(ABC, nnx.Pytree):
         """Return total number of nonzero elements"""
         raise NotImplementedError
 
-    def _as_array(self, u: Array | JAXFunction) -> Array:
+    def _as_array(
+        self, u: Array | tuple[Array, ...] | JAXFunction
+    ) -> Array | tuple[Array, ...]:
         from jaxfun.galerkin import JAXFunction
 
-        return u.array if isinstance(u, JAXFunction) else u
+        return u.get_array() if isinstance(u, JAXFunction) else u
 
     def __call__(self, u: Array | JAXFunction) -> Array:
         raise NotImplementedError

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -13,7 +13,7 @@ import jax
 import jax.numpy as jnp
 from flax import nnx
 
-from jaxfun.la.matrixprotocol import BaseMatrix
+from jaxfun.la.matrixprotocol import BaseMatrix, DiaMatrixSolveMethod
 
 if TYPE_CHECKING:
     import jax
@@ -108,24 +108,6 @@ class PinnedSystem(BaseMatrix):
             b_moved = b_moved.at[idx].set(val)
         return jnp.moveaxis(b_moved, 0, axis)
 
-    def solve(self, b: Array, axis: int = 0) -> Array:
-        """Modify the RHS and solve the pinned system.
-
-        Applies :meth:`fix_rhs` to ``b`` then solves using the cached LU
-        factorisation of the modified matrix.
-
-        Args:
-            b:    Right-hand side array.  ``b.shape[axis]`` must equal ``n``.
-            axis: Axis of ``b`` along which the system is solved.  All other
-                  axes are treated as independent batch dimensions.  The
-                  output has the same shape as ``b``.
-
-        Returns:
-            Solution array with the same shape as ``b``.
-        """
-        b_mod = self.fix_rhs(b, axis=axis)
-        return self.matrix.solve(b_mod, axis=axis)
-
     def scale(self, alpha: complex | Array) -> PinnedSystem:
         """Pinned systems cannot be scaled without changing constraint rows."""
         raise TypeError("PinnedSystem does not support scaling")
@@ -156,13 +138,6 @@ class PinnedSystem(BaseMatrix):
     def matvec(self, x: Array, axis: int = 0) -> Array:
         """Apply the *modified* (row-substituted) matrix along ``axis`` of ``x``."""
         return self.matrix.matvec(x, axis=axis)
-
-    def lu_solve(self, b: Array, axis: int = 0) -> Array:
-        """Solve using the cached LU factors (does **not** call :meth:`fix_rhs`).
-
-        Use :meth:`solve` for the full pinned solve that also fixes the RHS.
-        """
-        return self.matrix.lu_solve(b, axis=axis)
 
     def diagonal(self, k: int = 0) -> Array:
         """Return the ``k``-th diagonal of the modified matrix."""
@@ -199,3 +174,84 @@ class PinnedSystem(BaseMatrix):
     def __repr__(self) -> str:
         pins = ", ".join(f"{k}: {v}" for k, v in self.constraints)
         return f"PinnedSystem(shape={self.shape}, constraints={{{pins}}})"
+
+
+class PinnedDiaMatrix(PinnedSystem):
+    matrix: DiaMatrix
+
+    def __init__(
+        self,
+        matrix: DiaMatrix,
+        constraints: tuple[tuple[int, float], ...],
+    ) -> None:
+        PinnedSystem.__init__(self, matrix, constraints)
+
+    def lu_solve(
+        self,
+        b: Array,
+        axis: int = 0,
+        *,
+        pivot: bool = False,
+        method: DiaMatrixSolveMethod | str = DiaMatrixSolveMethod.AUTO,
+        auto_threshold: int = 100,
+    ) -> Array:
+        """Solve using the cached LU factors.
+
+        Args:
+            b:    Right-hand side array.  ``b.shape[axis]`` must equal ``n``.
+            axis: Axis of ``b`` along which the system is solved.  All other
+                  axes are treated as independent batch dimensions.  The
+                  output has the same shape as ``b``.
+            pivot: Passed to :meth:`lu_factor` (banded and RCM paths only).
+            method: One of ``"auto"``, ``"banded"``, ``"rcm"``, or
+                ``"dense"``.  Default ``"auto"``.
+            auto_threshold: Threshold for the ``"auto"`` method, trading off
+                banded/RCM solvers against dense.  The banded solver is usually
+                faster for small bandwidth, but compile time grows with bandwidth.
+                RCM can reduce bandwidth and enable the banded solver, but adds
+                overhead and is not guaranteed to help.  Default is 100.
+
+        """
+        b_mod = self.fix_rhs(b, axis=axis)
+        return self.matrix.lu_solve(
+            b_mod,
+            axis=axis,
+            pivot=pivot,
+            method=method,
+            auto_threshold=auto_threshold,
+        )
+
+    solve = lu_solve
+
+    def __repr__(self) -> str:
+        pins = ", ".join(f"{k}: {v}" for k, v in self.constraints)
+        return f"PinnedDiaMatrix(shape={self.shape}, constraints={{{pins}}})"
+
+
+class PinnedMatrix(PinnedSystem):
+    matrix: Matrix
+
+    def __init__(
+        self,
+        matrix: Matrix | DiaMatrix,
+        constraints: tuple[tuple[int, float], ...],
+    ) -> None:
+        PinnedSystem.__init__(self, matrix, constraints)
+
+    def lu_solve(self, b: Array, axis: int = 0) -> Array:
+        """Solve using the cached LU factors.
+
+        Args:
+            b:    Right-hand side array.  ``b.shape[axis]`` must equal ``n``.
+            axis: Axis of ``b`` along which the system is solved.  All other
+                  axes are treated as independent batch dimensions.  The
+                  output has the same shape as ``b``.
+        """
+        b_mod = self.fix_rhs(b, axis=axis)
+        return self.matrix.lu_solve(b_mod, axis=axis)
+
+    solve = lu_solve
+
+    def __repr__(self) -> str:
+        pins = ", ".join(f"{k}: {v}" for k, v in self.constraints)
+        return f"PinnedMatrix(shape={self.shape}, constraints={{{pins}}})"

--- a/src/jaxfun/la/tpmatrix.py
+++ b/src/jaxfun/la/tpmatrix.py
@@ -432,6 +432,7 @@ class TPMatrices(BaseMatrix):
         *,
         method: TPSolveMethod | str = TPSolveMethod.AUTO,
         kron_method: DiaMatrixSolveMethod | str = DiaMatrixSolveMethod.AUTO,
+        auto_threshold: int = 100,
     ) -> Array:
         """Solve the summed tensor-product system.
 
@@ -456,6 +457,11 @@ class TPMatrices(BaseMatrix):
                 sparse).  One of ``"auto"``, ``"banded"``, ``"rcm"``,
                 ``"dense"``.  Ignored when the assembled matrix is a dense
                 :class:`~jaxfun.la.Matrix`.
+                auto_threshold: Threshold for the ``"auto"`` method, trading off
+                    banded/RCM solvers against dense.  The banded solver is usually
+                    faster for small bandwidth, but compile time grows with bandwidth.
+                    RCM can reduce bandwidth and enable the banded solver, but adds
+                    overhead and is not guaranteed to help.  Default is 100.
 
         Returns:
             Solution array with the same shape as *rhs*.
@@ -475,9 +481,9 @@ class TPMatrices(BaseMatrix):
             # DiaMatrix path: shared cache with tosparse()
             sparse_box: _SparseMatrixCache | None = getattr(self, "_sparse_cache", None)
             if sparse_box is not None:
-                return sparse_box.value.lu_solve(flat, method=kron_method).reshape(
-                    r.shape
-                )
+                return sparse_box.value.lu_solve(
+                    flat, method=kron_method, auto_threshold=auto_threshold
+                ).reshape(r.shape)
             # Dense Matrix path
             dense_box: _DenseMatrixCache | None = getattr(self, "_dense_cache", None)
             if dense_box is not None:
@@ -486,7 +492,9 @@ class TPMatrices(BaseMatrix):
             kron = tpmats_to_kron(list(self.tpmats))
             if isinstance(kron, DiaMatrix):
                 object.__setattr__(self, "_sparse_cache", _CacheBox(kron))
-                return kron.lu_solve(flat, method=kron_method).reshape(r.shape)
+                return kron.lu_solve(
+                    flat, method=kron_method, auto_threshold=auto_threshold
+                ).reshape(r.shape)
             object.__setattr__(self, "_dense_cache", _CacheBox(kron))
             return kron.solve(flat).reshape(r.shape)
 

--- a/src/jaxfun/la/tpmatrix.py
+++ b/src/jaxfun/la/tpmatrix.py
@@ -158,7 +158,7 @@ class TPMatrix(BaseMatrix):  # noqa: B903
     def __call__(self, u: Array | JAXFunction) -> Array:
         """Apply matrix to rank-2 coefficient array u."""
         w = self._as_array(u)
-        return self._matmul_array(w)
+        return self._matmul_array(cast(Array, w))
 
     def __matmul__(self, u: Array | JAXFunction) -> Array:
         """Alias to __call__ for @ operator."""
@@ -172,7 +172,7 @@ class TPMatrix(BaseMatrix):  # noqa: B903
 
     def __rmatmul__(self, u: Array | JAXFunction) -> Array:
         """Right matmul (u @ A) treating u as left factor."""
-        w = self._as_array(u)
+        w = cast(Array, self._as_array(u))
         return self._rmatmul_array(w)
 
     def solve(self, rhs: Array) -> Array:
@@ -316,7 +316,7 @@ class TPMatrices(BaseMatrix):
 
     def __rmatmul__(self, u: Array | JAXFunction) -> Array:
         """Right matmul (u @ A) treating u as left factor."""
-        w = self._as_array(u)
+        w = cast(Array, self._as_array(u))
         return jnp.sum(
             jnp.array([mat._rmatmul_array(w) for mat in self.tpmats]), axis=0
         )

--- a/src/jaxfun/pinns/loss.py
+++ b/src/jaxfun/pinns/loss.py
@@ -14,7 +14,7 @@ from jax.flatten_util import ravel_pytree
 from jax.sharding import NamedSharding, PartitionSpec as P
 
 from jaxfun.coordinates import BaseScalar, get_system
-from jaxfun.galerkin import TensorProductSpace, TestFunction, VectorTensorProductSpace
+from jaxfun.galerkin import CartesianProductSpace, TensorProductSpace, TestFunction
 from jaxfun.galerkin.arguments import ArgumentTag, get_arg
 from jaxfun.typing import Array, Loss_Tuple
 from jaxfun.utils import lambdify
@@ -482,7 +482,7 @@ class ResidualVPINN(Residual):
     def _compute_test_function(self, x: Array) -> dict[str, Array]:
         # The test functions should be evaluated once per derivative count
         # FIXME: only implemented for 1D currently
-        assert not isinstance(self.V, TensorProductSpace | VectorTensorProductSpace), (
+        assert not isinstance(self.V, TensorProductSpace | CartesianProductSpace), (
             "Only implemented for 1D spaces currently"
         )
         TD = {

--- a/src/jaxfun/pinns/module.py
+++ b/src/jaxfun/pinns/module.py
@@ -21,13 +21,14 @@ from sympy.printing.pretty.stringpict import prettyForm
 from sympy.vector import VectorAdd
 
 from jaxfun.coordinates import BaseTime, CoordSys
-from jaxfun.galerkin import Chebyshev, DirectSum
-from jaxfun.galerkin.arguments import ArgumentTag
-from jaxfun.galerkin.orthogonal import OrthogonalSpace
-from jaxfun.galerkin.tensorproductspace import (
+from jaxfun.galerkin import (
+    Chebyshev,
+    DirectSum,
     TensorProductSpace,
     VectorTensorProductSpace,
 )
+from jaxfun.galerkin.arguments import ArgumentTag
+from jaxfun.galerkin.orthogonal import OrthogonalSpace
 from jaxfun.typing import Activation
 from jaxfun.utils.common import Domain, lambdify
 
@@ -627,17 +628,19 @@ class SpectralModule(BaseModule):
             self.kernel: nnx.Param[Array] = nnx.Param(w * x[None, :])
 
         elif basespace.dims == 2:
-            w = kernel_init(rngs(), basespace.num_dofs)
             if isinstance(basespace, TensorProductSpace):
+                w = kernel_init(rngs(), basespace.num_dofs)
                 x = jnp.logspace(0, -6, basespace.num_dofs[0])
                 y = jnp.logspace(0, -6, basespace.num_dofs[1])
                 self.kernel = nnx.Param(x[:, None] * y[None, :] * w)
             elif isinstance(basespace, VectorTensorProductSpace):
-                x = jnp.logspace(0, -6, basespace.num_dofs[1])
-                y = jnp.logspace(0, -6, basespace.num_dofs[2])
-                self.kernel: nnx.Param[Array] = nnx.Param(
-                    (x[None, :, None] * y[None, None, :]) * w
-                )
+                c = []
+                for b in basespace:
+                    w = kernel_init(rngs(), b.num_dofs)
+                    x = jnp.logspace(0, -6, b.num_dofs[0])
+                    y = jnp.logspace(0, -6, b.num_dofs[1])
+                    c.append((x[:, None] * y[None, :]) * w)
+                self.kernel: nnx.Param[tuple[Array, ...]] = nnx.Param(tuple(c))
 
         self.space = basespace
         self.name = name
@@ -652,9 +655,9 @@ class SpectralModule(BaseModule):
         """Return spatial dimensionality of the basespace."""
         return self.space.dims
 
-    def set_kernel(self, kernel: Array) -> None:
+    def set_kernel(self, kernel: Array | tuple[Array, ...]) -> None:
         """Set kernel parameters directly."""
-        self.kernel = nnx.Param(kernel)
+        self.kernel: nnx.Param[Array | tuple[Array, ...]] = nnx.Param(kernel)
 
     def __call__(self, x: Array) -> Array:
         """Evaluate spectral expansion at coordinates.
@@ -668,7 +671,11 @@ class SpectralModule(BaseModule):
         if isinstance(self.space, OrthogonalSpace | DirectSum):
             return self.space.evaluate(x, self.kernel[0])
 
-        z = self.space.evaluate(x, self.kernel[...])
+        if isinstance(self.space, TensorProductSpace):
+            z = self.space.evaluate(x, cast(Array, self.kernel))
+        elif isinstance(self.space, VectorTensorProductSpace):
+            z = self.space.evaluate(x, cast(tuple[Array, ...], self.kernel))
+
         if self.space.rank == 0:
             return jnp.expand_dims(z, -1)
         return z

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -29,6 +29,7 @@ from jaxfun.la.matrixprotocol import (
 if TYPE_CHECKING:
     from jaxfun.coordinates import BaseDyadic, BaseScalar, BaseVector
     from jaxfun.galerkin import (
+        CartesianProductSpace,
         DirectSum,
         DirectSumTPS,
         TensorProductSpace,
@@ -43,11 +44,31 @@ type FunctionSpaceType = (
     OrthogonalSpace
     | TensorProductSpace
     | VectorTensorProductSpace
+    | CartesianProductSpace
     | DirectSum
     | DirectSumTPS
 )
 type TrialSpaceType = FunctionSpaceType
-type TestSpaceType = OrthogonalSpace | TensorProductSpace | VectorTensorProductSpace
+type TestSpaceType = (
+    OrthogonalSpace
+    | TensorProductSpace
+    | VectorTensorProductSpace
+    | CartesianProductSpace
+)
+type ComputationalSpaceType = (
+    OrthogonalSpace | TensorProductSpace | VectorTensorProductSpace
+)
+type RankedTrialSpaceType = (
+    OrthogonalSpace
+    | TensorProductSpace
+    | VectorTensorProductSpace
+    | DirectSum
+    | DirectSumTPS
+)
+type RankedTestSpaceType = (
+    OrthogonalSpace | TensorProductSpace | VectorTensorProductSpace
+)
+type ScalarSpaceType = OrthogonalSpace | TensorProductSpace | DirectSum | DirectSumTPS
 
 type VectorLike = BaseVector | Vector | VectorAdd | VectorMul | VectorZero
 type DyadicLike = BaseDyadic | Dyadic | DyadicAdd | DyadicMul | DyadicZero

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, Protocol, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NotRequired,
+    Protocol,
+    cast,
+    overload,
+)
 
 import sympy as sp
 from jax import Array as Array
@@ -20,7 +28,7 @@ from sympy.vector import (
 )
 from typing_extensions import TypedDict
 
-from jaxfun.la import BaseMatrix
+from jaxfun.la import BaseMatrix, BlockArray, IndexedArray
 from jaxfun.la.matrixprotocol import (
     DiaMatrixSolveMethod as DiaMatrixSolveMethod,
     SolverNotApplicable as SolverNotApplicable,
@@ -144,10 +152,10 @@ type DomainType = Literal["inside", "boundary", "intersection", "all"]
 type InnerBilinearResult = Array | BaseMatrix
 type InnerBilinearResults = list[Array | BaseMatrix]
 type InnerLinearResults = list[Array]
-type InnerItems = tuple[list[BaseMatrix], list[Array]]
+type InnerItems = tuple[list[BaseMatrix], list[IndexedArray]]
 type GalerkinOperator = BaseMatrix
 type GalerkinAssembledForm = (
-    GalerkinOperator | Array | tuple[GalerkinOperator | Array, Array | None] | None
+    GalerkinOperator | Array | BlockArray | tuple[GalerkinOperator, Array | BlockArray]
 )
 
 

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -153,9 +153,8 @@ type InnerBilinearResult = Array | BaseMatrix
 type InnerBilinearResults = list[Array | BaseMatrix]
 type InnerLinearResults = list[Array]
 type InnerItems = tuple[list[BaseMatrix], list[IndexedArray]]
-type GalerkinOperator = BaseMatrix
 type GalerkinAssembledForm = (
-    GalerkinOperator | Array | BlockArray | tuple[GalerkinOperator, Array | BlockArray]
+    BaseMatrix | Array | BlockArray | tuple[BaseMatrix, Array | BlockArray]
 )
 
 

--- a/src/jaxfun/utils/operator_tools.py
+++ b/src/jaxfun/utils/operator_tools.py
@@ -6,15 +6,15 @@ import jax.numpy as jnp
 import sympy as sp
 
 from jaxfun.galerkin.inner import inner
-from jaxfun.la import Matrix
-from jaxfun.typing import Array, GalerkinAssembledForm, GalerkinOperator
+from jaxfun.la import BaseMatrix, Matrix
+from jaxfun.typing import Array, GalerkinAssembledForm
 
-type AssembledTerm = tuple[GalerkinOperator | None, Array | None]
+type AssembledTerm = tuple[BaseMatrix | None, Array | None]
 
 
 def _normalize_assembled_operator(
-    operator: GalerkinOperator | Array | None,
-) -> GalerkinOperator | None:
+    operator: BaseMatrix | Array | None,
+) -> BaseMatrix | None:
     """Return one concrete matrix-like operator for time integration."""
     if operator is None:
         return None
@@ -42,7 +42,7 @@ def split_operator_and_forcing(
     if form is None:
         return None, None
     if isinstance(form, tuple):
-        operator, forcing = cast(tuple[GalerkinOperator | Array, Array | None], form)
+        operator, forcing = cast(tuple[BaseMatrix | Array, Array | None], form)
         rhs = jnp.asarray(forcing) if forcing is not None else None
         return _normalize_assembled_operator(operator), rhs
 
@@ -51,7 +51,7 @@ def split_operator_and_forcing(
             return None, form
         return Matrix(form), None
 
-    return form, None
+    return cast(BaseMatrix, form), None
 
 
 def assemble_linear_term(

--- a/tests/galerkin/test_additional_coverage.py
+++ b/tests/galerkin/test_additional_coverage.py
@@ -6,20 +6,18 @@ import sympy as sp
 
 from jaxfun.galerkin import (
     Chebyshev,
+    DirectSumTPS,
     Fourier,
     FunctionSpace,
     Legendre,
     TensorProduct,
     TestFunction,
     TrialFunction,
+    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.arguments import JAXFunction, ScalarFunction, VectorFunction
 from jaxfun.galerkin.forms import split_coeff
 from jaxfun.galerkin.inner import inner, inner_items, project
-from jaxfun.galerkin.tensorproductspace import (
-    DirectSumTPS,
-    VectorTensorProductSpace,
-)
 from jaxfun.la import DiaMatrix, TPMatrix
 from jaxfun.utils.common import Domain, ulp
 
@@ -28,7 +26,7 @@ def test_vector_tensor_product_space_and_jaxfunction_latex_and_matmul():
     C = Chebyshev.Chebyshev(4)
     # Need at least 2D tensorspace for sub_system logic
     TP = TensorProduct(C, C)
-    _VT = VectorTensorProductSpace(TP)  # rank 1 space
+    VT = VectorTensorProductSpace(TP)  # rank 1 space
     coeffs = jax.random.normal(jax.random.PRNGKey(0), shape=(C.N, C.N))
     jf = JAXFunction(coeffs, TP, name="U")
     # Latex function (no bold since rank==0 for scalar TensorProductSpace)
@@ -39,6 +37,19 @@ def test_vector_tensor_product_space_and_jaxfunction_latex_and_matmul():
     right = a @ jf
     assert left.shape == (C.N, C.N)
     assert right.shape == (C.N, C.N)
+
+    coeffs = tuple(
+        jax.random.normal(jax.random.PRNGKey(i), shape=(C.N, C.N)) for i in range(2)
+    )
+    jf = JAXFunction(coeffs, VT, name="U")
+    # Latex function (no bold since rank==0 for scalar TensorProductSpace)
+    _ = jf._latex()
+    # __matmul__ / __rmatmul__
+    a = (jnp.ones((C.N, C.N)), jnp.ones((C.N, C.N)))
+    left = jf @ a
+    right = a @ jf
+    assert left[0].shape == (C.N, C.N) and left[1].shape == (C.N, C.N)
+    assert right[0].shape == (C.N, C.N) and right[1].shape == (C.N, C.N)
 
 
 def test_inner_items_and_sparse_paths():

--- a/tests/galerkin/test_approximations.py
+++ b/tests/galerkin/test_approximations.py
@@ -157,7 +157,7 @@ def test_backward_primitive_2d(space):
     f = sp.sin(x) * sp.cos(y)
     uf = JAXFunction(f, T)
     du = JAXFunction(sp.diff(f, x, y), T)
-    df = T.backward_primitive(uf.array, (1, 1))
+    df = T.backward_primitive(uf.get_array(), (1, 1))
     error = jnp.linalg.norm(df - du.backward())
     assert error < jnp.sqrt(ulp(100))
 
@@ -185,6 +185,6 @@ def test_backward_primitive_directsum_2d(jspace: type[Jacobi], domain: Domain):
     f = T.system.expr_psi_to_base_scalar(f)
     uf = JAXFunction(f, T)
     du = JAXFunction(sp.diff(f, x, y), T.get_orthogonal())
-    df = T.backward_primitive(uf.array, (1, 1))
+    df = T.backward_primitive(uf.get_array(), (1, 1))
     error = jnp.linalg.norm(df - du.backward())
     assert error < jnp.sqrt(ulp(1000)), error

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -1,0 +1,354 @@
+"""Tests for CartesianProductSpace and related infrastructure.
+
+Covers the heterogeneous (rank=-1) Cartesian product space, BlockArray
+arithmetic, and the nested mixed-system assembly path used by Stokes-like
+problems.
+
+API notes
+---------
+* inner() must be called once per (test_block, trial_block) coupling and
+  the results combined with +.  Passing v*u + q*p as a single expression
+  raises AssertionError because two distinct test functions are found.
+* When component spaces use different polynomial degrees (e.g. Stokes
+  velocity N vs. pressure N-2), explicit num_quad_points must be passed to
+  inner(), evaluate_mesh, and backward so all components use the same mesh.
+"""
+
+from typing import cast
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import sympy as sp
+
+from jaxfun.galerkin import (
+    Chebyshev,
+    Legendre,
+    TensorProduct,
+    TestFunction,
+    TrialFunction,
+    inner,
+)
+from jaxfun.galerkin.cartesianproductspace import (
+    CartesianProduct,
+    CartesianProductSpace,
+    VectorTensorProductSpace,
+)
+from jaxfun.la import BlockArray, BlockTPMatrix, IndexedArray
+from jaxfun.utils.common import ulp
+
+pytestmark = pytest.mark.integration
+
+N = 8  # polynomial degree used throughout
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _two_component_space(N: int):
+    """W = CartesianProduct(T_cheb, T_leg) — two scalar TPS with different N."""
+    T0 = TensorProduct(Chebyshev.Chebyshev(N), Chebyshev.Chebyshev(N))
+    T1 = TensorProduct(Legendre.Legendre(N - 2), Legendre.Legendre(N - 2))
+    return CartesianProduct(T0, T1, name="W"), T0, T1
+
+
+def _same_n_two_component_space(N: int):
+    """W = CartesianProduct(T_cheb, T_leg) — both components use the same N.
+
+    Use this when calling evaluate_mesh without explicit N, so that all
+    components share the same quadrature grid.
+    """
+    T0 = TensorProduct(Chebyshev.Chebyshev(N), Chebyshev.Chebyshev(N))
+    T1 = TensorProduct(Legendre.Legendre(N), Legendre.Legendre(N))
+    return CartesianProduct(T0, T1, name="W"), T0, T1
+
+
+def _stokes_like_space(N: int):
+    """W = CartesianProduct(V, Q) — rank-1 velocity block V plus scalar pressure Q."""
+    T = TensorProduct(Chebyshev.Chebyshev(N), Chebyshev.Chebyshev(N))
+    Q = TensorProduct(Legendre.Legendre(N - 2), Legendre.Legendre(N - 2))
+    V = CartesianProduct(T, T, name="V", rank=1)
+    W = CartesianProduct(V, Q, name="W")
+    return W, V, Q
+
+
+# ---------------------------------------------------------------------------
+# 1. Space structure
+# ---------------------------------------------------------------------------
+
+
+def test_heterogeneous_space_properties():
+    W, T0, T1 = _two_component_space(N)
+    assert isinstance(W, CartesianProductSpace)
+    assert not isinstance(W, VectorTensorProductSpace)
+    assert W.rank == -1
+    assert W.dims == 2
+    assert W.num_components == 2
+    assert W.dim == T0.dim + T1.dim
+    assert W.block_sizes == (T0.dim, T1.dim)
+    assert W.num_dofs == (T0.num_dofs, T1.num_dofs)
+
+
+def test_heterogeneous_space_flatten():
+    W, T0, T1 = _two_component_space(N)
+    flat = W.flatten()
+    assert len(flat) == 2
+    assert flat[0].dim == T0.dim
+    assert flat[1].dim == T1.dim
+
+
+def test_nested_cartesian_product_structure():
+    """CartesianProduct(V, Q) where V is itself a CartesianProductSpace."""
+    W, V, Q = _stokes_like_space(N)
+    assert W.num_components == 3  # two velocity + one pressure
+    assert W.dim == V.dim + Q.dim
+    flat = W.flatten()
+    assert len(flat) == 3
+    for i, space in enumerate(flat):
+        assert space.global_index == i
+
+
+def test_rank_one_is_vector_tps():
+    T = TensorProduct(Chebyshev.Chebyshev(N), Chebyshev.Chebyshev(N))
+    V = CartesianProduct(T, T, name="V", rank=1)
+    assert isinstance(V, VectorTensorProductSpace)
+
+
+def test_rank_minus_one_is_not_vector_tps():
+    W, _, _ = _two_component_space(N)
+    assert not isinstance(W, VectorTensorProductSpace)
+
+
+# ---------------------------------------------------------------------------
+# 2. BlockArray
+# ---------------------------------------------------------------------------
+
+
+def test_block_array_from_tuple():
+    W, T0, T1 = _two_component_space(N)
+    a0 = jnp.ones(T0.num_dofs)
+    a1 = jnp.ones(T1.num_dofs) * 2.0
+    ba = BlockArray(W, tuple_array=(a0, a1))
+    assert jnp.allclose(ba[0], a0)
+    assert jnp.allclose(ba[1], a1)
+    assert ba.shape == (W.dim,)
+
+
+def test_block_array_flat_roundtrip_two_components():
+    """Flat → BlockArray → flat preserves data for two-component space."""
+    W, T0, T1 = _two_component_space(N)
+    a0 = jnp.arange(T0.dim, dtype=float).reshape(T0.num_dofs)
+    a1 = jnp.arange(T1.dim, dtype=float).reshape(T1.num_dofs) + T0.dim
+    flat = BlockArray(W, tuple_array=(a0, a1)).flatten()
+    assert flat.shape == (W.dim,)
+    ba_rt = BlockArray(W, flat_array=flat)
+    assert jnp.allclose(ba_rt[0], a0)
+    assert jnp.allclose(ba_rt[1], a1)
+
+
+def test_block_array_flat_roundtrip_three_components():
+    """Three-component roundtrip verifies the s0 += s1 cumulative-offset fix."""
+    W, V, Q = _stokes_like_space(N)
+    flat_spaces = W.flatten()
+    blocks = [
+        jnp.arange(s.dim, dtype=float).reshape(s.num_dofs) * (i + 1)
+        for i, s in enumerate(flat_spaces)
+    ]
+    flat = BlockArray(W, tuple_array=tuple(blocks)).flatten()
+    assert flat.shape == (W.dim,)
+    ba_rt = BlockArray(W, flat_array=flat)
+    for i, b in enumerate(blocks):
+        assert jnp.allclose(ba_rt[i], b), f"Block {i} mismatch after flat roundtrip"
+
+
+def test_block_array_arithmetic():
+    W, T0, T1 = _two_component_space(N)
+    a0, a1 = jnp.ones(T0.num_dofs), jnp.ones(T1.num_dofs) * 2.0
+    b0, b1 = jnp.ones(T0.num_dofs) * 3.0, jnp.ones(T1.num_dofs) * 4.0
+    A = BlockArray(W, tuple_array=(a0, a1))
+    B = BlockArray(W, tuple_array=(b0, b1))
+
+    C = A + B
+    assert jnp.allclose(C[0], a0 + b0) and jnp.allclose(C[1], a1 + b1)
+    D = A - B
+    assert jnp.allclose(D[0], a0 - b0) and jnp.allclose(D[1], a1 - b1)
+    assert jnp.allclose((-A)[0], -a0) and jnp.allclose((-A)[1], -a1)
+    assert jnp.allclose((3.0 * A)[0], 3 * a0) and jnp.allclose((A * 3.0)[1], 3 * a1)
+
+
+def test_block_array_accumulate():
+    W, T0, T1 = _two_component_space(N)
+    ba = BlockArray(W)
+    ba.accumulate(IndexedArray(0, jnp.ones(T0.num_dofs)))
+    ba.accumulate(IndexedArray(0, jnp.ones(T0.num_dofs)))
+    ba.accumulate(IndexedArray(1, jnp.ones(T1.num_dofs) * 5.0))
+    assert jnp.allclose(ba[0], 2.0)
+    assert jnp.allclose(ba[1], 5.0)
+
+
+# ---------------------------------------------------------------------------
+# 3. TrialFunction / TestFunction unpacking
+# ---------------------------------------------------------------------------
+
+
+def test_trialfunction_testfunction_unpack_two_components():
+    W, T0, T1 = _two_component_space(N)
+    u, p = TrialFunction(W, name="up")
+    v, q = TestFunction(W, name="vq")
+    assert u.functionspace.dim == T0.dim
+    assert p.functionspace.dim == T1.dim
+    assert v.functionspace.dim == T0.dim
+    assert q.functionspace.dim == T1.dim
+
+
+def test_trialfunction_testfunction_unpack_nested():
+    """Unpacking from a nested CartesianProductSpace (Stokes-like)."""
+    W, V, Q = _stokes_like_space(N)
+    u_vec, p = TrialFunction(W, name="up")
+    assert u_vec.functionspace.dim == V.dim
+    assert p.functionspace.dim == Q.dim
+
+
+# ---------------------------------------------------------------------------
+# 4. inner() over heterogeneous CartesianProductSpace
+#
+# Each inner() call handles one (test_block, trial_block) coupling.
+# Combine the resulting BlockTPMatrix objects with +.
+# ---------------------------------------------------------------------------
+
+
+def test_inner_per_block_returns_blocktpmatrix():
+    """Each individual inner() call over a component of W returns a BlockTPMatrix."""
+    W, T0, T1 = _two_component_space(N)
+    u, p = TrialFunction(W, name="up")
+    v, q = TestFunction(W, name="vq")
+
+    A0 = inner(v * u, sparse=True, kind="bilinear", num_quad_points=(N, N))
+    A1 = inner(q * p, sparse=True, kind="bilinear", num_quad_points=(N, N))
+
+    assert isinstance(A0, BlockTPMatrix)
+    assert isinstance(A1, BlockTPMatrix)
+    assert A0.shape == (W.dim, W.dim)
+    assert A1.shape == (W.dim, W.dim)
+
+
+def test_inner_block_sum_is_block_diagonal():
+    """Adding per-block matrices gives a block-diagonal BlockTPMatrix."""
+    W, T0, T1 = _two_component_space(N)
+    u, p = TrialFunction(W, name="up")
+    v, q = TestFunction(W, name="vq")
+
+    A = inner(v * u, sparse=True, kind="bilinear", num_quad_points=(N, N)) + inner(
+        q * p, sparse=True, kind="bilinear", num_quad_points=(N, N)
+    )
+    assert isinstance(A, BlockTPMatrix)
+    dense = A.todense()
+    assert dense.shape == (W.dim, W.dim)
+    s0 = T0.dim
+    # Off-diagonal coupling blocks must be zero for decoupled L2 mass
+    assert jnp.allclose(dense[:s0, s0:], 0.0, atol=1e-12)
+    assert jnp.allclose(dense[s0:, :s0], 0.0, atol=1e-12)
+
+
+def test_inner_system_heterogeneous_solve():
+    """Solve two decoupled L2 projections assembled as a single block system.
+
+    Each block is assembled separately, combined via +, then solved.
+    The result must match independent single-block solves for each component.
+    """
+    W, T0, T1 = _two_component_space(N)
+    x, y = W.system.base_scalars()
+    u, p = TrialFunction(W, name="up")
+    v, q = TestFunction(W, name="vq")
+
+    ue = sp.sin(sp.pi * x) * sp.sin(sp.pi * y)
+    pe = sp.cos(sp.pi * x) * sp.cos(sp.pi * y)
+
+    A0, b0 = inner(v * (u - ue), sparse=True, kind="system", num_quad_points=(N, N))
+    A1, b1 = inner(q * (p - pe), sparse=True, kind="system", num_quad_points=(N, N))
+    A = A0 + A1
+    b = cast(BlockArray, b0) + cast(BlockArray, b1)
+
+    assert isinstance(A, BlockTPMatrix)
+    assert isinstance(b, BlockArray)
+
+    x_joint = A.solve(b)
+    assert isinstance(x_joint, BlockArray)
+
+    # Compare against independent single-block solves
+    u0 = TrialFunction(T0)
+    v0 = TestFunction(T0)
+    A_ref0, b_ref0 = inner(v0 * (u0 - ue), sparse=True, kind="system")
+    x_ref0 = A_ref0.solve(b_ref0)
+
+    v1 = TestFunction(T1)
+    A_ref1, b_ref1 = inner(v1 * (p - pe), sparse=True, kind="system")
+    x_ref1 = A_ref1.solve(b_ref1)
+
+    assert jnp.linalg.norm(x_joint[0] - x_ref0) < jnp.sqrt(ulp(1000))
+    assert jnp.linalg.norm(x_joint[1] - x_ref1) < jnp.sqrt(ulp(1000))
+
+
+# ---------------------------------------------------------------------------
+# 5. evaluate / evaluate_mesh
+#
+# Both act on the same mesh for all components.  When components have
+# different polynomial degrees, use _same_n_two_component_space (or pass
+# explicit N) so the outputs all share the same shape and can be stacked.
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_stacks_components():
+    """evaluate() stacks component outputs into a single Array."""
+    W, T0, T1 = _two_component_space(N)
+    rng = np.random.default_rng(42)
+    c0 = jnp.array(rng.standard_normal(T0.num_dofs))
+    c1 = jnp.array(rng.standard_normal(T1.num_dofs))
+
+    x_pts = jnp.linspace(-0.9, 0.9, 5)
+    x_eval = jnp.stack(jnp.meshgrid(x_pts, x_pts), axis=-1).reshape(-1, 2)
+
+    result = W.evaluate(x_eval, (c0, c1))
+    assert isinstance(result, jnp.ndarray)
+    assert result.shape == (2, x_eval.shape[0])
+    assert jnp.allclose(result[0], T0.evaluate(x_eval, c0))
+    assert jnp.allclose(result[1], T1.evaluate(x_eval, c1))
+
+
+def test_evaluate_mesh_stacks_components():
+    """evaluate_mesh() stacks component outputs into a single Array.
+
+    Uses same-N components so all share the same quadrature grid size
+    without needing to pass explicit N.
+    """
+    W, T0, T1 = _same_n_two_component_space(N)
+    rng = np.random.default_rng(7)
+    c0 = jnp.array(rng.standard_normal(T0.num_dofs))
+    c1 = jnp.array(rng.standard_normal(T1.num_dofs))
+
+    result = W.evaluate_mesh((c0, c1))
+    assert isinstance(result, jnp.ndarray)
+    assert result.shape[0] == 2
+    assert jnp.allclose(result[0], T0.evaluate_mesh(c0))
+    assert jnp.allclose(result[1], T1.evaluate_mesh(c1))
+
+
+# ---------------------------------------------------------------------------
+# 6. forward / backward / scalar_product
+# ---------------------------------------------------------------------------
+
+
+def test_forward_backward_roundtrip():
+    """forward followed by backward recovers the original physical arrays."""
+    W, T0, T1 = _two_component_space(N)
+    rng = np.random.default_rng(13)
+    u0 = jnp.array(rng.standard_normal(T0.num_quad_points))
+    u1 = jnp.array(rng.standard_normal(T1.num_quad_points))
+
+    coeffs = W.forward((u0, u1))
+    assert len(coeffs) == 2
+    ua = W.backward(coeffs)
+    assert jnp.linalg.norm(ua[0] - u0) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(ua[1] - u1) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -6,9 +6,6 @@ problems.
 
 API notes
 ---------
-* inner() must be called once per (test_block, trial_block) coupling and
-  the results combined with +.  Passing v*u + q*p as a single expression
-  raises AssertionError because two distinct test functions are found.
 * When component spaces use different polynomial degrees (e.g. Stokes
   velocity N vs. pressure N-2), explicit num_quad_points must be passed to
   inner(), evaluate_mesh, and backward so all components use the same mesh.
@@ -342,13 +339,16 @@ def test_evaluate_mesh_stacks_components():
 
 def test_forward_backward_roundtrip():
     """forward followed by backward recovers the original physical arrays."""
-    W, T0, T1 = _two_component_space(N)
+    W, T0, T1 = _same_n_two_component_space(N)
     rng = np.random.default_rng(13)
     u0 = jnp.array(rng.standard_normal(T0.num_quad_points))
     u1 = jnp.array(rng.standard_normal(T1.num_quad_points))
 
-    coeffs = W.forward((u0, u1))
+    u_stacked = jnp.stack([u0, u1])
+    coeffs = W.forward(u_stacked)
     assert len(coeffs) == 2
     ua = W.backward(coeffs)
+    assert isinstance(ua, jnp.ndarray)
+    assert ua.shape == u_stacked.shape
     assert jnp.linalg.norm(ua[0] - u0) < jnp.sqrt(ulp(100))
     assert jnp.linalg.norm(ua[1] - u1) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -123,13 +123,13 @@ def test_backward_primitive_tps_2d(domain):
     f = sp.sin(x) * sp.cos(y)
     uf = JAXFunction(f, T)
     du = JAXFunction(sp.diff(f, x, y), T)
-    df = T.backward_primitive(uf.array, (1, 1))
+    df = T.backward_primitive(uf.get_array(), (1, 1))
     error = jnp.linalg.norm(df - du.backward())
 
     assert error < jnp.sqrt(ulp(100))
     if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
         du = JAXFunction(sp.diff(f, x, 2, y, 1), T)
-        df = T.backward_primitive(uf.array, (2, 1))
+        df = T.backward_primitive(uf.get_array(), (2, 1))
         error = jnp.linalg.norm(df - du.backward())
         assert error < jnp.sqrt(ulp(100)), error
 
@@ -144,11 +144,11 @@ def test_backward_primitive_tps_3d(domain):
         f = sp.sin(x) * sp.cos(y) * sp.sin(z)
         uf = JAXFunction(f, T)
         du = JAXFunction(sp.diff(f, x, y, z), T)
-        df = T.backward_primitive(uf.array, (1, 1, 1))
+        df = T.backward_primitive(uf.get_array(), (1, 1, 1))
         error = jnp.linalg.norm(df - du.backward())
 
         assert error < jnp.sqrt(ulp(100))
         du = JAXFunction(sp.diff(f, x, 2, y, 1, z, 1), T)
-        df = T.backward_primitive(uf.array, (2, 1, 1))
+        df = T.backward_primitive(uf.get_array(), (2, 1, 1))
         error = jnp.linalg.norm(df - du.backward())
         assert error < jnp.sqrt(ulp(100)), error

--- a/tests/galerkin/test_inner.py
+++ b/tests/galerkin/test_inner.py
@@ -1,9 +1,9 @@
 from typing import assert_type, cast
 
-import jax
 import jax.numpy as jnp
 import pytest
 import sympy as sp
+from jax import Array
 from scipy.integrate import dblquad
 
 from jaxfun.galerkin import (
@@ -19,7 +19,7 @@ from jaxfun.galerkin.Chebyshev import Chebyshev
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.Legendre import Legendre
-from jaxfun.la import BaseMatrix, DiaMatrix, TPMatrices
+from jaxfun.la import BaseMatrix, BlockArray, DiaMatrix, TPMatrices
 from jaxfun.typing import GalerkinAssembledForm
 from jaxfun.utils import ulp
 
@@ -49,7 +49,7 @@ def test_inner(space: type[Legendre] | type[Chebyshev]) -> None:
     v = TestFunction(C)
     M = inner(x * v * u + sp.diff(u, x) * v, sparse=False)
     assert hasattr(M, "diagonal")
-    M_arr = cast(jax.Array, M)
+    M_arr = cast(Array, M)
     a0 = answer2[space.__name__]
     for d in (-3, -1, 1, 3):
         assert jnp.allclose(M_arr.diagonal(d), a0[d], atol=1000 * ulp(1.0))
@@ -69,16 +69,15 @@ def test_inner_kind_checked_return_types() -> None:
 
     assert_type(raw, GalerkinAssembledForm)
     assert_type(A, BaseMatrix)
-    assert_type(b, jax.Array)
-    assert_type((A_str, b_str), tuple[BaseMatrix, jax.Array])
-    assert_type((A_enum, b_enum), tuple[BaseMatrix, jax.Array])
+    assert_type(b, Array | BlockArray)
+    assert_type((A_str, b_str), tuple[BaseMatrix, Array | BlockArray])
+    assert_type((A_enum, b_enum), tuple[BaseMatrix, Array | BlockArray])
 
     assert isinstance(A, BaseMatrix)
-    assert isinstance(b, jax.Array)
+    assert isinstance(b, Array | BlockArray)
     assert isinstance(A_str, BaseMatrix)
-    assert isinstance(b_str, jax.Array)
+    assert isinstance(b_str, Array | BlockArray)
     assert jnp.allclose(A_str.todense(), A_enum.todense())
-    assert jnp.allclose(b_str, b_enum)
 
 
 def test_inner_kind_rejects_mismatches_and_unknown_strings() -> None:
@@ -346,7 +345,7 @@ def test_inner_padding_resolved(
     y1 = inner(v * uf**2, num_quad_points=48, kind="linear")
     # Since the function is well-resolved with 36 modes, we expect no
     # aliasing and thus the same result with or without padding
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = D.forward(uf.backward() ** 2)
     y3 = D.forward(uf.backward(N=48) ** 2)
     assert jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -364,7 +363,7 @@ def test_inner_padding_not_resolved(
     y1 = inner(v * uf**2, num_quad_points=12, kind="linear")
     # Since the function is not well-resolved with 8 modes, we expect
     # aliasing and thus different results with or without padding
-    assert not jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert not jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = D.forward(uf.backward() ** 2)
     y3 = D.forward(uf.backward(N=12) ** 2)
     assert not jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -387,7 +386,7 @@ def test_inner_padding_resolved_2d(
     y1 = inner(v * uf**2, num_quad_points=(48, 48), kind="linear")
     # Since the function is well-resolved with 36 modes, we expect no
     # aliasing and thus the same result with or without padding
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = T.forward(uf.backward() ** 2)
     y3 = T.forward(uf.backward(N=(48, 48)) ** 2)
     assert jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -407,7 +406,7 @@ def test_inner_padding_not_resolved_2d(
     y1 = inner(v * uf**2, num_quad_points=(12, 12), kind="linear")
     # Since the function is not well-resolved with 8 modes, we expect
     # aliasing and thus different results with or without padding
-    assert not jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert not jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = T.forward(uf.backward() ** 2)
     y3 = T.forward(uf.backward(N=(12, 12)) ** 2)
     assert not jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -442,8 +441,11 @@ def test_inner_padding_Fourier_2d() -> None:
     v = TestFunction(T)
     y0 = inner(v * uf**2, num_quad_points=None, kind="linear")
     y1 = inner(v * uf**2, num_quad_points=(9, 9), kind="linear")
+
     assert jnp.linalg.norm(y1) < jnp.sqrt(ulp(100))  # No aliasing - thus zero
-    assert abs(y0[2, 2] - (2 * jnp.pi) ** 2) < jnp.sqrt(ulp(100))  # Aliasing error
+    assert abs(cast(Array, y0)[2, 2] - (2 * jnp.pi) ** 2) < jnp.sqrt(
+        ulp(100)
+    )  # Aliasing error  # noqa: E501
     y2 = T.forward(uf.backward() ** 2)
     y3 = T.forward(uf.backward(N=(9, 9)) ** 2)
     assert jnp.linalg.norm(y3) < jnp.sqrt(ulp(100))  # No aliasing - thus zero
@@ -463,7 +465,7 @@ def test_inner_padding_composite_resolved(
     y1 = inner(v * uf**2, num_quad_points=48, kind="linear")
     # Since the function is well-resolved with 36 modes, we expect no
     # aliasing and thus the same result with or without padding
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = D.forward(uf.backward() ** 2)
     y3 = D.forward(uf.backward(N=48) ** 2)
     assert jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -482,7 +484,7 @@ def test_inner_padding_directsum_resolved(
     y1 = inner(v * uf**2, num_quad_points=48, kind="linear")
     # Since the function is well-resolved with 36 modes, we expect no
     # aliasing and thus the same result with or without padding
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = D.forward(uf.backward() ** 2)
     y3 = D.forward(uf.backward(N=48) ** 2)
     assert jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))
@@ -508,7 +510,7 @@ def test_inner_padding_directsumtps_resolved_2d(
     y1 = inner(v * uf**2, num_quad_points=(48, 48), kind="linear")
     # Since the function is well-resolved with 36 modes, we expect no
     # aliasing and thus the same result with or without padding
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert jnp.linalg.norm(cast(Array, y0) - cast(Array, y1)) < jnp.sqrt(ulp(100))
     y2 = T.forward(uf.backward() ** 2)
     y3 = T.forward(uf.backward(N=(48, 48)) ** 2)
     assert jnp.linalg.norm(y2 - y3) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -6,6 +6,7 @@ import sympy as sp
 
 from jaxfun import Domain
 from jaxfun.galerkin import (
+    CartesianProduct,
     Chebyshev,
     ChebyshevU,
     Fourier,
@@ -219,14 +220,16 @@ def test_jaxfunction_2d_vector(space: type[OrthogonalSpace], domain: Domain | No
     N = 8
     D = space(N, domain=domain)
     T = TensorProduct(D, D)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
     u = TrialFunction(V)
     v = TestFunction(V)
     A = inner(Dot(u, v), kind="bilinear")
-    uf = JAXFunction(jnp.ones((2, N, N)), V)
+    uf = JAXFunction(tuple((jnp.ones((N, N)), jnp.ones((N, N)))), V)
     b0 = A @ uf.array
     b1 = inner(Dot(uf, v), kind="linear")
-    assert jnp.linalg.norm(b0 - b1) < jnp.sqrt(ulp(10))
+    assert all(
+        jnp.linalg.norm(b0[i] - b1[i]) < jnp.sqrt(ulp(10)) for i in range(len(b0))
+    )
 
 
 def test_jaxfunction_vector(jspace: type[OrthogonalSpace], domain: Domain | None):

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -253,6 +253,26 @@ def test_jaxfunction_vector(jspace: type[OrthogonalSpace], domain: Domain | None
     assert jnp.linalg.norm(uj[1] - (1 - xj**2) * (1 - yj**2)) < jnp.sqrt(ulp(10))
 
 
+def test_jaxfunction_vector_composite(
+    jspace: type[OrthogonalSpace], domain: Domain | None
+):
+    N = 8
+    bcs = {"left": {"D": 0}, "right": {"D": 0}}
+    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
+    T = TensorProduct(D, D)
+    V = CartesianProduct(T, T, name="V", rank=1)
+    x, y = T.system.base_scalars()
+    R = T.system
+
+    a = D.domain.upper
+    ue = sp.Mul((a**2 - x**2) * (a**2 - y**2), R.i + R.j)
+    w = JAXFunction(ue, V, name="w")
+    uj = w.backward()
+    xj, yj = T.mesh()
+    assert jnp.linalg.norm(uj[0] - (a**2 - xj**2) * (a**2 - yj**2)) < jnp.sqrt(ulp(10))
+    assert jnp.linalg.norm(uj[1] - (a**2 - xj**2) * (a**2 - yj**2)) < jnp.sqrt(ulp(10))
+
+
 def test_jaxfunction_vector_directsum(
     jspace: type[OrthogonalSpace], domain: Domain | None
 ):

--- a/tests/galerkin/test_jaxfunction.py
+++ b/tests/galerkin/test_jaxfunction.py
@@ -3,6 +3,7 @@ from typing import cast
 import jax.numpy as jnp
 import pytest
 import sympy as sp
+from jax import Array
 
 from jaxfun import Domain
 from jaxfun.galerkin import (
@@ -18,7 +19,6 @@ from jaxfun.galerkin import (
     TestFunction,
     TrialFunction,
     Ultraspherical,
-    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.inner import inner
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
@@ -149,11 +149,11 @@ def test_jaxfunction_2d(space: type[OrthogonalSpace], domain: Domain | None):
     v = TestFunction(T)
     A = cast(TPMatrix, inner(u * v, kind="bilinear"))
     uf = JAXFunction(jnp.ones((N, N)), T)
-    b0 = A.todense() @ uf.array.ravel()
+    b0 = A.todense() @ uf.get_array().ravel()
     b1 = A.mats[0] @ uf @ A.mats[1].T
     assert jnp.linalg.norm(b0 - b1.ravel()) < ulp(10)
     z = inner(uf * v, kind="linear")
-    assert jnp.linalg.norm(z.ravel() - b0) < ulp(10)
+    assert jnp.linalg.norm(cast(Array, z).ravel() - b0) < ulp(10)
 
 
 def test_jaxfunction_directsum_2d(jspace: type[Jacobi.Jacobi], domain: Domain | None):
@@ -225,7 +225,7 @@ def test_jaxfunction_2d_vector(space: type[OrthogonalSpace], domain: Domain | No
     v = TestFunction(V)
     A = inner(Dot(u, v), kind="bilinear")
     uf = JAXFunction(tuple((jnp.ones((N, N)), jnp.ones((N, N)))), V)
-    b0 = A @ uf.array
+    b0 = A @ uf
     b1 = inner(Dot(uf, v), kind="linear")
     assert all(
         jnp.linalg.norm(b0[i] - b1[i]) < jnp.sqrt(ulp(10)) for i in range(len(b0))
@@ -236,7 +236,7 @@ def test_jaxfunction_vector(jspace: type[OrthogonalSpace], domain: Domain | None
     N = 8
     D = jspace(N, domain=domain)
     T = TensorProduct(D, D)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
     x, y = T.system.base_scalars()
     R = T.system
     ue = x * R.i + y * R.j
@@ -253,26 +253,6 @@ def test_jaxfunction_vector(jspace: type[OrthogonalSpace], domain: Domain | None
     assert jnp.linalg.norm(uj[1] - (1 - xj**2) * (1 - yj**2)) < jnp.sqrt(ulp(10))
 
 
-def test_jaxfunction_vector_composite(
-    jspace: type[OrthogonalSpace], domain: Domain | None
-):
-    N = 8
-    bcs = {"left": {"D": 0}, "right": {"D": 0}}
-    D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
-    T = TensorProduct(D, D)
-    V = VectorTensorProductSpace(T, name="V")
-    x, y = T.system.base_scalars()
-    R = T.system
-
-    a = D.domain.upper
-    ue = sp.Mul((a**2 - x**2) * (a**2 - y**2), R.i + R.j)
-    w = JAXFunction(ue, V, name="w")
-    uj = w.backward()
-    xj, yj = T.mesh()
-    assert jnp.linalg.norm(uj[0] - (a**2 - xj**2) * (a**2 - yj**2)) < jnp.sqrt(ulp(10))
-    assert jnp.linalg.norm(uj[1] - (a**2 - xj**2) * (a**2 - yj**2)) < jnp.sqrt(ulp(10))
-
-
 def test_jaxfunction_vector_directsum(
     jspace: type[OrthogonalSpace], domain: Domain | None
 ):
@@ -280,7 +260,7 @@ def test_jaxfunction_vector_directsum(
     bcs = {"left": {"D": 1}, "right": {"D": 1}}
     D = FunctionSpace(N, jspace, domain=domain, bcs=bcs)
     T = TensorProduct(D, D)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
     x, y = T.system.base_scalars()
     R = T.system
 

--- a/tests/galerkin/test_tensorproductspace.py
+++ b/tests/galerkin/test_tensorproductspace.py
@@ -34,7 +34,6 @@ def test_tensorproduct_forward_backward_padding_fourier():
     u = TrialFunction(T)
     v = TestFunction(T)
     M, b = inner(v * (u - sp.sin(x) * sp.sin(y)), kind="system")
-    assert isinstance(M, TPMatrix)
     # Solve
     uh = M.solve(b)
     # Backward on padded grid
@@ -196,7 +195,7 @@ def test_inner_linear_only():
     v = TestFunction(C)
     x = C.system.x
     b = inner(sp.sin(x) * v, kind="linear")
-    assert b.shape[0] == C.N
+    assert cast(Array, b).shape[0] == C.N
 
 
 def test_inner_returns_matrix_and_vector_with_bcs():
@@ -209,7 +208,7 @@ def test_inner_returns_matrix_and_vector_with_bcs():
     A, b = inner(v * u + x * v * u, kind="system")
     # A is dense matrix, b vector
     assert A.shape[0] == A.shape[1]
-    assert b.shape[0] == A.shape[0]
+    assert cast(Array, b).shape[0] == A.shape[0]
 
 
 def test_vectortensorproductspace_project():

--- a/tests/galerkin/test_tensorproductspace.py
+++ b/tests/galerkin/test_tensorproductspace.py
@@ -1,9 +1,13 @@
+from typing import cast
+
 import jax
 import jax.numpy as jnp
 import pytest
 import sympy as sp
+from jax import Array
 
 from jaxfun.galerkin import (
+    CartesianProduct,
     Chebyshev,
     Fourier,
     FunctionSpace,
@@ -12,12 +16,12 @@ from jaxfun.galerkin import (
     TensorProduct,
     TestFunction,
     TrialFunction,
-    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.composite import DirectSum
 from jaxfun.galerkin.inner import inner
 from jaxfun.la import TensorMatrix, TPMatrices, TPMatrix
-from jaxfun.utils.common import ulp
+from jaxfun.operators import Dot
+from jaxfun.utils.common import lambdify, ulp
 
 pytestmark = pytest.mark.integration
 
@@ -85,13 +89,17 @@ def test_vectortensorproductspace_forward_backward_roundtrip():
     N = 8
     C = Chebyshev.Chebyshev(N)
     T = TensorProduct(C, C)
-    V = VectorTensorProductSpace(T, name="V")
-    key = jax.random.PRNGKey(0)
-    coeffs = jax.random.normal(key, shape=V.shape())
+    V = CartesianProduct(T, T, name="V", rank=1)
+    coeffs = tuple(
+        jax.random.normal(jax.random.PRNGKey(i), shape=Vi.num_dofs)
+        for i, Vi in enumerate(V.flatten())
+    )
     u = JAXFunction(coeffs, V)
-    ua = V.backward(u.array)
+    ua = V.backward(cast(tuple[Array, ...], u.array))
     coeffs_rt = V.forward(ua)
-    assert jnp.linalg.norm(u.array - coeffs_rt) < ulp(1000)
+    assert all(
+        jnp.linalg.norm(u.array[i] - coeffs_rt[i]) < ulp(1000) for i in range(len(V))
+    )
 
 
 def test_vectortensorproductspace_padded_backward_forward_truncation_roundtrip():
@@ -100,18 +108,73 @@ def test_vectortensorproductspace_padded_backward_forward_truncation_roundtrip()
 
     C = Chebyshev.Chebyshev(N)
     T = TensorProduct(C, C)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
 
-    key = jax.random.PRNGKey(1)
-    coeffs = jax.random.normal(key, shape=V.num_dofs)
+    coeffs = tuple(
+        jax.random.normal(jax.random.PRNGKey(i), shape=Vi.num_dofs)
+        for i, Vi in enumerate(V.flatten())
+    )
     u = JAXFunction(coeffs, V)
 
-    ua = V.backward(u.array, N=(pad, pad))
+    ua = V.backward(cast(tuple[Array, ...], u.array), N=(pad, pad))
     coeffs_rt = V.forward(ua)
 
-    assert ua.shape == (2,) + pad
-    assert coeffs_rt.shape == V.num_dofs
-    assert jnp.linalg.norm(u.array - coeffs_rt) < ulp(1000)
+    assert ua[0].shape == pad and ua[1].shape == pad
+    assert all(
+        jnp.linalg.norm(u.array[i] - coeffs_rt[i]) < ulp(1000) for i in range(len(V))
+    )
+
+
+def test_vectortensorproductspace_project_different_tpspaces():
+    N = 20
+    bcsD = {"left": {"D": 0}, "right": {"D": 0}}
+    bcsB = {"left": {"D": 0, "N": 0}, "right": {"D": 0, "N": 0}}
+    C0 = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsD)
+    C1 = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsB)
+    T0 = TensorProduct(C0, C0)
+    T1 = TensorProduct(C1, C1)
+    V = CartesianProduct(T0, T1, name="V", rank=1)
+    x, y = V.system.base_scalars()
+    i, j = V.system.base_vectors()
+    coeffs = (
+        sp.sin(x * sp.pi) * sp.sin(y * sp.pi) * i + ((1 - x**2) * (1 - y**2)) ** 2 * j
+    )
+    u = JAXFunction(coeffs, V)
+    uej = (
+        lambdify((x, y), Dot(coeffs, i).doit())(*V.mesh()),
+        lambdify((x, y), Dot(coeffs, j).doit())(*V.mesh()),
+    )
+    ua = u.backward()
+    assert all(
+        jnp.linalg.norm(ua[i] - uej[i]) < jnp.sqrt(ulp(10)) for i in range(len(V))
+    )
+
+
+def test_compositetensorproductspace_project():
+    N = 20
+    bcsD = {"left": {"D": 0}, "right": {"D": 0}}
+    bcsB = {"left": {"D": 0, "N": 0}, "right": {"D": 0, "N": 0}}
+    C0 = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsD)
+    C1 = FunctionSpace(N, Chebyshev.Chebyshev, bcs=bcsB)
+    T0 = TensorProduct(C0, C0)
+    T1 = TensorProduct(C1, C1)
+    V = CartesianProduct(T0, T1, name="V", rank=1)
+    W = CartesianProduct(V, T1, name="W")
+    x, y = W.system.base_scalars()
+    i, j = W.system.base_vectors()
+
+    coeffs = (
+        sp.sin(x * sp.pi) * sp.sin(y * sp.pi) * i + ((1 - x**2) * (1 - y**2)) ** 2 * j
+    )
+    u = JAXFunction(coeffs, V)
+    uej = (
+        lambdify((x, y), Dot(coeffs, i).doit())(*V.mesh()),
+        lambdify((x, y), Dot(coeffs, j).doit())(*V.mesh()),
+    )
+    ua = u.backward()
+    assert all(
+        jnp.linalg.norm(ua[i] - uej[i]) < jnp.sqrt(ulp(10)) for i in range(len(V))
+    )
 
 
 def test_inner_multivar_expression():
@@ -154,13 +217,13 @@ def test_vectortensorproductspace_project():
 
     C = Chebyshev.Chebyshev(N)
     T = TensorProduct(C, C)
-    V = VectorTensorProductSpace(T, name="V")
-    x, y = T.system.base_scalars()
-    i, j = T.system.base_vectors()
+    V = CartesianProduct(T, T, name="V", rank=1)
+    x, y = V.system.base_scalars()
+    i, j = V.system.base_vectors()
 
     u = JAXFunction(y * i + x * j, V)
 
-    ua = V.backward(u.array)
+    ua = V.backward(cast(tuple[Array, ...], u.array))
     xi, yj = T.mesh()
     assert jnp.linalg.norm(ua[0] - yj) < ulp(1000)
     assert jnp.linalg.norm(ua[1] - xi) < ulp(1000)

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -214,11 +214,17 @@ def test_vectortensorproductspace_to_orthogonal():
     T = TensorProduct(F1, F2)
     V = VectorTensorProductSpace(T, name="V")
     O = V.get_orthogonal()
-    c = jax.random.normal(jax.random.PRNGKey(0), shape=V.num_dofs)
+    c = tuple(
+        jax.random.normal(jax.random.PRNGKey(i), shape=Vi.num_dofs)
+        for i, Vi in enumerate(V.tensorspaces)
+    )
     c0 = V.to_orthogonal(c)
     y0 = V.backward(c)
     y1 = O.backward(c0)
-    assert jnp.linalg.norm(y0 - y1) < jnp.sqrt(ulp(100))
+    assert all(
+        jnp.linalg.norm(y0[i] - y1[i]) < jnp.sqrt(ulp(100))
+        for i in range(len(V.tensorspaces))
+    )
 
 
 def test_directsumtps():

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -6,6 +6,7 @@ import pytest
 import sympy as sp
 
 from jaxfun.galerkin import (
+    CartesianProduct,
     Chebyshev,
     ChebyshevU,
     DirectSum,
@@ -16,7 +17,6 @@ from jaxfun.galerkin import (
     TestFunction,
     TrialFunction,
     Ultraspherical,
-    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.inner import inner, inner_items, project
 from jaxfun.galerkin.tensorproductspace import DirectSumTPS
@@ -212,18 +212,18 @@ def test_vectortensorproductspace_to_orthogonal():
     F1 = FunctionSpace(N1, Legendre.Legendre, bcs={"left": {"D": 0}, "right": {"D": 0}})
     F2 = FunctionSpace(N2, Legendre.Legendre, bcs={"left": {"N": 0}, "right": {"N": 0}})
     T = TensorProduct(F1, F2)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
     O = V.get_orthogonal()
     c = tuple(
         jax.random.normal(jax.random.PRNGKey(i), shape=Vi.num_dofs)
-        for i, Vi in enumerate(V.tensorspaces)
+        for i, Vi in enumerate(V.flatten())
     )
     c0 = V.to_orthogonal(c)
     y0 = V.backward(c)
     y1 = O.backward(c0)
     assert all(
         jnp.linalg.norm(y0[i] - y1[i]) < jnp.sqrt(ulp(100))
-        for i in range(len(V.tensorspaces))
+        for i in range(len(V.flatten()))
     )
 
 

--- a/tests/la/test_diamatrix.py
+++ b/tests/la/test_diamatrix.py
@@ -19,7 +19,7 @@ from jaxfun.la.diamatrix import (
     diags,
 )
 from jaxfun.la.matrix import Matrix
-from jaxfun.la.pinned import PinnedSystem
+from jaxfun.la.pinned import PinnedDiaMatrix, PinnedSystem
 from jaxfun.utils.common import ulp
 
 
@@ -1092,7 +1092,10 @@ class TestPin:
         _, A = _tridiag(4)
         sys = A.pin({0: 0.0})
         r = repr(sys)
-        assert "PinnedSystem" in r
+        if isinstance(sys, PinnedDiaMatrix):
+            assert "PinnedDiaMatrix" in r
+        else:
+            assert "PinnedMatrix" in r
         assert "0: 0.0" in r
 
     # ------------------------------------------------------------------

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -372,7 +372,7 @@ class TestManualKronSolve:
         B = _diag5(5)
         K = diakron(A, B)
         b = jax.random.normal(jax.random.PRNGKey(2), shape=(30,))
-        x = K.solve(b, method="banded")
+        x = K.solve(b, method="banded", auto_threshold=200)
         assert float(jnp.linalg.norm(K.todense() @ x - b)) < ulp(1000)
 
     def test_lu_vs_dense_on_kron(self):

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -18,6 +18,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax import Array
 
 from jaxfun.galerkin import (
     FunctionSpace,
@@ -66,7 +67,7 @@ def _diag5(n: int) -> DiaMatrix:
     )
 
 
-def _poisson_tpmats(N: int = 8) -> tuple[TPMatrices, jnp.ndarray]:
+def _poisson_tpmats(N: int = 8) -> tuple[TPMatrices, Array]:
     """Return (A, b) for a 2-D Poisson problem on a Legendre composite space."""
     bcs = {"left": {"D": 0}, "right": {"D": 0}}
     D = FunctionSpace(N, Legendre.Legendre, bcs=bcs)
@@ -75,10 +76,10 @@ def _poisson_tpmats(N: int = 8) -> tuple[TPMatrices, jnp.ndarray]:
     x, y = T.system.base_scalars()
     ue = (1 - x**2) * (1 - y**2)
     A, b = inner(v * Div(Grad(u)) - v * Div(Grad(ue)), sparse=True, kind="system")
-    return cast(TPMatrices, A), b
+    return cast(TPMatrices, A), cast(Array, b)
 
 
-def _biharmonic_tpmats(N: int = 8) -> tuple[TPMatrices, jnp.ndarray]:
+def _biharmonic_tpmats(N: int = 8) -> tuple[TPMatrices, Array]:
     """Return (A, b) for a 2-D biharmonic problem on a Chebyshev composite space."""
     from jaxfun.coordinates import x, y
     from jaxfun.galerkin import Chebyshev
@@ -97,7 +98,7 @@ def _biharmonic_tpmats(N: int = 8) -> tuple[TPMatrices, jnp.ndarray]:
         sparse=True,
         kind="system",
     )
-    return cast(TPMatrices, A), b
+    return cast(TPMatrices, A), cast(Array, b)
 
 
 class TestDiakron:

--- a/tests/la/test_tpmatrices_solvers.py
+++ b/tests/la/test_tpmatrices_solvers.py
@@ -4,20 +4,22 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import sympy as sp
+from jax import Array
 
 from jaxfun.galerkin import (
+    CartesianProduct,
     Chebyshev,
     FunctionSpace,
     Legendre,
     TensorProduct,
     TestFunction,
     TrialFunction,
-    VectorTensorProductSpace,
 )
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.galerkin.inner import inner
 from jaxfun.la import (
     BaseMatrix,
+    BlockArray,
     BlockTPMatrix,
     TPMatrices,
     TPMatrix,
@@ -316,7 +318,7 @@ def test_tpmatrices_solve_fourier_fourier_legendre_3d():
     assert isinstance(lu, TPMatricesWavenumberSolver)
 
     uh = A.solve(b)
-    assert uh.shape == b.shape
+    assert uh.shape == cast(Array, b).shape
 
     M = 20
     uj = T.backward(uh, N=(M, M, M))
@@ -343,16 +345,16 @@ def _vector_block_system(N: int, poly):
     F0 = FunctionSpace(N, poly, BCS_VEC)
     F1 = FunctionSpace(N, poly, BCS_VEC)
     T = TensorProduct(F0, F1)
-    V = VectorTensorProductSpace(T, name="V")
+    V = CartesianProduct(T, T, name="V", rank=1)
     u = TrialFunction(V)
     v = TestFunction(V)
     A = inner(Dot(v, u), sparse=True)
     assert isinstance(A, BlockTPMatrix)
     assert isinstance(A, BaseMatrix)
     rng = np.random.default_rng(0)
-    x_true = jnp.array(rng.standard_normal(A.shape[1]), dtype=jnp.float32)
+    x_true = jnp.array(rng.standard_normal(A.shape[1]))
     b = A.to_matrix().matvec(x_true)
-    return A, b, x_true
+    return A, BlockArray(V, flat_array=b), x_true
 
 
 @POLY_SPACES
@@ -368,11 +370,11 @@ def test_blocktpmatrix_tosparse_returns_diamatrix(poly):
 def test_blocktpmatrix_solve_sparse_matches_dense(poly):
     A, b, x_true = _vector_block_system(8, poly)
     # Dense reference
-    x_dense = A.to_matrix().solve(b.ravel()).reshape(b.shape)
+    x_dense = A.to_matrix().solve(b.flatten())
     # Sparse / RCM path
     x_sparse = A.solve(b)
     assert x_sparse.shape == b.shape
-    assert jnp.allclose(x_sparse.ravel(), x_dense.ravel(), atol=ulp(1000))
+    assert jnp.allclose(x_sparse.flatten(), x_dense.ravel(), atol=ulp(1000))
 
 
 @POLY_SPACES
@@ -390,9 +392,9 @@ def test_blocktpmatrix_call_matches_dense_matvec(poly):
     A, b, x_true = _vector_block_system(8, poly)
     # Warm the RCM cache via solve
     _ = A.solve(b)
-    y_block = A(x_true)
+    y_block = A(BlockArray(A.test_space, flat_array=x_true))
     y_dense = A.to_matrix().matvec(x_true.ravel()).reshape(x_true.shape)
-    assert jnp.allclose(y_block.ravel(), y_dense.ravel(), atol=ulp(1000))
+    assert jnp.allclose(y_block.flatten(), y_dense.ravel(), atol=ulp(1000))
 
 
 @POLY_SPACES
@@ -401,4 +403,4 @@ def test_blocktpmatrix_solve_cached_rcm(poly):
     A, b, _ = _vector_block_system(8, poly)
     x1 = A.solve(b)
     x2 = A.solve(b)
-    assert jnp.allclose(x1.ravel(), x2.ravel(), atol=ulp(10))
+    assert jnp.allclose(x1.flatten(), x2.flatten(), atol=ulp(10))


### PR DESCRIPTION
## Summary

Adds `CartesianProductSpace` for mixed / composite function spaces, enabling heterogeneous tensor-product space combinations such as Stokes velocity + pressure. `VectorTensorProductSpace` is refactored to be a rank-1 subclass of the new class. Includes new block-assembly infrastructure (`BlockArray`, `IndexedArray`, updated `BlockTPMatrix`) and a complete Stokes flow example.

## Types of Changes

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] Build / CI
- [ ] Other (describe):

## Related Issues

Refs #

## Description of Changes

**New class hierarchy:**
- `CartesianProductSpace` (`galerkin/cartesianproductspace.py`) — composite space of arbitrary `TensorProductSpace` or nested `CartesianProductSpace` components; supports `rank=-1` (general mixed) and `rank=1` (vector field via `VectorTensorProductSpace` subclass).
- `VectorTensorProductSpace` moved from `tensorproductspace.py` into `cartesianproductspace.py` as a rank-1 subclass; public API is unchanged.
- `CartesianProduct` factory — deep-copies inputs and dispatches to the correct subclass based on `rank`.

**Block assembly infrastructure:**
- `BlockArray` — flat-vector `nnx.Pytree` wrapping per-component spectral arrays; supports arithmetic, `accumulate`, and `IndexedArray` scatter. Used as the RHS type returned by `inner()` on composite spaces.
- `IndexedArray` — lightweight `(global_index, data)` wrapper routing assembly contributions to the correct block.
- `BlockTPMatrix` — updated to operate on `BlockArray` / `CartesianProductSpace`; supports `+` for multi-block assembly and `solve` / `tosparse` / `pin`.
- `PinnedDiaMatrix` / `PinnedMatrix` — new concrete subclasses of `PinnedSystem` exposing the full `lu_solve` signature on the DIA variant.

**inner() API for mixed spaces:** each call handles one `(test_block, trial_block)` coupling; results are combined with `+`:
```python
W = CartesianProduct(V, Q, name="W")
u, p = TrialFunction(W, name="up")
v, q = TestFunction(W, name="vq")
A, a = inner(Dot(nu * Div(Grad(u)), v), sparse=True, kind="system", num_quad_points=(N, N))
B, b = inner(q * Div(u), sparse=True, kind="system", num_quad_points=(N, N))
C = A + B + inner(p * Div(v), sparse=True, kind="bilinear", num_quad_points=(N, N))
```

**Transform conventions:** physical-space transforms use a stacked `Array` of shape `(n_components, *mesh_shape)` — `backward` returns one, `forward` and `scalar_product` accept one. Spectral-space inputs/outputs remain `tuple[Array, ...]` since component shapes may differ.

**Bug fixes included:**
- `BlockTPMatrix.__call__`: missing `else` caused RCM-permuted matvec result to be overwritten.
- `BlockArray._list_from_flat_array`: `s0 = s1` gave wrong block boundaries for spaces with more than two components (fixed to `s0 += s1`).
- `ExpansionFunction.__getitem__`: return type corrected from `sp.Expr` to `Self`.
- `Cordsys.__deepcopy__` and `__copy__` fixed to return self because deepcopy was messed up.

## Screenshots / Logs (if applicable)

`examples/Stokes.py` — driven-cavity Stokes flow on a square domain assembles the full saddle-point system, pins one pressure DOF, and solves with RCM-reordered LU.

## Breaking Changes

- [x] Yes (describe below)
- [ ] No

`CartesianProductSpace.backward` now returns a stacked `Array` instead of `tuple[Array, ...]`. `forward` and `scalar_product` now accept a stacked `Array` instead of `tuple[Array, ...]`. Code that unpacks the result of `backward` as a tuple (`u0, u1 = W.backward(...)`) continues to work via JAX first-axis iteration; code that explicitly type-annotates the result as `tuple[Array, ...]` needs updating.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [ ] Coverage does not decrease
- [ ] Git history is clean (squash/fixup before merge)

## Additional Notes

When component spaces use different polynomial degrees (e.g. Stokes velocity N vs. pressure N−2), `num_quad_points` must be passed to `inner()` and explicit `N` to `backward` / `evaluate_mesh` to ensure all components are evaluated on the same mesh. This matches the pattern shown in `examples/Stokes.py`.
