### PR TITLE
Cartesian products introduced for 1D problems

### DIFF
--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -56,7 +56,9 @@ C_pin = C.tosparse().pin({2 * (N - 2) ** 2: 0})
 d = C_pin.lu_solve(c.flatten(), method="rcm", pivot=True)
 
 sol = BlockArray(W, flat_array=d)
-up_ = W.backward(sol.array, N=(None, None, (N, N)))
+up_ = W.backward(
+    sol.array, N=(N, N)
+)  # Need to provide N since spaces have different shape  # noqa: E501
 
 if "PYTEST" in os.environ:
     for i in range(3):

--- a/examples/Stokes.py
+++ b/examples/Stokes.py
@@ -20,7 +20,7 @@ from jaxfun.galerkin import (
     TrialFunction,
     inner,
 )
-from jaxfun.la.blocktpmatrix import BlockArray
+from jaxfun.la.blockmatrix import BlockArray
 from jaxfun.operators import Constant, Div, Dot, Grad
 
 f = (1 - x) ** 2 * (1 + x) ** 2

--- a/examples/coupled1D.py
+++ b/examples/coupled1D.py
@@ -38,7 +38,7 @@ B, b = inner(u.diff(x) * q - s * q, kind="system", sparse=True)
 H = A + B
 h = a + b  # ty:ignore[unsupported-operator]
 
-uh = H.solve(h, method="banded", pivot=True)
+uh = H.solve(h, method="banded", pivot=True, auto_threshold=10000)
 
 z = H @ uh
 assert jnp.linalg.norm(z.flatten() - h.flatten()) < ulp(100)

--- a/examples/coupled1D.py
+++ b/examples/coupled1D.py
@@ -1,5 +1,8 @@
 # ruff: noqa: E402
 # Solve Poisson's equation using mixed formulation in 1D
+import os
+import sys
+
 import jax.numpy as jnp
 import sympy as sp
 
@@ -44,4 +47,9 @@ xj = D.mesh()
 uj = C.backward(uh)
 uej = lambdify(x, ue)(xj)
 error = jnp.linalg.norm(uj[0] - uej)
+
+if "PYTEST" in os.environ:
+    assert error < jnp.sqrt(ulp(1)), error
+    sys.exit(0)
+
 print("Error =", error)

--- a/examples/coupled1D.py
+++ b/examples/coupled1D.py
@@ -1,0 +1,47 @@
+# ruff: noqa: E402
+# Solve Poisson's equation using mixed formulation in 1D
+import jax.numpy as jnp
+import sympy as sp
+
+from jaxfun.coordinates import BaseScalar, x
+from jaxfun.galerkin import CartesianProduct
+from jaxfun.galerkin.arguments import TestFunction, TrialFunction
+
+# from jaxfun.galerkin.Chebyshev import Chebyshev as space
+from jaxfun.galerkin.functionspace import FunctionSpace
+from jaxfun.galerkin.inner import inner
+from jaxfun.galerkin.Legendre import Legendre as space
+from jaxfun.utils.common import lambdify, ulp
+
+M = 60
+ue = sp.exp(sp.cos(2 * sp.pi * x))
+
+bcs = {"left": {"D": ue.subs(x, -1)}, "right": {"D": ue.subs(x, 1)}}
+
+D = FunctionSpace(M, space, bcs=bcs, name="D", fun_str="psi")
+S = FunctionSpace(M, space, name="S", fun_str="phi")
+C = CartesianProduct(D, S, name="C")
+
+v, q = TestFunction(C, name="vq")
+u, s = TrialFunction(C, name="us")
+
+# Method of manufactured solution
+x: BaseScalar = C.system.x
+ue = C.system.expr_psi_to_base_scalar(ue)
+
+A, a = inner(s.diff(x) * v - ue.diff(x, 2) * v, kind="system", sparse=True)
+B, b = inner(u.diff(x) * q - s * q, kind="system", sparse=True)
+
+H = A + B
+h = a + b  # ty:ignore[unsupported-operator]
+
+uh = H.solve(h, method="banded", pivot=True)
+
+z = H @ uh
+assert jnp.linalg.norm(z.flatten() - h.flatten()) < ulp(100)
+
+xj = D.mesh()
+uj = C.backward(uh)
+uej = lambdify(x, ue)(xj)
+error = jnp.linalg.norm(uj[0] - uej)
+print("Error =", error)

--- a/src/jaxfun/galerkin/__init__.py
+++ b/src/jaxfun/galerkin/__init__.py
@@ -17,6 +17,7 @@ from .arguments import (
 from .cartesianproductspace import (
     CartesianProduct as CartesianProduct,
     CartesianProductSpace as CartesianProductSpace,
+    CartesianTensorProductSpace as CartesianTensorProductSpace,
     VectorTensorProductSpace as VectorTensorProductSpace,
 )
 from .composite import Composite as Composite, DirectSum as DirectSum

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -38,6 +38,7 @@ from jaxfun.typing import (
     FunctionSpaceType,
     MeshKind,
     Padding,
+    RankTag,
     ScalarSpaceType,
     TestSpaceType,
     TrialSpaceType,
@@ -75,7 +76,7 @@ def get_BasisFunction(
     vector_index: int,
     local_index: int,
     global_index: int,
-    rank: int,
+    rank: RankTag,
     offset: int,
     functionspace: BaseSpace,
     argument: ArgumentTag,
@@ -109,9 +110,9 @@ def get_BasisFunction(
         index = indices[cls.local_index + cls.offset]
         lhs = f"{cls.name}_{index}"
         rhs = f"({cls.args[0].name})"
-        if cls.rank == 0:
+        if cls.rank == RankTag.SCALAR:
             return lhs + rhs
-        elif cls.rank == 1:
+        elif cls.rank == RankTag.VECTOR:
             sup = "^{(" + str(cls.vector_index) + ")}"
             return lhs + sup + rhs
         raise NotImplementedError("Rank > 1 basis functions not supported.")
@@ -126,9 +127,9 @@ def get_BasisFunction(
         index = indices[cls.local_index + cls.offset]
         lhs = f"{latex_symbols[cls.name]}_{index}"
         rhs = f"({latex_symbols[cls.args[0].name]})"
-        if cls.rank == 0:
+        if cls.rank == RankTag.SCALAR:
             s = lhs + rhs
-        elif cls.rank == 1:
+        elif cls.rank == RankTag.VECTOR:
             sup = "^{(" + str(cls.vector_index) + ")}"
             s = lhs + sup + rhs
         else:
@@ -177,7 +178,7 @@ def _get_computational_function(
             vector_index=0,
             local_index=0,
             global_index=getattr(V, "global_index", 0),
-            rank=0,
+            rank=RankTag.SCALAR,
             offset=offset,
             functionspace=V,
             argument=ArgumentTag.TEST if arg == "test" else ArgumentTag.TRIAL,
@@ -191,7 +192,7 @@ def _get_computational_function(
                 vector_index=0,
                 local_index=getattr(a, "_id", [0])[0],
                 global_index=getattr(V, "global_index", 0),
-                rank=0,
+                rank=RankTag.SCALAR,
                 offset=offset,
                 functionspace=v,
                 argument=ArgumentTag.TEST if arg == "test" else ArgumentTag.TRIAL,
@@ -211,7 +212,7 @@ def _get_computational_function(
                 vector_index=i,
                 local_index=getattr(a, "_id", [0])[0],
                 global_index=getattr(Vi, "global_index", 0),
-                rank=1,
+                rank=RankTag.VECTOR,
                 offset=offset,
                 functionspace=v,
                 argument=ArgumentTag.TEST if arg == "test" else ArgumentTag.TRIAL,
@@ -271,14 +272,16 @@ class ExpansionFunction(BaseFunction):
 
     def __str__(self) -> str:
         V = self.functionspace
-        name = "\033[1m%s\033[0m" % (self.name,) if V.rank == 1 else self.name  # noqa: UP031
+        name = (
+            "\033[1m%s\033[0m" % (self.name,) if V.rank == RankTag.VECTOR else self.name  # noqa: UP031
+        )
         return f"{name}({self.c_names}; {V.name})"
 
     def _latex(self, printer: Any = None) -> str:
         name = self.name
         if name != self.own_name:
             assert not isinstance(self.functionspace, DirectSum)
-            if self.functionspace.rank == 1:
+            if self.functionspace.rank == RankTag.VECTOR:
                 name = r"\mathbf{ {%s} }" % (name,)  # noqa: UP031
         return f"{name}({self.c_names}; {self.functionspace.name})"
 
@@ -352,7 +355,9 @@ class TestFunction(ExpansionFunction):
         if isinstance(V, CartesianProductSpace | CartesianTensorProductSpace):
             if name is None:
                 name = "abcdefg"[len(V)]
-            elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
+            elif len(name) != len(V) and not (
+                len(name) == 1 and V.rank == RankTag.VECTOR
+            ):
                 raise ValueError(
                     f"Length of name str must equal the length of basespaces in "
                     f"CartesianProductSpace. Got {len(V)} basespaces and "
@@ -363,7 +368,7 @@ class TestFunction(ExpansionFunction):
         return obj
 
     def doit(self, **hints: Any) -> Expr | AppliedUndef:
-        if self.functionspace.rank < 0:
+        if self.functionspace.rank == RankTag.NONE:
             raise ValueError(
                 "TestFunction expansion not possible for Cartesian products that are "
                 "not ranked tensors"
@@ -399,7 +404,9 @@ class TrialFunction(ExpansionFunction):
         if isinstance(V, CartesianProductSpace | CartesianTensorProductSpace):
             if name is None:
                 name = "abcdefg"[len(V)]
-            elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
+            elif len(name) != len(V) and not (
+                len(name) == 1 and V.rank == RankTag.VECTOR
+            ):
                 raise ValueError(
                     f"Length of name str must equal the length of basespaces in "
                     f"CartesianProductSpace. Got {len(V)} basespaces and "
@@ -448,7 +455,7 @@ class TrialFunction(ExpansionFunction):
                                 vector_index=i,
                                 local_index=getattr(a, "_id", [0])[0],
                                 global_index=getattr(Vi, "global_index", 0),
-                                rank=1,
+                                rank=RankTag.VECTOR,
                                 offset=fspace.dims,
                                 functionspace=v,
                                 argument=ArgumentTag.TRIAL,
@@ -599,7 +606,7 @@ def get_JAXFunction(
     *,
     array: Array,
     global_index: int,
-    rank: int,
+    rank: RankTag,
     functionspace: FunctionSpaceType,
     argument: ArgumentTag,
     args: Tuple,
@@ -629,10 +636,10 @@ def get_JAXFunction(
     def __str__(cls) -> str:
         lhs = f"{cls.name}"
 
-        if cls.rank == 0:
+        if cls.rank == RankTag.SCALAR:
             rhs = f"{cls.args}" if len(cls.args) > 1 else f"({cls.args[0].name})"
             return lhs + rhs
-        elif cls.rank == 1:
+        elif cls.rank == RankTag.VECTOR:
             rhs = f"{cls.args}"
             sup = "^{(" + str(cls.global_index) + ")}"
             return lhs + sup + rhs
@@ -646,14 +653,14 @@ def get_JAXFunction(
 
     def _latex(cls, printer: Any = None, exp: float | None = None) -> str:
         lhs = f"{latex_symbols[cls.name]}"
-        if cls.rank == 0:
+        if cls.rank == RankTag.SCALAR:
             rhs = (
                 f"({latex_symbols[cls.args[0]]})"
                 if len(cls.args) == 1
                 else f"{latex_symbols[cls.args]}"
             )
             s = lhs + rhs
-        elif cls.rank == 1:
+        elif cls.rank == RankTag.VECTOR:
             rhs = f"{latex_symbols[cls.args]}"
             sup = "^{(" + str(cls.global_index) + ")}"
             s = lhs + sup + rhs
@@ -732,7 +739,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         obj: Self = Function.__new__(cls, *(list(coors._cartesian_xyz) + [sp.Dummy()]))
 
         if isinstance(array, sp.Expr | sp.Tuple):
-            if V.rank == 1:
+            if V.rank == RankTag.VECTOR:
                 assert isinstance(array, sp.Expr)
                 array = project(array, cast(VectorTensorProductSpace, V))
             else:
@@ -771,11 +778,11 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
             local_indices = slice(offset, 2 * offset)
             global_index = 0
             hat = f"\\hat{{{self.name}}}"
-            if V.rank == 0:
+            if V.rank == RankTag.SCALAR:
                 name = "".join((hat, "_{", indices[local_indices], "}"))
                 return Jaxc(cast(Array, self.array), V, name=name) * trial
 
-            elif V.rank == 1:
+            elif V.rank == RankTag.VECTOR:
                 assert isinstance(V, VectorTensorProductSpace)
                 s = []
                 for k, v in cast(Vector, trial).components.items():
@@ -804,18 +811,18 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
                 )
 
         # Nonlinear case, return a multivar function.
-        if V.rank == 0:
+        if V.rank == RankTag.SCALAR:
             return get_JAXFunction(
                 self.name,
                 array=cast(Array, self.array),
                 global_index=0,
-                rank=0,
+                rank=RankTag.SCALAR,
                 functionspace=V,
                 argument=ArgumentTag.JAXFUNC,
                 args=V.system.base_scalars(),
             )
 
-        elif V.rank == 1:
+        elif V.rank == RankTag.VECTOR:
             assert isinstance(V, VectorTensorProductSpace)
 
             return VectorAdd.fromiter(
@@ -823,7 +830,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
                     "".join((self.name, "^{(", str(i), ")}")),
                     array=self.array[i],
                     global_index=i,
-                    rank=0,
+                    rank=RankTag.SCALAR,
                     functionspace=V[i],
                     argument=ArgumentTag.JAXFUNC,
                     args=V.system.base_scalars(),
@@ -882,7 +889,7 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
         else:
             z = V.evaluate(x, cast(tuple[Array, ...], self.array))
 
-        if V.rank == 0:
+        if V.rank == RankTag.SCALAR:
             return jnp.expand_dims(z, -1)
         return z
 

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -30,6 +30,7 @@ from jaxfun.basespace import BaseSpace
 from jaxfun.coordinates import BaseScalar, CoordSys, Vector, latex_symbols
 from jaxfun.galerkin.cartesianproductspace import (
     CartesianProductSpace,
+    CartesianTensorProductSpace,
     VectorTensorProductSpace,
 )
 from jaxfun.typing import (
@@ -50,7 +51,9 @@ t, x, y, z = sp.symbols("t,x,y,z", real=True)
 
 indices = "ijklmn"
 
-_CompositeSpaceT = TypeVar("_CompositeSpaceT", bound=CartesianProductSpace)
+_CompositeSpaceT = TypeVar(
+    "_CompositeSpaceT", bound=CartesianTensorProductSpace | CartesianProductSpace
+)
 _ScalarSpaceT = TypeVar("_ScalarSpaceT", bound=ScalarSpaceType)
 
 
@@ -280,7 +283,9 @@ class ExpansionFunction(BaseFunction):
         return f"{name}({self.c_names}; {self.functionspace.name})"
 
     def __getitem__(self, i: int) -> Self:
-        assert isinstance(self.functionspace, CartesianProductSpace)
+        assert isinstance(
+            self.functionspace, CartesianTensorProductSpace | CartesianProductSpace
+        )
         name = self.name
         if (
             isinstance(self.functionspace, VectorTensorProductSpace)
@@ -297,12 +302,18 @@ class ExpansionFunction(BaseFunction):
             )
         result = self.__class__(self.functionspace[i], name=name)
         parent = self.functionspace
-        if isinstance(result.functionspace, CartesianProductSpace):
-            result.functionspace.leaf = parent
+        if isinstance(result.functionspace, CartesianTensorProductSpace):
+            result.functionspace.leaf = cast(CartesianTensorProductSpace, parent)
             for space in result.functionspace.flatten():
-                space.leaf = parent
+                space.leaf = cast(CartesianTensorProductSpace, parent)
+        elif isinstance(result.functionspace, CartesianProductSpace):
+            result.functionspace.leaf = cast(CartesianProductSpace, parent)
+            for space in result.functionspace.flatten():
+                space.leaf = cast(CartesianProductSpace, parent)
         elif isinstance(result.functionspace, TensorProductSpace):
-            result.functionspace.leaf = parent
+            result.functionspace.leaf = cast(CartesianTensorProductSpace, parent)
+        elif isinstance(result.functionspace, OrthogonalSpace | DirectSum):
+            result.functionspace.leaf = cast(CartesianProductSpace, parent)
         return result
 
 
@@ -330,14 +341,20 @@ class TestFunction(ExpansionFunction):
         obj: Self = Function.__new__(cls, *(list(coors._cartesian_xyz) + [sp.Dummy()]))
         obj.argument = ArgumentTag.TEST
 
-        if isinstance(V, DirectSum | DirectSumTPS | CartesianProductSpace):
+        _composite = (
+            DirectSum
+            | DirectSumTPS
+            | CartesianProductSpace
+            | CartesianTensorProductSpace
+        )
+        if isinstance(V, _composite):
             obj.functionspace = V.get_homogeneous()
         elif isinstance(V, OrthogonalSpace | TensorProductSpace):
             obj.functionspace = V
         else:
             raise ValueError("Unknown test space")
 
-        if isinstance(V, CartesianProductSpace):
+        if isinstance(V, CartesianProductSpace | CartesianTensorProductSpace):
             if name is None:
                 name = "abcdefg"[len(V)]
             elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
@@ -383,7 +400,7 @@ class TrialFunction(ExpansionFunction):
             cls, *(list(coors._cartesian_xyz) + time_arg + [sp.Dummy()])
         )
         obj.functionspace = V
-        if isinstance(V, CartesianProductSpace):
+        if isinstance(V, CartesianProductSpace | CartesianTensorProductSpace):
             if name is None:
                 name = "abcdefg"[len(V)]
             elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
@@ -721,7 +738,9 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
             array = project(array, cast(ScalarSpaceType, V))
 
         elif isinstance(array, sp.Tuple):
-            array = project(array, cast(CartesianProductSpace, V))
+            array = project(
+                array, cast(CartesianTensorProductSpace | CartesianProductSpace, V)
+            )
 
         obj.array = array
         obj.functionspace = V

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -287,18 +287,13 @@ class ExpansionFunction(BaseFunction):
             self.functionspace, CartesianTensorProductSpace | CartesianProductSpace
         )
         name = self.name
-        if (
-            isinstance(self.functionspace, VectorTensorProductSpace)
-            and len(self.name) == 1
-        ):
-            # use indices
-            name = self.name + "_" + str(i)
+        if isinstance(self.functionspace, VectorTensorProductSpace) and len(name) == 1:
+            name = f"{name}_{i}"
         elif len(name) == len(self.functionspace):
             name = name[i]
         else:
             raise ValueError(
-                f"Lenght of self.name {self.name} != "
-                f"len(self.functionspace) = {len(self.functionspace)}"
+                f"Length of self.name ({name}) != {len(self.functionspace) = }"
             )
         result = self.__class__(self.functionspace[i], name=name)
         parent = self.functionspace
@@ -359,9 +354,9 @@ class TestFunction(ExpansionFunction):
                 name = "abcdefg"[len(V)]
             elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
                 raise ValueError(
-                    f"Lenght of name str must equal the length of basespaces in "
+                    f"Length of name str must equal the length of basespaces in "
                     f"CartesianProductSpace. Got {len(V)} basespaces and "
-                    f"len({name}) == {len(name)}"
+                    f"{len({name}) = }"
                 )
         obj.name = name if name is not None else "TestFunction"
         obj.own_name = "TestFunction"
@@ -370,7 +365,8 @@ class TestFunction(ExpansionFunction):
     def doit(self, **hints: Any) -> Expr | AppliedUndef:
         if self.functionspace.rank < 0:
             raise ValueError(
-                "TestFunction expansion not possible for CartesianProductSpace"
+                "TestFunction expansion not possible for Cartesian products that are "
+                "not ranked tensors"
             )
         return _get_computational_function(
             "test", cast(ComputationalSpaceType, self.functionspace)
@@ -405,9 +401,9 @@ class TrialFunction(ExpansionFunction):
                 name = "abcdefg"[len(V)]
             elif len(name) != len(V) and not (len(name) == 1 and V.rank == 1):
                 raise ValueError(
-                    f"Lenght of name str must equal the length of basespaces in "
+                    f"Length of name str must equal the length of basespaces in "
                     f"CartesianProductSpace. Got {len(V)} basespaces and "
-                    f"len({name}) == {len(name)}"
+                    f"{len({name}) = }"
                 )
         obj.name = name if name is not None else "TrialFunction"
         obj.own_name = "TrialFunction"
@@ -734,13 +730,19 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
 
         coors: CoordSys = V.system
         obj: Self = Function.__new__(cls, *(list(coors._cartesian_xyz) + [sp.Dummy()]))
-        if isinstance(array, sp.Expr):
-            array = project(array, cast(ScalarSpaceType, V))
 
-        elif isinstance(array, sp.Tuple):
-            array = project(
-                array, cast(CartesianTensorProductSpace | CartesianProductSpace, V)
-            )
+        if isinstance(array, sp.Expr | sp.Tuple):
+            if V.rank == 1:
+                assert isinstance(array, sp.Expr)
+                array = project(array, cast(VectorTensorProductSpace, V))
+            else:
+                if isinstance(array, sp.Expr):
+                    array = project(array, cast(ScalarSpaceType, V))
+                else:
+                    array = project(
+                        array,
+                        cast(CartesianTensorProductSpace | CartesianProductSpace, V),
+                    )
 
         obj.array = array
         obj.functionspace = V
@@ -797,7 +799,8 @@ class JAXFunction[SpaceT: FunctionSpaceType](ExpansionFunction):
 
             else:
                 raise ValueError(
-                    "Unranked Composite space not supported for linear expansion."
+                    "JAXFunction expansion not possible for Cartesian products that "
+                    "are not ranked tensors"
                 )
 
         # Nonlinear case, return a multivar function.

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -130,7 +130,7 @@ class CartesianTensorProductSpace:
             if isinstance(space, CartesianTensorProductSpace):
                 spaces.extend(space.flatten())
             else:
-                spaces.append(cast(TensorProductSpace, space))
+                spaces.append(space)
         return spaces
 
     @property
@@ -151,7 +151,7 @@ class CartesianTensorProductSpace:
     @property
     def dim(self) -> int:
         """Return total number of modes."""
-        return sum(space.dim for space in self.basespaces)
+        return sum(self.block_sizes)
 
     @property
     def block_sizes(self) -> tuple[int, ...]:
@@ -168,9 +168,10 @@ class CartesianTensorProductSpace:
         """Return True if underlying bases are all orthogonal."""
         return all(space.is_orthogonal for space in self.basespaces)
 
+    @property
     def shape(self) -> Any:
         """Return modal shape for each subspace."""
-        return tuple(space.shape() for space in self.basespaces)
+        return tuple(space.shape for space in self.basespaces)
 
     def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
         """Evaluate each component at scattered points and stack into one Array."""
@@ -336,7 +337,7 @@ class CartesianProductSpace:
     @property
     def dim(self) -> int:
         """Return total number of modes."""
-        return sum(space.dim for space in self.basespaces)
+        return sum(self.block_sizes)
 
     @property
     def block_sizes(self) -> tuple[int, ...]:
@@ -361,14 +362,12 @@ class CartesianProductSpace:
         """Return True if underlying bases are all orthogonal."""
         return all(space.is_orthogonal for space in self.basespaces)
 
+    @property
     def shape(self) -> Any:
         """Return modal shape for each subspace."""
         result = []
         for space in self.basespaces:
-            if isinstance(space, DirectSum):
-                result.append((space.dim,))
-            else:
-                result.append(space.shape())
+            result.append(space.shape)
         return tuple(result)
 
     def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Iterator
-from typing import Any, cast, overload
+from abc import ABC, abstractmethod
+from collections.abc import Iterator, Sequence
+from typing import Any, Self, cast, overload
 
 import jax
 import jax.numpy as jnp
@@ -64,7 +65,176 @@ def CartesianProduct(
     )
 
 
-class CartesianTensorProductSpace:
+class CartesianBaseSpace(ABC):
+    """Abstract space for all Cartesian classes."""
+
+    is_transient = False
+    basespaces: Sequence[OneDimensionalSpace | MultiDimensionalSpace]
+    _rank: int
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[Any]:
+        """return iterator over basespaces"""
+
+    @abstractmethod
+    def __getitem__(self, i: int) -> Any:
+        """Return component space i."""
+
+    @abstractmethod
+    def flatten(self) -> list[Any]:
+        """Return flattened list of all component TensorProductSpace objects."""
+
+    @abstractmethod
+    def get_homogeneous(self) -> Self:
+        """Return self as homogeneous space"""
+
+    @abstractmethod
+    def get_orthogonal(self) -> Self:
+        """Return orthogonal version of self"""
+
+    def __len__(self) -> int:
+        """Return number of subspaces."""
+        return len(self.basespaces)
+
+    @property
+    def num_components(self) -> int:
+        """Return total number of scalar components."""
+        return len(self.flatten())
+
+    @property
+    def rank(self) -> int:
+        """Return tensor rank (1 for vector fields, -1 for composite)."""
+        return self._rank
+
+    @property
+    def dims(self) -> int:
+        """Return spatial dimension."""
+        return self.basespaces[0].dims
+
+    @property
+    def dim(self) -> int:
+        """Return total number of modes."""
+        return sum(self.block_sizes)
+
+    @property
+    def block_sizes(self) -> tuple[int, ...]:
+        """Return tuple of component space dimensions."""
+        return tuple(space.dim for space in self.flatten())
+
+    @property
+    def num_dofs(self) -> tuple[tuple[int, ...], ...]:
+        """Return tuple of active degrees of freedom per axis."""
+        result = []
+        for space in self.flatten():
+            nd = space.num_dofs
+            result.append((nd,) if isinstance(nd, int) else nd)
+        return tuple(result)
+
+    @property
+    def is_orthogonal(self) -> bool:
+        """Return True if underlying bases are all orthogonal."""
+        return all(space.is_orthogonal for space in self.basespaces)
+
+    @property
+    def shape(self) -> Any:
+        """Return modal shape for each subspace."""
+        return tuple(space.shape for space in self.basespaces)
+
+    def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
+        """Evaluate each component at scattered points and stack into one Array."""
+        return jnp.array(
+            [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
+        )
+
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Evaluate each component on a mesh and stack into one Array.
+
+        Args:
+            u: input coefficients.
+            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
+                MeshKind.UNIFORM).
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        results = []
+        for i, space in enumerate(self.flatten()):
+            results.append(space.evaluate_mesh(u[i], kind=kind, N=N))
+        return jnp.stack(results)
+
+    def forward(self, u: Array) -> tuple[Array, ...]:
+        """Forward transform each physical component into spectral space."""
+        return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
+
+    def scalar_product(self, u: Array) -> tuple[Array, ...]:
+        """Return scalar products along each axis for all components."""
+        return tuple(
+            space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
+        )
+
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Backward transform per-component spectral coefficients to physical
+        space.
+
+        Args:
+            u: input coefficients
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        coeffs = [space.backward(u[i], N=N) for i, space in enumerate(self.flatten())]
+        return jnp.stack(coeffs)
+
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: tuple[tuple[int, ...], ...],
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Backward primitive transform for all components.
+
+        Args:
+            u: input coefficients
+            k: tuple of the number of derivatives for each direction. One
+                tuple item for each basespace.
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+        """
+        coeffs = [
+            space.backward_primitive(u[i], k=k[i], N=N)
+            for i, space in enumerate(self.flatten())
+        ]
+        return jnp.stack(coeffs)
+
+    def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients to orthogonal basis."""
+        return tuple(
+            space.to_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
+
+    def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients from orthogonal basis."""
+        return tuple(
+            space.from_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
+
+
+class CartesianTensorProductSpace(CartesianBaseSpace):
     """Composite tensor product space for ND (dims > 1) problems.
 
     Holds a tuple of TensorProductSpace (or DirectSumTPS) components, such as
@@ -76,9 +246,11 @@ class CartesianTensorProductSpace:
         system: Shared coordinate system.
         name: Label.
         tensorname: Joined printable representation.
+        leaf: CartesianTensorProductSpace this space is part of or self.
     """
 
     is_transient = False
+    basespaces: Sequence[MultiDimensionalSpace]
 
     def __init__(
         self,
@@ -111,10 +283,6 @@ class CartesianTensorProductSpace:
         self.mesh = self.basespaces[0].mesh
         self.num_quad_points = self.basespaces[0].num_quad_points
 
-    def __len__(self) -> int:
-        """Return number of subspaces."""
-        return len(self.basespaces)
-
     def __iter__(self) -> Iterator[MultiDimensionalSpace]:
         """Iterate over component spaces."""
         return iter(self.basespaces)
@@ -132,112 +300,6 @@ class CartesianTensorProductSpace:
             else:
                 spaces.append(space)
         return spaces
-
-    @property
-    def num_components(self) -> int:
-        """Return total number of scalar components."""
-        return len(self.flatten())
-
-    @property
-    def rank(self) -> int:
-        """Return tensor rank (1 for vector fields, -1 for composite)."""
-        return self._rank
-
-    @property
-    def dims(self) -> int:
-        """Return spatial dimension."""
-        return self.basespaces[0].dims
-
-    @property
-    def dim(self) -> int:
-        """Return total number of modes."""
-        return sum(self.block_sizes)
-
-    @property
-    def block_sizes(self) -> tuple[int, ...]:
-        """Return tuple of component space dimensions."""
-        return tuple(space.dim for space in self.flatten())
-
-    @property
-    def num_dofs(self) -> tuple[tuple[int, ...], ...]:
-        """Return tuple of active degrees of freedom per axis."""
-        return tuple(space.num_dofs for space in self.flatten())
-
-    @property
-    def is_orthogonal(self) -> bool:
-        """Return True if underlying bases are all orthogonal."""
-        return all(space.is_orthogonal for space in self.basespaces)
-
-    @property
-    def shape(self) -> Any:
-        """Return modal shape for each subspace."""
-        return tuple(space.shape for space in self.basespaces)
-
-    def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
-        """Evaluate each component at scattered points and stack into one Array."""
-        return jnp.array(
-            [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
-        )
-
-    def evaluate_mesh(
-        self,
-        u: tuple[Array, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Evaluate each component on a mesh and stack into one Array."""
-        results = []
-        for i, space in enumerate(self.flatten()):
-            ni = N[i] if N is not None else None
-            results.append(space.evaluate_mesh(u[i], kind=kind, N=ni))
-        return jnp.stack(results)
-
-    def forward(self, u: Array) -> tuple[Array, ...]:
-        """Forward transform each physical component into spectral space."""
-        return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
-
-    def scalar_product(self, u: Array) -> tuple[Array, ...]:
-        """Return scalar products along each axis for all components."""
-        return tuple(
-            space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
-        )
-
-    def backward(
-        self,
-        u: tuple[Array, ...],
-        N: tuple[tuple[int | None, ...] | None, ...] | None = None,
-    ) -> Array:
-        """Backward transform per-component spectral coefficients to physical space."""
-        coeffs = [
-            space.backward(u[i], N=N[i] if N is not None else None)
-            for i, space in enumerate(self.flatten())
-        ]
-        return jnp.stack(coeffs)
-
-    def backward_primitive(
-        self,
-        u: tuple[Array, ...],
-        k: tuple[int, ...],
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Backward primitive transform for all components."""
-        coeffs = [
-            space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
-            for i, space in enumerate(self.flatten())
-        ]
-        return jnp.stack(coeffs)
-
-    def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients to orthogonal basis."""
-        return tuple(
-            space.to_orthogonal(c[i]) for i, space in enumerate(self.flatten())
-        )
-
-    def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients from orthogonal basis."""
-        return tuple(
-            space.from_orthogonal(c[i]) for i, space in enumerate(self.flatten())
-        )
 
     def get_homogeneous(self) -> CartesianTensorProductSpace:
         from .tensorproductspace import DirectSumTPS
@@ -258,7 +320,7 @@ class CartesianTensorProductSpace:
         )
 
 
-class CartesianProductSpace:
+class CartesianProductSpace(CartesianBaseSpace):
     """Composite 1D function space (Cartesian product of OrthogonalSpace objects).
 
     Represents a tuple of 1D spaces for mixed-variable formulations on 1D
@@ -269,9 +331,12 @@ class CartesianProductSpace:
         system: Shared coordinate system.
         name: Label.
         tensorname: Joined printable representation.
+        leaf: CartesianProductSpace this space is part of or self.
     """
 
     is_transient = False
+    basespaces: Sequence[OneDimensionalSpace]
+    _rank: int
 
     def __init__(
         self,
@@ -297,9 +362,8 @@ class CartesianProductSpace:
                     subspace.global_index = i
                     subspace.leaf = self
 
-    def __len__(self) -> int:
-        """Return number of subspaces."""
-        return len(self.basespaces)
+        self.mesh = self.basespaces[0].mesh
+        self.num_quad_points = self.basespaces[0].num_quad_points
 
     def __iter__(self) -> Iterator[OneDimensionalSpace]:
         """Iterate over component spaces."""
@@ -320,126 +384,9 @@ class CartesianProductSpace:
         return spaces
 
     @property
-    def num_components(self) -> int:
-        """Return total number of scalar components."""
-        return len(self.flatten())
-
-    @property
-    def rank(self) -> int:
-        """Return tensor rank (-1 for composite mixed spaces)."""
-        return self._rank
-
-    @property
     def dims(self) -> int:
         """Return spatial dimension (always 1)."""
         return 1
-
-    @property
-    def dim(self) -> int:
-        """Return total number of modes."""
-        return sum(self.block_sizes)
-
-    @property
-    def block_sizes(self) -> tuple[int, ...]:
-        """Return tuple of component space dimensions."""
-        return tuple(space.dim for space in self.flatten())
-
-    @property
-    def num_dofs(self) -> tuple[tuple[int, ...], ...]:
-        """Return tuple of active degrees of freedom per axis.
-
-        OrthogonalSpace.num_dofs returns an int; wrap in a 1-tuple so
-        BlockArray always receives a uniform tuple[tuple[int, ...], ...].
-        """
-        result = []
-        for space in self.flatten():
-            nd = space.num_dofs
-            result.append((nd,) if isinstance(nd, int) else nd)
-        return tuple(result)
-
-    @property
-    def is_orthogonal(self) -> bool:
-        """Return True if underlying bases are all orthogonal."""
-        return all(space.is_orthogonal for space in self.basespaces)
-
-    @property
-    def shape(self) -> Any:
-        """Return modal shape for each subspace."""
-        result = []
-        for space in self.basespaces:
-            result.append(space.shape)
-        return tuple(result)
-
-    def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
-        """Evaluate each component at scattered points and stack into one Array."""
-        return jnp.array(
-            [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
-        )
-
-    def evaluate_mesh(
-        self,
-        u: tuple[Array, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Evaluate each component on a mesh and stack into one Array."""
-        results = []
-        for i, space in enumerate(self.flatten()):
-            ni = N[i] if N is not None else None
-            if isinstance(space, DirectSum):
-                results.append(
-                    space[0].evaluate_mesh(space.to_orthogonal(u[i]), kind=kind, N=ni)
-                )
-            else:
-                results.append(space.evaluate_mesh(u[i], kind=kind, N=ni))
-        return jnp.stack(results)
-
-    def forward(self, u: Array) -> tuple[Array, ...]:
-        """Forward transform each physical component into spectral space."""
-        return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
-
-    def scalar_product(self, u: Array) -> tuple[Array, ...]:
-        """Return scalar products for all components."""
-        return tuple(
-            space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
-        )
-
-    def backward(
-        self,
-        u: tuple[Array, ...],
-        N: tuple[tuple[int | None, ...] | None, ...] | None = None,
-    ) -> Array:
-        """Backward transform per-component spectral coefficients to physical space."""
-        coeffs = [
-            space.backward(u[i], N=N[i] if N is not None else None)
-            for i, space in enumerate(self.flatten())
-        ]
-        return jnp.stack(coeffs)
-
-    def backward_primitive(
-        self,
-        u: tuple[Array, ...],
-        k: tuple[int, ...],
-        N: tuple[tuple[int | None, ...], ...] | None = None,
-    ) -> Array:
-        """Backward primitive transform for all components."""
-        coeffs = [
-            space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
-            for i, space in enumerate(self.flatten())
-        ]
-        return jnp.stack(coeffs)
-
-    def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients to orthogonal basis."""
-        return tuple(
-            space.to_orthogonal(c[i]) for i, space in enumerate(self.flatten())
-        )
-
-    def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients from orthogonal basis."""
-        return tuple(
-            space.from_orthogonal(c[i]) for i, space in enumerate(self.flatten())
-        )
 
     def get_homogeneous(self) -> CartesianProductSpace:
         f = []
@@ -468,12 +415,3 @@ class VectorTensorProductSpace(CartesianTensorProductSpace):
     def __getitem__(self, i: int) -> TensorProductSpace:
         """Return component space i."""
         return cast(list[TensorProductSpace], self.basespaces)[i]
-
-    def mesh(
-        self,
-        kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[int | None, ...] | None = None,
-        broadcast: bool = True,
-    ) -> tuple[Array, ...]:
-        """Delegate to first component TensorProductSpace mesh."""
-        return self[0].mesh(kind=kind, N=N, broadcast=broadcast)

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -14,7 +14,7 @@ from jaxfun.galerkin.composite import DirectSum
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
 from jaxfun.galerkin.tensorproductspace import TensorProductSpace, multiplication_sign
 from jaxfun.sharding import physical_sharding, spectral_sharding
-from jaxfun.typing import MeshKind
+from jaxfun.typing import MeshKind, RankTag
 
 type MultiDimensionalSpace = TensorProductSpace | CartesianTensorProductSpace
 type OneDimensionalSpace = OrthogonalSpace | DirectSum | CartesianProductSpace
@@ -22,20 +22,26 @@ type OneDimensionalSpace = OrthogonalSpace | DirectSum | CartesianProductSpace
 
 @overload
 def CartesianProduct(
-    *basespaces: MultiDimensionalSpace, name: str = "CP", rank: int = -1
+    *basespaces: MultiDimensionalSpace,
+    name: str = "CP",
+    rank: int | RankTag = RankTag.NONE,
 ) -> CartesianTensorProductSpace: ...
 @overload
 def CartesianProduct(
-    *basespaces: OneDimensionalSpace, name: str = "CP", rank: int = -1
+    *basespaces: OneDimensionalSpace,
+    name: str = "CP",
+    rank: int | RankTag = RankTag.NONE,
 ) -> CartesianProductSpace: ...
 @overload
 def CartesianProduct(
-    *basespaces: MultiDimensionalSpace, name: str = "CP", rank: int = 1
+    *basespaces: MultiDimensionalSpace,
+    name: str = "CP",
+    rank: int | RankTag = RankTag.VECTOR,
 ) -> VectorTensorProductSpace: ...
 def CartesianProduct(
     *basespaces: MultiDimensionalSpace | OneDimensionalSpace,
     name: str = "CP",
-    rank: int = -1,
+    rank: int | RankTag = RankTag.NONE,
 ) -> CartesianTensorProductSpace | CartesianProductSpace:
     """Factory returning the appropriate Cartesian product space.
 
@@ -51,20 +57,23 @@ def CartesianProduct(
         CartesianTensorProductSpace, CartesianProductSpace, or
         VectorTensorProductSpace instance.
     """
+    rank_tag = RankTag(rank) if isinstance(rank, int) else rank
     basespaces_list = [copy.deepcopy(space) for space in basespaces]
     if all(basespace.dims == 1 for basespace in basespaces_list):
         return CartesianProductSpace(
-            *cast(list[OneDimensionalSpace], basespaces_list), name=name, rank=rank
+            *cast(list[OneDimensionalSpace], basespaces_list), name=name, rank=rank_tag
         )
     assert all(basespace.dims > 1 for basespace in basespaces_list)
     assert len({b.dims for b in basespaces_list}) == 1
 
-    if rank == 1:
+    if rank_tag == RankTag.VECTOR:
         return VectorTensorProductSpace(
-            *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=1
+            *cast(list[MultiDimensionalSpace], basespaces_list),
+            name=name,
+            rank=RankTag.VECTOR,
         )
     return CartesianTensorProductSpace(
-        *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=rank
+        *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=rank_tag
     )
 
 
@@ -73,7 +82,7 @@ class CartesianBaseSpace(ABC):
 
     is_transient = False
     basespaces: Sequence[OneDimensionalSpace | MultiDimensionalSpace]
-    _rank: int
+    _rank: RankTag
 
     @abstractmethod
     def __iter__(self) -> Iterator[Any]:
@@ -128,7 +137,7 @@ class CartesianBaseSpace(ABC):
         return len(self.flatten())
 
     @property
-    def rank(self) -> int:
+    def rank(self) -> RankTag:
         """Return tensor rank (1 for vector fields, -1 for composite)."""
         return self._rank
 
@@ -217,7 +226,7 @@ class CartesianTensorProductSpace(CartesianBaseSpace):
         self,
         *basespaces: MultiDimensionalSpace,
         name: str = "CTPS",
-        rank: int = -1,
+        rank: int | RankTag = RankTag.NONE,
     ) -> None:
         from jaxfun.galerkin import DirectSumTPS
 
@@ -227,7 +236,7 @@ class CartesianTensorProductSpace(CartesianBaseSpace):
         self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])
         self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
-        self._rank = rank
+        self._rank = RankTag(rank) if isinstance(rank, int) else rank
         self.leaf: CartesianTensorProductSpace = self
 
         for space in self.basespaces:
@@ -362,19 +371,19 @@ class CartesianProductSpace(CartesianBaseSpace):
 
     is_transient = False
     basespaces: Sequence[OneDimensionalSpace]
-    _rank: int
+    _rank: RankTag
 
     def __init__(
         self,
         *basespaces: OneDimensionalSpace,
         name: str = "CPS",
-        rank: int = -1,
+        rank: int | RankTag = RankTag.NONE,
     ) -> None:
         self.basespaces = list(basespaces)
         self.system: CoordSys = self.basespaces[0].system
         self.name = name
         self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])
-        self._rank = rank
+        self._rank = RankTag(rank) if isinstance(rank, int) else rank
         self.leaf: CartesianProductSpace = self
 
         for space in self.basespaces:

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -163,7 +163,7 @@ class CartesianBaseSpace(ABC):
 
     @property
     def shape(self) -> Any:
-        """Return modal shape for each subspace."""
+        """Return physical-space shape for each subspace."""
         return tuple(space.shape for space in self.basespaces)
 
     def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -52,10 +52,13 @@ def CartesianProduct(
         VectorTensorProductSpace instance.
     """
     basespaces_list = [copy.deepcopy(space) for space in basespaces]
-    if basespaces_list[0].dims == 1:
+    if all(basespace.dims == 1 for basespace in basespaces_list):
         return CartesianProductSpace(
             *cast(list[OneDimensionalSpace], basespaces_list), name=name, rank=rank
         )
+    assert all(basespace.dims > 1 for basespace in basespaces_list)
+    assert len({b.dims for b in basespaces_list}) == 1
+
     if rank == 1:
         return VectorTensorProductSpace(
             *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=1
@@ -91,6 +94,29 @@ class CartesianBaseSpace(ABC):
     @abstractmethod
     def get_orthogonal(self) -> Self:
         """Return orthogonal version of self"""
+
+    @abstractmethod
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: Any = None,
+    ) -> Array: ...
+
+    @abstractmethod
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: Any = None,
+    ) -> Array: ...
+
+    @abstractmethod
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: Any,
+        N: Any = None,
+    ) -> Array: ...
 
     def __len__(self) -> int:
         """Return number of subspaces."""
@@ -146,29 +172,6 @@ class CartesianBaseSpace(ABC):
             [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
         )
 
-    def evaluate_mesh(
-        self,
-        u: tuple[Array, ...],
-        kind: MeshKind | str = MeshKind.QUADRATURE,
-        N: tuple[int | None, ...] | None = None,
-    ) -> Array:
-        """Evaluate each component on a mesh and stack into one Array.
-
-        Args:
-            u: input coefficients.
-            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
-                MeshKind.UNIFORM).
-            N: Number of physical points along each axis.
-
-        Note:
-            All basespaces must use the same number of points in physical space.
-
-        """
-        results = []
-        for i, space in enumerate(self.flatten()):
-            results.append(space.evaluate_mesh(u[i], kind=kind, N=N))
-        return jnp.stack(results)
-
     def forward(self, u: Array) -> tuple[Array, ...]:
         """Forward transform each physical component into spectral space."""
         return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
@@ -178,48 +181,6 @@ class CartesianBaseSpace(ABC):
         return tuple(
             space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
         )
-
-    def backward(
-        self,
-        u: tuple[Array, ...],
-        N: tuple[int | None, ...] | None = None,
-    ) -> Array:
-        """Backward transform per-component spectral coefficients to physical
-        space.
-
-        Args:
-            u: input coefficients
-            N: Number of physical points along each axis.
-
-        Note:
-            All basespaces must use the same number of points in physical space.
-
-        """
-        coeffs = [space.backward(u[i], N=N) for i, space in enumerate(self.flatten())]
-        return jnp.stack(coeffs)
-
-    def backward_primitive(
-        self,
-        u: tuple[Array, ...],
-        k: tuple[tuple[int, ...], ...],
-        N: tuple[int | None, ...] | None = None,
-    ) -> Array:
-        """Backward primitive transform for all components.
-
-        Args:
-            u: input coefficients
-            k: tuple of the number of derivatives for each direction. One
-                tuple item for each basespace.
-            N: Number of physical points along each axis.
-
-        Note:
-            All basespaces must use the same number of points in physical space.
-        """
-        coeffs = [
-            space.backward_primitive(u[i], k=k[i], N=N)
-            for i, space in enumerate(self.flatten())
-        ]
-        return jnp.stack(coeffs)
 
     def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
         """Convert coefficients to orthogonal basis."""
@@ -319,6 +280,71 @@ class CartesianTensorProductSpace(CartesianBaseSpace):
             *orthogonal_spaces, name=self.name + "O", rank=self.rank
         )
 
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Evaluate each component on a mesh and stack into one Array.
+
+        Args:
+            u: input coefficients.
+            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
+                MeshKind.UNIFORM).
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        results = []
+        for i, space in enumerate(self.flatten()):
+            results.append(space.evaluate_mesh(u[i], kind=kind, N=N))
+        return jnp.stack(results)
+
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Backward transform per-component spectral coefficients to physical
+        space.
+
+        Args:
+            u: input coefficients
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        coeffs = [space.backward(u[i], N=N) for i, space in enumerate(self.flatten())]
+        return jnp.stack(coeffs)
+
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: tuple[tuple[int, ...], ...],
+        N: tuple[int | None, ...] | None = None,
+    ) -> Array:
+        """Backward primitive transform for all components.
+
+        Args:
+            u: input coefficients
+            k: tuple of the number of derivatives for each direction. One
+                tuple item for each basespace.
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+        """
+        coeffs = [
+            space.backward_primitive(u[i], k=k[i], N=N)
+            for i, space in enumerate(self.flatten())
+        ]
+        return jnp.stack(coeffs)
+
 
 class CartesianProductSpace(CartesianBaseSpace):
     """Composite 1D function space (Cartesian product of OrthogonalSpace objects).
@@ -403,6 +429,70 @@ class CartesianProductSpace(CartesianBaseSpace):
         return CartesianProduct(
             *orthogonal_spaces, name=self.name + "O", rank=self.rank
         )
+
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: int | None = None,
+    ) -> Array:
+        """Evaluate each component on a mesh and stack into one Array.
+
+        Args:
+            u: input coefficients.
+            kind: Mesh type for backward evaluation (MeshKind.QUADRATURE or
+                MeshKind.UNIFORM).
+            N: Number of physical points along each axis.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        results = []
+        for i, space in enumerate(self.flatten()):
+            results.append(space.evaluate_mesh(u[i], kind=kind, N=N))
+        return jnp.stack(results)
+
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: int | None = None,
+    ) -> Array:
+        """Backward transform per-component spectral coefficients to physical
+        space.
+
+        Args:
+            u: input coefficients
+            N: Number of physical points.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+
+        """
+        coeffs = [space.backward(u[i], N=N) for i, space in enumerate(self.flatten())]
+        return jnp.stack(coeffs)
+
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: tuple[int, ...],
+        N: int | None = None,
+    ) -> Array:
+        """Backward primitive transform for all components.
+
+        Args:
+            u: input coefficients
+            k: tuple of the number of derivatives for each space.
+            N: Number of physical points.
+
+        Note:
+            All basespaces must use the same number of points in physical space.
+        """
+        coeffs = [
+            space.backward_primitive(u[i], k=k[i], N=N)
+            for i, space in enumerate(self.flatten())
+        ]
+        return jnp.stack(coeffs)
 
 
 class VectorTensorProductSpace(CartesianTensorProductSpace):

--- a/src/jaxfun/galerkin/cartesianproductspace.py
+++ b/src/jaxfun/galerkin/cartesianproductspace.py
@@ -2,49 +2,77 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Iterator
-from typing import Any, cast
+from typing import Any, cast, overload
 
 import jax
 import jax.numpy as jnp
 from jax import Array
 
 from jaxfun.coordinates import CoordSys
+from jaxfun.galerkin.composite import DirectSum
+from jaxfun.galerkin.orthogonal import OrthogonalSpace
 from jaxfun.galerkin.tensorproductspace import TensorProductSpace, multiplication_sign
 from jaxfun.sharding import physical_sharding, spectral_sharding
 from jaxfun.typing import MeshKind
 
+type MultiDimensionalSpace = TensorProductSpace | CartesianTensorProductSpace
+type OneDimensionalSpace = OrthogonalSpace | DirectSum | CartesianProductSpace
 
+
+@overload
 def CartesianProduct(
-    *basespaces: TensorProductSpace | CartesianProductSpace,
+    *basespaces: MultiDimensionalSpace, name: str = "CP", rank: int = -1
+) -> CartesianTensorProductSpace: ...
+@overload
+def CartesianProduct(
+    *basespaces: OneDimensionalSpace, name: str = "CP", rank: int = -1
+) -> CartesianProductSpace: ...
+@overload
+def CartesianProduct(
+    *basespaces: MultiDimensionalSpace, name: str = "CP", rank: int = 1
+) -> VectorTensorProductSpace: ...
+def CartesianProduct(
+    *basespaces: MultiDimensionalSpace | OneDimensionalSpace,
     name: str = "CP",
     rank: int = -1,
-) -> CartesianProductSpace:
-    """Factory returning CartesianProductSpace.
+) -> CartesianTensorProductSpace | CartesianProductSpace:
+    """Factory returning the appropriate Cartesian product space.
+
+    Returns CartesianProductSpace for 1D components, VectorTensorProductSpace
+    when rank==1, and CartesianTensorProductSpace otherwise.
 
     Args:
-        *basespaces: TensorProductSpace or CartesianProductSpace objects.
+        *basespaces: Component spaces (all must have the same dims).
         name: Label for the Cartesian product space.
-        rank: Rank of the Cartesian product space.
+        rank: Rank of the Cartesian (tensor) product space.
 
     Returns:
-        Instance of CartesianProductSpace
+        CartesianTensorProductSpace, CartesianProductSpace, or
+        VectorTensorProductSpace instance.
     """
-    basespaces_list: list[TensorProductSpace | CartesianProductSpace] = [
-        copy.deepcopy(space) for space in basespaces
-    ]
+    basespaces_list = [copy.deepcopy(space) for space in basespaces]
+    if basespaces_list[0].dims == 1:
+        return CartesianProductSpace(
+            *cast(list[OneDimensionalSpace], basespaces_list), name=name, rank=rank
+        )
     if rank == 1:
-        return VectorTensorProductSpace(*basespaces_list, name=name, rank=1)
-    return CartesianProductSpace(*basespaces_list, name=name, rank=rank)
+        return VectorTensorProductSpace(
+            *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=1
+        )
+    return CartesianTensorProductSpace(
+        *cast(list[MultiDimensionalSpace], basespaces_list), name=name, rank=rank
+    )
 
 
-class CartesianProductSpace:
-    """Composite tensor product space.
+class CartesianTensorProductSpace:
+    """Composite tensor product space for ND (dims > 1) problems.
 
-    Represents a tuple of identical (or differing in boundary conditions)
-    TensorProductSpace objects.
+    Holds a tuple of TensorProductSpace (or DirectSumTPS) components, such as
+    used for vector-valued or mixed-variable formulations on multi-dimensional
+    domains (e.g. Stokes equations in 2D/3D).
 
     Attributes:
-        tensorspaces: Tuple of component tensor spaces.
+        basespaces: List of component tensor product spaces.
         system: Shared coordinate system.
         name: Label.
         tensorname: Joined printable representation.
@@ -54,7 +82,7 @@ class CartesianProductSpace:
 
     def __init__(
         self,
-        *basespaces: TensorProductSpace | CartesianProductSpace,
+        *basespaces: MultiDimensionalSpace,
         name: str = "CTPS",
         rank: int = -1,
     ) -> None:
@@ -67,7 +95,7 @@ class CartesianProductSpace:
         self._spectral_sharding = spectral_sharding if len(jax.devices()) > 1 else None
         self._physical_sharding = physical_sharding if len(jax.devices()) > 1 else None
         self._rank = rank
-        self.leaf: CartesianProductSpace = self
+        self.leaf: CartesianTensorProductSpace = self
 
         for space in self.basespaces:
             space.leaf = self
@@ -87,22 +115,22 @@ class CartesianProductSpace:
         """Return number of subspaces."""
         return len(self.basespaces)
 
-    def __iter__(self) -> Iterator[CartesianProductSpace | TensorProductSpace]:
+    def __iter__(self) -> Iterator[MultiDimensionalSpace]:
         """Iterate over component spaces."""
         return iter(self.basespaces)
 
-    def __getitem__(self, i: int) -> CartesianProductSpace | TensorProductSpace:
+    def __getitem__(self, i: int) -> MultiDimensionalSpace:
         """Return component space i."""
         return self.basespaces[i]
 
     def flatten(self) -> list[TensorProductSpace]:
-        """Return flattened list of all component tensor spaces."""
+        """Return flattened list of all component TensorProductSpace objects."""
         spaces: list[TensorProductSpace] = []
         for space in self.basespaces:
-            if isinstance(space, CartesianProductSpace):
+            if isinstance(space, CartesianTensorProductSpace):
                 spaces.extend(space.flatten())
             else:
-                spaces.append(space)
+                spaces.append(cast(TensorProductSpace, space))
         return spaces
 
     @property
@@ -112,8 +140,7 @@ class CartesianProductSpace:
 
     @property
     def rank(self) -> int:
-        """Return tensor rank (1 for vector fields, 0 for scalars and -1
-        for composite)."""
+        """Return tensor rank (1 for vector fields, -1 for composite)."""
         return self._rank
 
     @property
@@ -124,7 +151,7 @@ class CartesianProductSpace:
     @property
     def dim(self) -> int:
         """Return total number of modes."""
-        return sum([space.dim for space in self.basespaces])
+        return sum(space.dim for space in self.basespaces)
 
     @property
     def block_sizes(self) -> tuple[int, ...]:
@@ -146,18 +173,7 @@ class CartesianProductSpace:
         return tuple(space.shape() for space in self.basespaces)
 
     def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
-        """Evaluate each component at scattered points and stack into one Array.
-
-        All components are evaluated at the same points so outputs have equal
-        leading shape and can be stacked.
-
-        Args:
-            x: Array of per-axis coordinates stacked (N, d).
-            c: Sequence of Coefficient arrays.
-
-        Returns:
-            Stacked array of shape (n_components, N).
-        """
+        """Evaluate each component at scattered points and stack into one Array."""
         return jnp.array(
             [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
         )
@@ -168,74 +184,33 @@ class CartesianProductSpace:
         kind: MeshKind | str = MeshKind.QUADRATURE,
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
-        """Evaluate each component on a mesh and stack into one Array.
-
-        Args:
-            u: Sequence of input arrays.
-            kind: Type of mesh to evaluate on.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Stacked array of shape (n_components, ...).
-        """
-        return jnp.stack(
-            [
-                space.evaluate_mesh(u[i], kind=kind, N=N[i] if N is not None else None)
-                for i, space in enumerate(self.flatten())
-            ]
-        )
+        """Evaluate each component on a mesh and stack into one Array."""
+        results = []
+        for i, space in enumerate(self.flatten()):
+            ni = N[i] if N is not None else None
+            results.append(space.evaluate_mesh(u[i], kind=kind, N=ni))
+        return jnp.stack(results)
 
     def forward(self, u: Array) -> tuple[Array, ...]:
-        """Forward transform each physical component into spectral space.
-
-        Args:
-            u: Stacked physical array of shape (n_components, *mesh_shape).
-
-        Returns:
-            Per-component spectral coefficient arrays (shapes may differ).
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.forward(u[i])
-            coeffs.append(ci)
-        return tuple(coeffs)
+        """Forward transform each physical component into spectral space."""
+        return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
 
     def scalar_product(self, u: Array) -> tuple[Array, ...]:
-        """Return scalar products along each axis for all components.
-
-        Args:
-            u: Stacked physical array of shape (n_components, *mesh_shape).
-
-        Returns:
-            Per-component scalar product arrays (shapes may differ).
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.scalar_product(u[i])
-            coeffs.append(ci)
-        return tuple(coeffs)
+        """Return scalar products along each axis for all components."""
+        return tuple(
+            space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
+        )
 
     def backward(
         self,
         u: tuple[Array, ...],
         N: tuple[tuple[int | None, ...] | None, ...] | None = None,
     ) -> Array:
-        """Backward transform per-component spectral coefficients to physical space.
-
-        All components are evaluated on the same mesh, so the outputs have equal
-        shape and are returned as a single stacked array.
-
-        Args:
-            u: Per-component spectral coefficient arrays.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Stacked physical array of shape (n_components, *mesh_shape).
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.backward(u[i], N=N[i] if N is not None else None)
-            coeffs.append(ci)
+        """Backward transform per-component spectral coefficients to physical space."""
+        coeffs = [
+            space.backward(u[i], N=N[i] if N is not None else None)
+            for i, space in enumerate(self.flatten())
+        ]
         return jnp.stack(coeffs)
 
     def backward_primitive(
@@ -244,60 +219,235 @@ class CartesianProductSpace:
         k: tuple[int, ...],
         N: tuple[tuple[int | None, ...], ...] | None = None,
     ) -> Array:
-        """Backward primitive transform for all components.
-
-        Args:
-            u: Per-component spectral coefficient arrays.
-            k: Tuple of derivative orders.
-            N: Optional per-axis counts (defaults each to space.num_quad_points).
-
-        Returns:
-            Stacked physical array of shape (n_components, *mesh_shape).
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
-            coeffs.append(ci)
+        """Backward primitive transform for all components."""
+        coeffs = [
+            space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
+            for i, space in enumerate(self.flatten())
+        ]
         return jnp.stack(coeffs)
 
     def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients to orthogonal basis.
-
-        Args:
-            c: Input array of coefficients.
-
-        Returns:
-            Array of coefficients in orthogonal basis.
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.to_orthogonal(c[i])
-            coeffs.append(ci)
-        return tuple(coeffs)
+        """Convert coefficients to orthogonal basis."""
+        return tuple(
+            space.to_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
 
     def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
-        """Convert coefficients from orthogonal basis.
+        """Convert coefficients from orthogonal basis."""
+        return tuple(
+            space.from_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
 
-        Args:
-            c: Input array of coefficients.
-
-        Returns:
-            Array of coefficients in the original basis.
-        """
-        coeffs = []
-        for i, space in enumerate(self.flatten()):
-            ci = space.from_orthogonal(c[i])
-            coeffs.append(ci)
-        return tuple(coeffs)
-
-    def get_homogeneous(self) -> CartesianProductSpace:
+    def get_homogeneous(self) -> CartesianTensorProductSpace:
         from .tensorproductspace import DirectSumTPS
 
         f = []
         for space in self.basespaces:
             f.append(
                 space.get_homogeneous()
-                if isinstance(space, DirectSumTPS | CartesianProductSpace)
+                if isinstance(space, DirectSumTPS | CartesianTensorProductSpace)
+                else space
+            )
+        return CartesianProduct(*f, name=self.name + "H", rank=self.rank)
+
+    def get_orthogonal(self) -> CartesianTensorProductSpace:
+        orthogonal_spaces = [space.get_orthogonal() for space in self.basespaces]
+        return CartesianProduct(
+            *orthogonal_spaces, name=self.name + "O", rank=self.rank
+        )
+
+
+class CartesianProductSpace:
+    """Composite 1D function space (Cartesian product of OrthogonalSpace objects).
+
+    Represents a tuple of 1D spaces for mixed-variable formulations on 1D
+    domains (e.g. a 1D Stokes-type problem).
+
+    Attributes:
+        basespaces: List of component 1D spaces.
+        system: Shared coordinate system.
+        name: Label.
+        tensorname: Joined printable representation.
+    """
+
+    is_transient = False
+
+    def __init__(
+        self,
+        *basespaces: OneDimensionalSpace,
+        name: str = "CPS",
+        rank: int = -1,
+    ) -> None:
+        self.basespaces = list(basespaces)
+        self.system: CoordSys = self.basespaces[0].system
+        self.name = name
+        self.tensorname = multiplication_sign.join([b.name for b in self.basespaces])
+        self._rank = rank
+        self.leaf: CartesianProductSpace = self
+
+        for space in self.basespaces:
+            space.leaf = self
+
+        for i, space in enumerate(self.flatten()):
+            space.global_index = i
+            space.leaf = self
+            if isinstance(space, DirectSum):
+                for subspace in space.basespaces:
+                    subspace.global_index = i
+                    subspace.leaf = self
+
+    def __len__(self) -> int:
+        """Return number of subspaces."""
+        return len(self.basespaces)
+
+    def __iter__(self) -> Iterator[OneDimensionalSpace]:
+        """Iterate over component spaces."""
+        return iter(self.basespaces)
+
+    def __getitem__(self, i: int) -> OneDimensionalSpace:
+        """Return component space i."""
+        return self.basespaces[i]
+
+    def flatten(self) -> list[OrthogonalSpace | DirectSum]:
+        """Return flattened list of all component 1D spaces."""
+        spaces: list[OrthogonalSpace | DirectSum] = []
+        for space in self.basespaces:
+            if isinstance(space, CartesianProductSpace):
+                spaces.extend(space.flatten())
+            else:
+                spaces.append(space)
+        return spaces
+
+    @property
+    def num_components(self) -> int:
+        """Return total number of scalar components."""
+        return len(self.flatten())
+
+    @property
+    def rank(self) -> int:
+        """Return tensor rank (-1 for composite mixed spaces)."""
+        return self._rank
+
+    @property
+    def dims(self) -> int:
+        """Return spatial dimension (always 1)."""
+        return 1
+
+    @property
+    def dim(self) -> int:
+        """Return total number of modes."""
+        return sum(space.dim for space in self.basespaces)
+
+    @property
+    def block_sizes(self) -> tuple[int, ...]:
+        """Return tuple of component space dimensions."""
+        return tuple(space.dim for space in self.flatten())
+
+    @property
+    def num_dofs(self) -> tuple[tuple[int, ...], ...]:
+        """Return tuple of active degrees of freedom per axis.
+
+        OrthogonalSpace.num_dofs returns an int; wrap in a 1-tuple so
+        BlockArray always receives a uniform tuple[tuple[int, ...], ...].
+        """
+        result = []
+        for space in self.flatten():
+            nd = space.num_dofs
+            result.append((nd,) if isinstance(nd, int) else nd)
+        return tuple(result)
+
+    @property
+    def is_orthogonal(self) -> bool:
+        """Return True if underlying bases are all orthogonal."""
+        return all(space.is_orthogonal for space in self.basespaces)
+
+    def shape(self) -> Any:
+        """Return modal shape for each subspace."""
+        result = []
+        for space in self.basespaces:
+            if isinstance(space, DirectSum):
+                result.append((space.dim,))
+            else:
+                result.append(space.shape())
+        return tuple(result)
+
+    def evaluate(self, x: Array, c: tuple[Array, ...]) -> Array:
+        """Evaluate each component at scattered points and stack into one Array."""
+        return jnp.array(
+            [space.evaluate(x, c[i]) for i, space in enumerate(self.flatten())]
+        )
+
+    def evaluate_mesh(
+        self,
+        u: tuple[Array, ...],
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> Array:
+        """Evaluate each component on a mesh and stack into one Array."""
+        results = []
+        for i, space in enumerate(self.flatten()):
+            ni = N[i] if N is not None else None
+            if isinstance(space, DirectSum):
+                results.append(
+                    space[0].evaluate_mesh(space.to_orthogonal(u[i]), kind=kind, N=ni)
+                )
+            else:
+                results.append(space.evaluate_mesh(u[i], kind=kind, N=ni))
+        return jnp.stack(results)
+
+    def forward(self, u: Array) -> tuple[Array, ...]:
+        """Forward transform each physical component into spectral space."""
+        return tuple(space.forward(u[i]) for i, space in enumerate(self.flatten()))
+
+    def scalar_product(self, u: Array) -> tuple[Array, ...]:
+        """Return scalar products for all components."""
+        return tuple(
+            space.scalar_product(u[i]) for i, space in enumerate(self.flatten())
+        )
+
+    def backward(
+        self,
+        u: tuple[Array, ...],
+        N: tuple[tuple[int | None, ...] | None, ...] | None = None,
+    ) -> Array:
+        """Backward transform per-component spectral coefficients to physical space."""
+        coeffs = [
+            space.backward(u[i], N=N[i] if N is not None else None)
+            for i, space in enumerate(self.flatten())
+        ]
+        return jnp.stack(coeffs)
+
+    def backward_primitive(
+        self,
+        u: tuple[Array, ...],
+        k: tuple[int, ...],
+        N: tuple[tuple[int | None, ...], ...] | None = None,
+    ) -> Array:
+        """Backward primitive transform for all components."""
+        coeffs = [
+            space.backward_primitive(u[i], k=k, N=N[i] if N is not None else None)
+            for i, space in enumerate(self.flatten())
+        ]
+        return jnp.stack(coeffs)
+
+    def to_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients to orthogonal basis."""
+        return tuple(
+            space.to_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
+
+    def from_orthogonal(self, c: tuple[Array, ...]) -> tuple[Array, ...]:
+        """Convert coefficients from orthogonal basis."""
+        return tuple(
+            space.from_orthogonal(c[i]) for i, space in enumerate(self.flatten())
+        )
+
+    def get_homogeneous(self) -> CartesianProductSpace:
+        f = []
+        for space in self.basespaces:
+            f.append(
+                space.get_homogeneous()
+                if isinstance(space, DirectSum | CartesianProductSpace)
                 else space
             )
         return CartesianProduct(*f, name=self.name + "H", rank=self.rank)
@@ -309,7 +459,9 @@ class CartesianProductSpace:
         )
 
 
-class VectorTensorProductSpace(CartesianProductSpace):
+class VectorTensorProductSpace(CartesianTensorProductSpace):
+    """Vector-valued tensor product space (rank-1 CartesianTensorProductSpace)."""
+
     def __iter__(self) -> Iterator[TensorProductSpace]:
         """Iterate over component spaces."""
         return iter(cast(list[TensorProductSpace], self.basespaces))
@@ -317,3 +469,12 @@ class VectorTensorProductSpace(CartesianProductSpace):
     def __getitem__(self, i: int) -> TensorProductSpace:
         """Return component space i."""
         return cast(list[TensorProductSpace], self.basespaces)[i]
+
+    def mesh(
+        self,
+        kind: MeshKind | str = MeshKind.QUADRATURE,
+        N: tuple[int | None, ...] | None = None,
+        broadcast: bool = True,
+    ) -> tuple[Array, ...]:
+        """Delegate to first component TensorProductSpace mesh."""
+        return self[0].mesh(kind=kind, N=N, broadcast=broadcast)

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -196,6 +196,12 @@ class Composite(OrthogonalSpace):
         """Evaluate constrained expansion at X with composite coeffs c."""
         return self.orthogonal._evaluate(X, self.to_orthogonal(c))
 
+    @jax.jit(static_argnums=(0, 2, 3))
+    def evaluate_mesh(
+        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
+    ) -> Array:
+        return self.orthogonal.evaluate_mesh(self.to_orthogonal(c), kind=kind, N=N)
+
     @jax.jit(static_argnums=(0, 2))
     def backward(self, c: Array, N: int | None = None) -> Array:
         """Inverse transform (physical -> coefficients) via underlying basis."""
@@ -595,6 +601,12 @@ class DirectSum:
     def evaluate(self, x: Array, c: Array) -> Array:
         """Evaluate direct-sum expansion at points x."""
         return self.orthogonal.evaluate(x, self.to_orthogonal(c))
+
+    @jax.jit(static_argnums=(0, 2, 3))
+    def evaluate_mesh(
+        self, c: Array, kind: MeshKind | str = MeshKind.QUADRATURE, N: int | None = None
+    ) -> Array:
+        return self.orthogonal.evaluate_mesh(self.to_orthogonal(c), kind=kind, N=N)
 
     @jax.jit(static_argnums=(0, 2))
     def backward(self, c: Array, N: int | None = None) -> Array:

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -568,8 +568,8 @@ class DirectSum:
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Return modal shape (not including inhomogen dofs) as a tuple."""
-        return (self.dim,)
+        """Return physical-space shape (number of quadrature points)."""
+        return (self.num_quad_points,)
 
     @property
     def dim(self) -> int:

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Iterator
-from typing import Literal, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 import jax
 import jax.numpy as jnp
@@ -15,6 +15,9 @@ from jaxfun.coordinates import CoordSys
 from jaxfun.la import DiaMatrix, Matrix, diags
 from jaxfun.typing import MeshKind, TestSpaceKind
 from jaxfun.utils.common import Domain, matmat, n
+
+if TYPE_CHECKING:
+    from jaxfun.galerkin.cartesianproductspace import CartesianProductSpace
 
 from .Jacobi import Jacobi
 from .orthogonal import OrthogonalSpace
@@ -526,6 +529,8 @@ class DirectSum:
         self.dims = a.dims
         self.rank = a.rank
         self.domain = a.domain
+        self.leaf: CartesianProductSpace | None = None
+        self.global_index: int = 0
 
     @overload
     def __getitem__(self, i: Literal[0]) -> Composite: ...

--- a/src/jaxfun/galerkin/composite.py
+++ b/src/jaxfun/galerkin/composite.py
@@ -561,6 +561,11 @@ class DirectSum:
         return self[1].bnd_vals()
 
     @property
+    def shape(self) -> tuple[int, ...]:
+        """Return modal shape (not including inhomogen dofs) as a tuple."""
+        return (self.dim,)
+
+    @property
     def dim(self) -> int:
         """Return dimension of unknown (homogeneous) part only."""
         return self[0].dim

--- a/src/jaxfun/galerkin/forms.py
+++ b/src/jaxfun/galerkin/forms.py
@@ -145,8 +145,7 @@ def check_if_nonlinear_in_jaxfunction(a: sp.Basic) -> bool:
         True if expression is nonlinear in any JAXFunction, False otherwise.
     """
     jaxfunctions = get_jaxfunctions(a)
-    have_jaxfunctions = len(jaxfunctions)
-    if not have_jaxfunctions:
+    if not len(jaxfunctions):
         return False
 
     def _is_nonlinear_in_jaxfunction(a: sp.Basic) -> bool:
@@ -229,6 +228,16 @@ def split_coeff(c0: sp.Expr | float) -> CoeffDict:
     return coeffs
 
 
+def unwrap_single_testfunction(
+    v: set[TestFunction | AppliedUndef] | TestFunction | AppliedUndef,
+) -> TestFunction | AppliedUndef:
+    if isinstance(v, set):
+        if len(v) > 1:
+            raise NotImplementedError("Multiple test functions not supported")
+        v = v.pop()
+    return v
+
+
 def split(forms: sp.Expr) -> ResultDict:
     """Split a full weak form expression into linear and bilinear parts.
 
@@ -255,9 +264,7 @@ def split(forms: sp.Expr) -> ResultDict:
     """
     v, _ = get_basisfunctions(forms)
     assert v is not None, "A test function is required"
-    if isinstance(v, set):
-        assert len(v) == 1, "Multiple test functions not supported"
-        v = v.pop()
+    v = unwrap_single_testfunction(v)
     assert _has_functionspace(v)
     V = v.functionspace
 

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -11,9 +11,11 @@ from jax import Array
 from jaxfun.la import (
     BaseMatrix,
     BlockArray,
+    BlockMatrix,
     BlockTPMatrix,
     DiaMatrix,
     IndexedArray,
+    IndexedMatrix,
     Matrix,
     TensorMatrix,
     TPMatrices,
@@ -42,6 +44,7 @@ from .arguments import (
 )
 from .cartesianproductspace import (
     CartesianProductSpace,
+    CartesianTensorProductSpace,
     VectorTensorProductSpace,
 )
 from .composite import BCGeneric, Composite, DirectSum
@@ -63,7 +66,7 @@ from .tensorproductspace import (
 type _NumQuadPoints = int | tuple[int | None, ...]
 type _BilinearFactor = tuple[Array, Array] | Matrix | DiaMatrix
 type _BilinearMat = tuple[_BilinearFactor, tuple[int, int]]
-type _InnerTerm = tuple[BaseMatrix | None, IndexedArray | None]
+type _InnerTerm = tuple[BaseMatrix | IndexedMatrix | None, IndexedArray | None]
 type _LinearFactor = Array | tuple[Array, ...]
 
 
@@ -251,7 +254,10 @@ def _prepare_inner_context(
     test_space = cast(RankedTestSpaceType, V.functionspace)
     if isinstance(U, set):
         leaf = set(
-            cast(CartesianProductSpace, cast(TrialFunction, u).functionspace).leaf
+            cast(
+                CartesianTensorProductSpace | CartesianProductSpace,
+                cast(TrialFunction, u).functionspace,
+            ).leaf
             for u in U
         )
         assert len(leaf) == 1
@@ -286,7 +292,7 @@ def _assemble_inner_items(
     context: _InnerContext,
     use_precomputed_matrices: bool,
 ) -> InnerItems:
-    aresults: list[BaseMatrix] = []
+    aresults: list[BaseMatrix | IndexedMatrix] = []
     bresults: list[IndexedArray] = []
 
     for a0 in context.a_forms:
@@ -361,7 +367,7 @@ def _assemble_bilinear_form(
     coeffs = split_coeff(a0["coeff"])
     sc = coeffs.get("bilinear", 1)
 
-    aresult: BaseMatrix | None = None
+    aresult: BaseMatrix | IndexedMatrix | None = None
     bresult: IndexedArray | None = None
     trial: list[OrthogonalSpace] = []
     has_bcs = False
@@ -384,7 +390,7 @@ def _assemble_bilinear_form(
             continue
         if isinstance(uf, BCGeneric) and context.test_space.dims == 1:
             sign = _linear_sign(context.all_linear)
-            bresult = IndexedArray(  # global_indices currently not used in 1D, but kept here for future developments  # noqa: E501
+            bresult = IndexedArray(
                 global_indices[0],
                 sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=float)),
             )
@@ -404,7 +410,12 @@ def _assemble_bilinear_form(
 
     if context.test_space.dims == 1 and "bilinear" in coeffs:
         assert isinstance(mats[0][0], Matrix | DiaMatrix)
-        aresult = mats[0][0]
+        test_leaf = context.test_space.leaf
+        if test_leaf is not None:
+            # Inside a CartesianProductSpace: tag with block indices for BlockMatrix
+            aresult = IndexedMatrix(mats[0][1], mats[0][0])
+        else:
+            aresult = mats[0][0]
         return aresult, bresult
 
     if isinstance(mats[0][0], tuple):
@@ -423,10 +434,10 @@ def _multivar_boundary_values(
     trial: list[OrthogonalSpace],
     gi: list[tuple[int, int]],
 ) -> Array:
-    assert isinstance(trial_space, DirectSumTPS | CartesianProductSpace)
+    assert isinstance(trial_space, DirectSumTPS | CartesianTensorProductSpace)
     if isinstance(trial_space, DirectSumTPS):
         return trial_space.bndvals[tuple(trial)]
-    assert isinstance(trial_space, CartesianProductSpace)
+    assert isinstance(trial_space, CartesianTensorProductSpace)
     dsspace = trial_space.flatten()[gi[1][1]]
     assert isinstance(dsspace, DirectSumTPS)
     return dsspace.bndvals[tuple(trial)]
@@ -489,16 +500,17 @@ def _separable_boundary_values(
     if trial_space is not None:
         if isinstance(trial_space, DirectSumTPS):
             return trial_space.bndvals[tuple(trial)]
-        if isinstance(trial_space, CartesianProductSpace):
+        if isinstance(trial_space, CartesianTensorProductSpace):
             dsspace = trial_space.flatten()[gi[1][1]]
             assert isinstance(dsspace, DirectSumTPS)
             return dsspace.bndvals[tuple(trial)]
         raise NotImplementedError(
-            "BCs only implemented for TensorProductSpace and CartesianProductSpace"
+            "BCs only implemented for TensorProductSpace"
+            " and CartesianTensorProductSpace"
         )
 
     jfs = coeffs["linear"]["jaxcoeff"].functionspace
-    assert isinstance(jfs, DirectSumTPS | CartesianProductSpace)
+    assert isinstance(jfs, DirectSumTPS | CartesianTensorProductSpace)
     if isinstance(jfs, DirectSumTPS):
         return jfs.bndvals[tuple(trial)]
     dsspace = jfs.flatten()[gi[1][1]]
@@ -542,7 +554,7 @@ def _assemble_separable_bilinear_form(
                 context.test_space, TensorProductSpace | VectorTensorProductSpace
             )
             assert isinstance(
-                context.trial_space, TensorProductSpace | CartesianProductSpace
+                context.trial_space, TensorProductSpace | CartesianTensorProductSpace
             )
             aresult = TPMatrix(
                 [cast(BaseMatrix, m[0]) for m in mats], 1, global_indices=gi[0]
@@ -594,16 +606,13 @@ def _assemble_linear_form(
 
     test_space = context.test_space
     if isinstance(test_space, OrthogonalSpace):
-        return IndexedArray(0, cast(Array, bs[0]))
+        return IndexedArray(global_index, cast(Array, bs[0]))
     if (
         isinstance(test_space, TensorProductSpace | VectorTensorProductSpace)
         and len(test_space) == 2
     ):
         return _assemble_linear_tensor2d(b0, bs, test_space, quads, global_index)
-    if (
-        isinstance(test_space, TensorProductSpace | CartesianProductSpace)
-        and len(test_space) == 3
-    ):
+    if isinstance(test_space, TensorProductSpace) and len(test_space) == 3:
         return _assemble_linear_tensor3d(b0, bs, test_space, quads, global_index)
     return None
 
@@ -662,7 +671,7 @@ def _assemble_linear_tensor3d(
 
 
 def _finalize_inner_result(
-    aresults: list[BaseMatrix],
+    aresults: list[BaseMatrix | IndexedMatrix],
     bresults: list[IndexedArray],
     test_space: RankedTestSpaceType,
     trial_space: TrialSpaceType | None,
@@ -683,7 +692,7 @@ def _finalize_inner_result(
     """
     assert test_space is not None
     dims: int = test_space.dims
-    test_leaf = getattr(test_space, "leaf", None)
+    test_leaf = test_space.leaf
     rank: int = 0 if test_leaf is None else test_leaf.rank
 
     bresult: Array | BlockArray | None = None
@@ -693,17 +702,39 @@ def _finalize_inner_result(
             bresult = jnp.sum(jnp.array([d.data for d in bresults]), axis=0)
         else:
             bresult = BlockArray(
-                cast(CartesianProductSpace, test_space).leaf, indexed_arrays=bresults
+                cast(CartesianTensorProductSpace, test_leaf), indexed_arrays=bresults
             )
 
     aresult: BaseMatrix | None = None
 
     if dims == 1:
         if len(aresults) > 0:
-            amats: list[Matrix | DiaMatrix] = []
-            for a in aresults:
-                amats.append(a.tosparse(tol=sparse_tol) if sparse else a.to_matrix())
-            aresult = sum(amats[1:], amats[0])
+            if all(isinstance(a, IndexedMatrix) for a in aresults):
+                # 1D CartesianProductSpace bilinear forms
+                iresults = cast(list[IndexedMatrix], aresults)
+                indexed_mats: list[IndexedMatrix] = []
+                for im in iresults:
+                    m = (
+                        im.data.tosparse(tol=sparse_tol)
+                        if sparse
+                        else im.data.to_matrix()
+                    )
+                    indexed_mats.append(IndexedMatrix(im.i, m))
+                assert trial_space is not None
+                trial_leaf = getattr(trial_space, "leaf", trial_space)
+                aresult = BlockMatrix(
+                    indexed_mats,
+                    cast(CartesianProductSpace, test_leaf),
+                    cast(CartesianProductSpace, trial_leaf),
+                )
+            else:
+                plain_results = cast(list[BaseMatrix], aresults)
+                amats: list[Matrix | DiaMatrix] = []
+                for a in plain_results:
+                    amats.append(
+                        a.tosparse(tol=sparse_tol) if sparse else a.to_matrix()
+                    )
+                aresult = sum(amats[1:], amats[0])
 
         if aresult is None:
             return cast(Array, bresult)
@@ -734,8 +765,8 @@ def _finalize_inner_result(
             else:
                 aresult = BlockTPMatrix(
                     tpresults,
-                    cast(CartesianProductSpace, test_space.leaf),
-                    cast(CartesianProductSpace, trial_space.leaf),
+                    cast(CartesianTensorProductSpace, test_space.leaf),
+                    cast(CartesianTensorProductSpace, trial_space.leaf),
                 )
 
         elif all(isinstance(a, TensorMatrix) for a in aresults):
@@ -1027,6 +1058,8 @@ def project(ue: sp.Expr, V: VectorTensorProductSpace) -> tuple[Array, ...]: ...
 @overload
 def project(ue: sp.Tuple, V: CartesianProductSpace) -> tuple[Array, ...]: ...
 @overload
+def project(ue: sp.Tuple, V: CartesianTensorProductSpace) -> tuple[Array, ...]: ...
+@overload
 def project(ue: sp.Expr, V: ScalarSpaceType) -> Array: ...
 def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array, ...]:
     """Project expression onto (possibly tensor) space V.
@@ -1041,12 +1074,19 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
     from jaxfun.operators import Dot
 
     if V.dims == 1:
+        if isinstance(V, CartesianProductSpace):
+            assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
+            spaces = V.flatten()
+            return tuple(
+                project(cast(sp.Expr, uei), cast(ScalarSpaceType, spaces[i]))
+                for i, uei in enumerate(ue)
+            )
         assert isinstance(V, OrthogonalSpace | DirectSum)
         assert isinstance(ue, sp.Expr)
         return project1D(ue, V)
 
     if len(get_jaxfunctions(ue if isinstance(ue, sp.Expr) else sum(ue))) == 0:
-        assert not isinstance(V, OrthogonalSpace | DirectSum)
+        assert not isinstance(V, OrthogonalSpace | DirectSum | CartesianProductSpace)
         if V.rank == 0:
             assert isinstance(ue, sp.Expr)
             uj = lambdify(V.system.base_scalars(), ue)(*V.mesh())

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -727,7 +727,7 @@ def _finalize_inner_result(
                     cast(CartesianProductSpace, trial_leaf),
                 )
             else:
-                plain_results = aresults
+                plain_results = cast(list[BaseMatrix], aresults)
                 amats: list[Matrix | DiaMatrix] = []
                 for a in plain_results:
                     amats.append(

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -29,6 +29,7 @@ from jaxfun.typing import (
     InnerKindLike,
     InnerResultDict,
     RankedTestSpaceType,
+    RankTag,
     ScalarSpaceType,
     TrialSpaceType,
 )
@@ -691,12 +692,12 @@ def _finalize_inner_result(
     assert test_space is not None
     dims: int = test_space.dims
     test_leaf = test_space.leaf
-    rank: int = 0 if test_leaf is None else test_leaf.rank
+    rank: RankTag = RankTag.SCALAR if test_leaf is None else test_leaf.rank
 
     bresult: Array | BlockArray | None = None
 
     if len(bresults) > 0:
-        if rank == 0:
+        if rank == RankTag.SCALAR:
             bresult = jnp.sum(jnp.array([d.data for d in bresults]), axis=0)
         else:
             bresult = BlockArray(
@@ -758,7 +759,7 @@ def _finalize_inner_result(
                 else:
                     a0.mats = nnx.List(mat.to_matrix() for mat in a0.mats)
 
-            if rank == 0:
+            if rank == RankTag.SCALAR:
                 aresult = tpresults[0] if len(tpresults) == 1 else TPMatrices(tpresults)
             else:
                 aresult = BlockMatrix(
@@ -768,7 +769,7 @@ def _finalize_inner_result(
                 )
 
         elif all(isinstance(a, TensorMatrix) for a in aresults):
-            if rank != 0:
+            if rank != RankTag.SCALAR:
                 raise NotImplementedError("Rank >0 TensorMatrix not implemented")
             tensor_results = cast(list[TensorMatrix], aresults)
             aresult = sum(tensor_results[1:], tensor_results[0])
@@ -1083,14 +1084,14 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
 
     if len(get_jaxfunctions(ue if isinstance(ue, sp.Expr) else sum(ue))) == 0:
         assert not isinstance(V, OrthogonalSpace | DirectSum | CartesianProductSpace)
-        if V.rank == 0:
+        if V.rank == RankTag.SCALAR:
             assert isinstance(ue, sp.Expr)
             uj = lambdify(V.system.base_scalars(), ue)(*V.mesh())
             uj = jnp.broadcast_to(uj, V.num_quad_points)
         else:
             s = V.system.base_scalars()
             bv = V.system.base_vectors()
-            if V.rank == 1:  # VectorTensorProductSpace
+            if V.rank == RankTag.VECTOR:  # VectorTensorProductSpace
                 assert isinstance(ue, sp.Expr)
                 uj = (lambdify(s, Dot(ue, n).doit())(*V.mesh()) for n in bv)
             else:
@@ -1102,11 +1103,11 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
 
     u = TrialFunction(V)
     v = TestFunction(V)
-    if V.rank == 0:
+    if V.rank == RankTag.SCALAR:
         A, b = inner(v * (u - ue), kind=InnerKind.SYSTEM)
         uh = A.solve(b)
 
-    elif V.rank == 1:
+    elif V.rank == RankTag.VECTOR:
         assert isinstance(V, VectorTensorProductSpace)
         A, b = inner(Dot(v, (u - ue)), kind=InnerKind.SYSTEM)
         uh = A.solve(b)

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -1112,7 +1112,7 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
         uh = A.solve(b)
 
     else:
-        assert isinstance(V, CartesianProductSpace)
+        assert isinstance(V, CartesianTensorProductSpace)
         assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
         spaces = V.flatten()
         uh = tuple(project(cast(sp.Expr, uei), spaces[i]) for i, uei in enumerate(ue))

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -56,6 +56,7 @@ from .forms import (
     get_jaxfunctions,
     split,
     split_coeff,
+    unwrap_single_testfunction,
 )
 from .orthogonal import OrthogonalSpace
 from .tensorproductspace import (
@@ -247,9 +248,7 @@ def _prepare_inner_context(
 ) -> _InnerContext:
     V, U = get_basisfunctions(expr)
     assert V is not None, "No TestFunction found in expression"
-    if isinstance(V, set):
-        assert len(V) == 1, "More than one testfunction found in expression"
-        V = V.pop()
+    V = unwrap_single_testfunction(V)
     assert _has_testspace(V), "TestFunction has no associated function space"
     test_space = cast(RankedTestSpaceType, V.functionspace)
     if isinstance(U, set):
@@ -392,7 +391,7 @@ def _assemble_bilinear_form(
             sign = _linear_sign(context.all_linear)
             bresult = IndexedArray(
                 global_indices[0],
-                sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=float)),
+                sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=z.dtype)),
             )
             continue
         if "linear" in coeffs and context.test_space.dims == 1:
@@ -867,8 +866,6 @@ def inner_bilinear(
         if len(jaxfunction) >= 1:
             scale *= evaluate_jaxfunction_expr_quad(aii, N=N)
             continue
-        elif len(jaxfunction) > 1:
-            raise ValueError("Multiple JAXFunctions found in single bilinear form")
 
         if len(aii.free_symbols) > 0:
             s = aii.free_symbols.pop()
@@ -1054,11 +1051,11 @@ def project1D(ue: sp.Expr, V: OrthogonalSpace | Composite | DirectSum) -> Array:
 
 
 @overload
-def project(ue: sp.Expr, V: VectorTensorProductSpace) -> tuple[Array, ...]: ...
-@overload
 def project(ue: sp.Tuple, V: CartesianProductSpace) -> tuple[Array, ...]: ...
 @overload
-def project(ue: sp.Tuple, V: CartesianTensorProductSpace) -> tuple[Array, ...]: ...
+def project(
+    ue: sp.Expr | sp.Tuple, V: CartesianTensorProductSpace
+) -> tuple[Array, ...]: ...
 @overload
 def project(ue: sp.Expr, V: ScalarSpaceType) -> Array: ...
 def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array, ...]:
@@ -1098,7 +1095,7 @@ def project(ue: sp.Expr | sp.Tuple, V: FunctionSpaceType) -> Array | tuple[Array
                 assert isinstance(ue, sp.Expr)
                 uj = (lambdify(s, Dot(ue, n).doit())(*V.mesh()) for n in bv)
             else:
-                assert isinstance(V, CartesianProductSpace)
+                assert isinstance(V, CartesianTensorProductSpace)
                 assert isinstance(ue, sp.Tuple) and len(ue) == V.num_components
                 uj = (lambdify(s, (uei).doit())(*V.mesh()) for uei in ue)
             uj = jnp.stack([jnp.broadcast_to(ui, V.num_quad_points) for ui in uj])

--- a/src/jaxfun/galerkin/inner.py
+++ b/src/jaxfun/galerkin/inner.py
@@ -12,10 +12,9 @@ from jaxfun.la import (
     BaseMatrix,
     BlockArray,
     BlockMatrix,
-    BlockTPMatrix,
     DiaMatrix,
-    IndexedArray,
-    IndexedMatrix,
+    GlobalArray,
+    GlobalMatrix,
     Matrix,
     TensorMatrix,
     TPMatrices,
@@ -67,7 +66,7 @@ from .tensorproductspace import (
 type _NumQuadPoints = int | tuple[int | None, ...]
 type _BilinearFactor = tuple[Array, Array] | Matrix | DiaMatrix
 type _BilinearMat = tuple[_BilinearFactor, tuple[int, int]]
-type _InnerTerm = tuple[BaseMatrix | IndexedMatrix | None, IndexedArray | None]
+type _InnerTerm = tuple[BaseMatrix | GlobalMatrix | None, GlobalArray | None]
 type _LinearFactor = Array | tuple[Array, ...]
 
 
@@ -291,8 +290,8 @@ def _assemble_inner_items(
     context: _InnerContext,
     use_precomputed_matrices: bool,
 ) -> InnerItems:
-    aresults: list[BaseMatrix | IndexedMatrix] = []
-    bresults: list[IndexedArray] = []
+    aresults: list[BaseMatrix | GlobalMatrix] = []
+    bresults: list[GlobalArray] = []
 
     for a0 in context.a_forms:
         aitem, bitem = _assemble_bilinear_form(a0, context, use_precomputed_matrices)
@@ -366,8 +365,8 @@ def _assemble_bilinear_form(
     coeffs = split_coeff(a0["coeff"])
     sc = coeffs.get("bilinear", 1)
 
-    aresult: BaseMatrix | IndexedMatrix | None = None
-    bresult: IndexedArray | None = None
+    aresult: BaseMatrix | GlobalMatrix | None = None
+    bresult: GlobalArray | None = None
     trial: list[OrthogonalSpace] = []
     has_bcs = False
 
@@ -389,7 +388,7 @@ def _assemble_bilinear_form(
             continue
         if isinstance(uf, BCGeneric) and context.test_space.dims == 1:
             sign = _linear_sign(context.all_linear)
-            bresult = IndexedArray(
+            bresult = GlobalArray(
                 global_indices[0],
                 sign * (z @ jnp.array(uf.bcs.orderedvals(), dtype=z.dtype)),
             )
@@ -397,7 +396,7 @@ def _assemble_bilinear_form(
         if "linear" in coeffs and context.test_space.dims == 1:
             sign = _linear_sign(context.all_linear)
             scale = coeffs["linear"].get("scale", 1) * sign
-            bresult = IndexedArray(
+            bresult = GlobalArray(
                 global_indices[0], scale * (z @ coeffs["linear"]["jaxcoeff"].array)
             )
 
@@ -412,7 +411,7 @@ def _assemble_bilinear_form(
         test_leaf = context.test_space.leaf
         if test_leaf is not None:
             # Inside a CartesianProductSpace: tag with block indices for BlockMatrix
-            aresult = IndexedMatrix(mats[0][1], mats[0][0])
+            aresult = GlobalMatrix(mats[0][1], mats[0][0])
         else:
             aresult = mats[0][0]
         return aresult, bresult
@@ -451,7 +450,7 @@ def _assemble_multivar_bilinear_form(
     context: _InnerContext,
 ) -> _InnerTerm:
     aresult: BaseMatrix | None = None
-    bresult: IndexedArray | None = None
+    bresult: GlobalArray | None = None
     assert len(mats) == 2
     assert isinstance(context.test_space, TensorProductSpace)
     mats_ = [
@@ -473,7 +472,7 @@ def _assemble_multivar_bilinear_form(
         sign = _linear_sign(context.all_linear)
         fun = _multivar_boundary_values(context.trial_space, trial, gi)
         res = sign * jnp.einsum("ikjl,kl->ij", Am, fun)
-        bresult = IndexedArray(gi[0][0], res)
+        bresult = GlobalArray(gi[0][0], res)
 
     else:
         if "linear" in coeffs:
@@ -481,7 +480,7 @@ def _assemble_multivar_bilinear_form(
             res = sign * jnp.einsum(
                 "ikjl,kl->ij", Am, coeffs["linear"]["jaxcoeff"].array
             )
-            bresult = IndexedArray(gi[0][0], res)
+            bresult = GlobalArray(gi[0][0], res)
 
         if "bilinear" in coeffs:
             assert isinstance(context.trial_space, TensorProductSpace)
@@ -525,7 +524,7 @@ def _assemble_separable_bilinear_form(
     context: _InnerContext,
 ) -> _InnerTerm:
     aresult: BaseMatrix | None = None
-    bresult: IndexedArray | None = None
+    bresult: GlobalArray | None = None
     mats_: list[Matrix | DiaMatrix] = [cast(Matrix | DiaMatrix, m[0]) for m in mats]
     gi = [m[1] for m in mats]
 
@@ -534,7 +533,7 @@ def _assemble_separable_bilinear_form(
         fun = _separable_boundary_values(context.trial_space, coeffs, trial, gi)
         sign = _linear_sign(context.all_linear)
         res = TPMatrix(mats_, sign) @ fun
-        bresult = IndexedArray(gi[0][0], res)
+        bresult = GlobalArray(gi[0][0], res)
 
     else:
         if "linear" in coeffs:
@@ -546,7 +545,7 @@ def _assemble_separable_bilinear_form(
             )
             for i, mat in enumerate(mats_):
                 res = mat.matvec(res, axis=i)
-            bresult = IndexedArray(gi[0][0], res)
+            bresult = GlobalArray(gi[0][0], res)
 
         if "bilinear" in coeffs:
             assert isinstance(
@@ -591,7 +590,7 @@ def _assemble_linear_factor(
 
 def _assemble_linear_form(
     b0: InnerResultDict, context: _InnerContext
-) -> IndexedArray | None:
+) -> GlobalArray | None:
     scale = _linear_form_scale(b0, len(context.a_forms) > 0)
     bs: list[_LinearFactor] = []
     global_index = 0
@@ -605,7 +604,7 @@ def _assemble_linear_form(
 
     test_space = context.test_space
     if isinstance(test_space, OrthogonalSpace):
-        return IndexedArray(global_index, cast(Array, bs[0]))
+        return GlobalArray(global_index, cast(Array, bs[0]))
     if (
         isinstance(test_space, TensorProductSpace | VectorTensorProductSpace)
         and len(test_space) == 2
@@ -622,7 +621,7 @@ def _assemble_linear_tensor2d(
     test_space: TensorProductSpace | VectorTensorProductSpace,
     num_quad_points: _NumQuadPoints,
     global_index: int,
-) -> IndexedArray:
+) -> GlobalArray:
     if isinstance(bs[0], tuple):
         assert isinstance(num_quad_points, tuple)
         uj = jnp.array(1.0)
@@ -636,10 +635,10 @@ def _assemble_linear_tensor2d(
         if "jaxfunction" not in b0 and "multivar" not in b0:
             raise ValueError("Expected multivar or jaxfunction key in b0")
         res = bs[0][0].T @ uj @ bs[1][0]
-        return IndexedArray(global_index, res)
+        return GlobalArray(global_index, res)
 
     res = jnp.multiply.outer(cast(Array, bs[0]), cast(Array, bs[1]))
-    return IndexedArray(global_index, res)
+    return GlobalArray(global_index, res)
 
 
 def _assemble_linear_tensor3d(
@@ -648,7 +647,7 @@ def _assemble_linear_tensor3d(
     test_space: TensorProductSpace | VectorTensorProductSpace,
     num_quad_points: _NumQuadPoints,
     global_index: int,
-) -> IndexedArray:
+) -> GlobalArray:
     if isinstance(bs[0], tuple):
         assert isinstance(num_quad_points, tuple)
         if "multivar" in b0:
@@ -661,17 +660,17 @@ def _assemble_linear_tensor3d(
         else:
             raise ValueError("Expected multivar or jaxfunction key in b0")
         res = jnp.einsum("il,jm,kn,ijk->lmn", bs[0][0], bs[1][0], bs[2][0], uj)
-        return IndexedArray(global_index, res)
+        return GlobalArray(global_index, res)
 
     res = jnp.multiply.outer(
         jnp.multiply.outer(cast(Array, bs[0]), cast(Array, bs[1])), cast(Array, bs[2])
     )
-    return IndexedArray(global_index, res)
+    return GlobalArray(global_index, res)
 
 
 def _finalize_inner_result(
-    aresults: list[BaseMatrix | IndexedMatrix],
-    bresults: list[IndexedArray],
+    aresults: list[BaseMatrix | GlobalMatrix],
+    bresults: list[GlobalArray],
     test_space: RankedTestSpaceType,
     trial_space: TrialSpaceType | None,
     sparse: bool,
@@ -708,17 +707,17 @@ def _finalize_inner_result(
 
     if dims == 1:
         if len(aresults) > 0:
-            if all(isinstance(a, IndexedMatrix) for a in aresults):
+            if all(isinstance(a, GlobalMatrix) for a in aresults):
                 # 1D CartesianProductSpace bilinear forms
-                iresults = cast(list[IndexedMatrix], aresults)
-                indexed_mats: list[IndexedMatrix] = []
+                iresults = cast(list[GlobalMatrix], aresults)
+                indexed_mats: list[GlobalMatrix] = []
                 for im in iresults:
                     m = (
                         im.data.tosparse(tol=sparse_tol)
                         if sparse
                         else im.data.to_matrix()
                     )
-                    indexed_mats.append(IndexedMatrix(im.i, m))
+                    indexed_mats.append(GlobalMatrix(im.global_indices, m))
                 assert trial_space is not None
                 trial_leaf = getattr(trial_space, "leaf", trial_space)
                 aresult = BlockMatrix(
@@ -727,7 +726,7 @@ def _finalize_inner_result(
                     cast(CartesianProductSpace, trial_leaf),
                 )
             else:
-                plain_results = cast(list[BaseMatrix], aresults)
+                plain_results = aresults
                 amats: list[Matrix | DiaMatrix] = []
                 for a in plain_results:
                     amats.append(
@@ -762,7 +761,7 @@ def _finalize_inner_result(
             if rank == 0:
                 aresult = tpresults[0] if len(tpresults) == 1 else TPMatrices(tpresults)
             else:
-                aresult = BlockTPMatrix(
+                aresult = BlockMatrix(
                     tpresults,
                     cast(CartesianTensorProductSpace, test_space.leaf),
                     cast(CartesianTensorProductSpace, trial_space.leaf),

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -306,8 +306,8 @@ class OrthogonalSpace(BaseSpace):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Return modal shape as a tuple."""
-        return (self.dim,)
+        """Return physical-space shape (number of quadrature points)."""
+        return (self.num_quad_points,)
 
     @property
     def dim(self) -> int:

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -26,7 +26,7 @@ import sympy as sp
 from jaxfun.basespace import BaseSpace
 from jaxfun.coordinates import CoordSys
 from jaxfun.la import BaseMatrix, DiaMatrix, Matrix, diags
-from jaxfun.typing import Array, MeshKind
+from jaxfun.typing import Array, MeshKind, RankTag
 from jaxfun.utils.common import Domain, jacn, jit_vmap, lambdify
 
 if TYPE_CHECKING:
@@ -325,9 +325,9 @@ class OrthogonalSpace(BaseSpace):
         return self.dim
 
     @property
-    def rank(self) -> int:
+    def rank(self) -> RankTag:
         """Return tensor rank (0 for scalar spaces)."""
-        return 0
+        return RankTag.SCALAR
 
     @property
     def domain(self) -> Domain:

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -48,10 +48,14 @@ class OrthogonalSpace(BaseSpace):
         N: Number of modes.
         domain: Physical Domain (None -> reference).
         num_quad_points: Default quadrature resolution (== N).
+        bcs: dictionary describing boundary conditions.
         S: Stencil matrix (identity here; overridden in Composite).
         P: DiaMatrix representing S @ S.T.
         stencil: Dict describing diagonal shifts (0:1 for identity).
         orthogonal: Self alias (Composite replaces with underlying).
+        leaf: If not None the CartesianProductSpace this space
+            belongs to.
+        global_index: Global index into CartesianProductSpace.
     """
 
     is_orthogonal = True
@@ -301,8 +305,13 @@ class OrthogonalSpace(BaseSpace):
         return a
 
     @property
+    def shape(self) -> tuple[int, ...]:
+        """Return modal shape as a tuple."""
+        return (self.dim,)
+
+    @property
     def dim(self) -> int:
-        """Return total number of raw modes N."""
+        """Return total number of degrees of freedom."""
         return self.N
 
     @property
@@ -453,10 +462,6 @@ class OrthogonalSpace(BaseSpace):
     def get_orthogonal(self) -> Self:
         """Return self (orthogonal space is self; overridden in Composite)."""
         return self
-
-    def shape(self) -> tuple[int, ...]:
-        """Return modal shape as a tuple."""
-        return (self.N,)
 
     def to_orthogonal(self, c: Array) -> Array:
         """Return coefficients unchanged (already in the orthogonal basis)."""

--- a/src/jaxfun/galerkin/orthogonal.py
+++ b/src/jaxfun/galerkin/orthogonal.py
@@ -30,6 +30,7 @@ from jaxfun.typing import Array, MeshKind
 from jaxfun.utils.common import Domain, jacn, jit_vmap, lambdify
 
 if TYPE_CHECKING:
+    from jaxfun.galerkin.cartesianproductspace import CartesianProductSpace
     from jaxfun.galerkin.composite import BoundaryConditions
 
 
@@ -75,6 +76,8 @@ class OrthogonalSpace(BaseSpace):
         self.stencil = {0: 1}
         self.S: DiaMatrix = diags([jnp.ones(N)], offsets=(0,), shape=(N, N))
         self.P: DiaMatrix = self.S
+        self.leaf: CartesianProductSpace | None = None
+        self.global_index: int = 0
         super().__init__(system, name, fun_str)
 
     @abstractmethod
@@ -450,6 +453,18 @@ class OrthogonalSpace(BaseSpace):
     def get_orthogonal(self) -> Self:
         """Return self (orthogonal space is self; overridden in Composite)."""
         return self
+
+    def shape(self) -> tuple[int, ...]:
+        """Return modal shape as a tuple."""
+        return (self.N,)
+
+    def to_orthogonal(self, c: Array) -> Array:
+        """Return coefficients unchanged (already in the orthogonal basis)."""
+        return c
+
+    def from_orthogonal(self, c: Array) -> Array:
+        """Return coefficients unchanged (already in the orthogonal basis)."""
+        return c
 
     def _matrices(
         self, i: int, trial: tuple[OrthogonalSpace, int], q: int = 0

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -117,8 +117,8 @@ class TensorProductSpace:
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Return dofs along each axis."""
-        return tuple(space.dim for space in self.basespaces)
+        """Return physical-space shape (number of quadrature points per axis)."""
+        return tuple(space.num_quad_points for space in self.basespaces)
 
     @property
     def dim(self) -> int:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -115,9 +115,10 @@ class TensorProductSpace:
         """Return True if underlying bases are all orthogonal."""
         return all(space.is_orthogonal for space in self.basespaces)
 
+    @property
     def shape(self) -> tuple[int, ...]:
-        """Return raw modal shape (N0, N1, ...)."""
-        return tuple([space.N for space in self.basespaces])
+        """Return dofs along each axis."""
+        return tuple(space.dim for space in self.basespaces)
 
     @property
     def dim(self) -> int:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -19,7 +19,7 @@ from jaxfun.sharding import (
     physical_sharding,
     spectral_sharding,
 )
-from jaxfun.typing import MeshKind
+from jaxfun.typing import MeshKind, RankTag
 from jaxfun.utils.common import jit_vmap, lambdify
 
 from .composite import BCGeneric, BoundaryConditions, Composite, DirectSum
@@ -106,9 +106,9 @@ class TensorProductSpace:
         return len(self)
 
     @property
-    def rank(self) -> int:
+    def rank(self) -> RankTag:
         """Return tensor rank (0 for scalar-valued space)."""
-        return 0
+        return RankTag.SCALAR
 
     @property
     def is_orthogonal(self) -> bool:

--- a/src/jaxfun/galerkin/tensorproductspace.py
+++ b/src/jaxfun/galerkin/tensorproductspace.py
@@ -29,7 +29,7 @@ tensor_product_symbol = "\u2297"
 multiplication_sign = "\u00d7"
 
 if TYPE_CHECKING:
-    from jaxfun.galerkin import CartesianProductSpace
+    from jaxfun.galerkin import CartesianTensorProductSpace
 
 
 IndivisibleError = ValueError
@@ -68,7 +68,7 @@ class TensorProductSpace:
         basespaces: Sequence[OrthogonalSpace],
         system: CoordSys | None = None,
         name: str = "TPS",
-        leaf: CartesianProductSpace | None = None,
+        leaf: CartesianTensorProductSpace | None = None,
         global_index: int = 0,
     ) -> None:
         from jaxfun.coordinates import CartCoordSys, x, y, z
@@ -580,7 +580,7 @@ class DirectSumTPS(TensorProductSpace):
         system: CoordSys,
         name: str = "DSTPS",
         global_index: int = 0,
-        leaf: CartesianProductSpace | None = None,
+        leaf: CartesianTensorProductSpace | None = None,
     ) -> None:
         from jaxfun.galerkin.inner import project, project1D
 

--- a/src/jaxfun/la/__init__.py
+++ b/src/jaxfun/la/__init__.py
@@ -1,4 +1,8 @@
-from .blocktpmatrix import BlockArray as BlockArray, BlockTPMatrix as BlockTPMatrix
+from .blocktpmatrix import (
+    BlockArray as BlockArray,
+    BlockMatrix as BlockMatrix,
+    BlockTPMatrix as BlockTPMatrix,
+)
 from .diamatrix import (
     DiagonalMatrix as DiagonalMatrix,
     DiaMatrix as DiaMatrix,
@@ -6,7 +10,11 @@ from .diamatrix import (
     diakron as diakron,
 )
 from .matrix import Matrix as Matrix
-from .matrixprotocol import BaseMatrix as BaseMatrix, IndexedArray as IndexedArray
+from .matrixprotocol import (
+    BaseMatrix as BaseMatrix,
+    IndexedArray as IndexedArray,
+    IndexedMatrix as IndexedMatrix,
+)
 from .operators import (
     IdentityMatrix as IdentityMatrix,
     SpecialMatrix as SpecialMatrix,

--- a/src/jaxfun/la/__init__.py
+++ b/src/jaxfun/la/__init__.py
@@ -1,8 +1,4 @@
-from .blocktpmatrix import (
-    BlockArray as BlockArray,
-    BlockMatrix as BlockMatrix,
-    BlockTPMatrix as BlockTPMatrix,
-)
+from .blockmatrix import BlockArray as BlockArray, BlockMatrix as BlockMatrix
 from .diamatrix import (
     DiagonalMatrix as DiagonalMatrix,
     DiaMatrix as DiaMatrix,
@@ -10,12 +6,10 @@ from .diamatrix import (
     diakron as diakron,
 )
 from .matrix import Matrix as Matrix
-from .matrixprotocol import (
-    BaseMatrix as BaseMatrix,
-    IndexedArray as IndexedArray,
-    IndexedMatrix as IndexedMatrix,
-)
+from .matrixprotocol import BaseMatrix as BaseMatrix
 from .operators import (
+    GlobalArray as GlobalArray,
+    GlobalMatrix as GlobalMatrix,
     IdentityMatrix as IdentityMatrix,
     SpecialMatrix as SpecialMatrix,
     ZeroMatrix as ZeroMatrix,

--- a/src/jaxfun/la/blockmatrix.py
+++ b/src/jaxfun/la/blockmatrix.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self, cast
 
 import jax.numpy as jnp
 from flax import nnx
@@ -11,10 +11,9 @@ from jaxfun.la.matrix import Matrix
 from jaxfun.la.matrixprotocol import (
     BaseMatrix,
     DiaMatrixSolveMethod,
-    IndexedArray,
-    IndexedMatrix,
     _CacheBox,
 )
+from jaxfun.la.operators import GlobalArray, GlobalMatrix
 from jaxfun.la.tpmatrix import TPMatrices, TPMatrix, tpmats_to_kron
 
 if TYPE_CHECKING:
@@ -27,16 +26,15 @@ if TYPE_CHECKING:
 type _SparseMatrixCache = _CacheBox[DiaMatrix]
 
 
-class _BaseBlockMatrix[SpaceT: CartesianTensorProductSpace | CartesianProductSpace](
-    BaseMatrix
-):
-    """Shared implementation for block matrices over a CartesianProductSpace.
+class BlockMatrix[
+    MatrixT: TPMatrix | GlobalMatrix,
+    SpaceT: CartesianTensorProductSpace | CartesianProductSpace,
+](BaseMatrix):
+    """Shared implementation for block matrices over a Cartesian-product space.
 
-    Subclasses supply ``_combined_blocks`` (an ``nnx.Dict`` mapping
-    ``"bi,bj"`` string keys to ``DiaMatrix | Matrix``), ``test_space``,
-    ``trial_space``, ``shape``, ``test_block_sizes`` and
-    ``trial_block_sizes``.  All heavy-lifting methods live here; only
-    construction, ``scale``, ``__add__`` and ``__sub__`` differ per subclass.
+    Works for both multidimensional CartesianTensorProductSpace and the single-
+    dimensional CartesianProductSpace.
+
     """
 
     _combined_blocks: nnx.Dict
@@ -45,6 +43,40 @@ class _BaseBlockMatrix[SpaceT: CartesianTensorProductSpace | CartesianProductSpa
     test_block_sizes: tuple[int, ...]
     trial_block_sizes: tuple[int, ...]
     shape: tuple[int, int]
+
+    def __init__(
+        self,
+        mats: list[MatrixT],
+        test_space: SpaceT,
+        trial_space: SpaceT,
+    ) -> None:
+        self.mats = nnx.List(mats)
+        self.test_space = test_space
+        self.trial_space = trial_space
+        self.shape = (self.test_space.dim, self.trial_space.dim)
+        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
+        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
+
+        if isinstance(mats[0], TPMatrix):
+            _grouped: dict[str, TPMatrices] = {}
+            for mat in mats:
+                idx = f"{mat.global_indices[0]},{mat.global_indices[1]}"
+                if idx not in _grouped:
+                    _grouped[idx] = TPMatrices([cast(TPMatrix, mat)])
+                else:
+                    _grouped[idx].tpmats.append(cast(TPMatrix, mat))
+            self._combined_blocks = nnx.Dict(
+                {idx: tpmats_to_kron(list(tpm.tpmats)) for idx, tpm in _grouped.items()}
+            )
+        else:
+            _grouped: dict[str, Matrix | DiaMatrix] = {}
+            for mi in mats:
+                key = f"{mi.global_indices[0]},{mi.global_indices[1]}"
+                if key not in _grouped:
+                    _grouped[key] = cast(DiaMatrix | Matrix, mi.data)
+                else:
+                    _grouped[key] = _grouped[key] + mi.data
+            self._combined_blocks = nnx.Dict(_grouped)
 
     def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:
         shapes = self.test_space.num_dofs
@@ -206,113 +238,25 @@ class _BaseBlockMatrix[SpaceT: CartesianTensorProductSpace | CartesianProductSpa
         M = self.to_matrix()
         return BlockArray(b.cartspace, flat_array=M.solve(x))
 
+    def scale(self, alpha: complex | Array) -> Self:
+        scaled = cast(
+            list[MatrixT],
+            [cast(GlobalMatrix | TPMatrix, m).scale(alpha) for m in self.mats],
+        )
+        return self.__class__(scaled, self.test_space, self.trial_space)
 
-class BlockTPMatrix(_BaseBlockMatrix):
-    """Block matrix of TPMatrix objects for ND CartesianTensorProductSpace.
-
-    Args:
-        tpmats: List of TPMatrix objects.
-        test_space: Leaf CartesianTensorProductSpace for rows.
-        trial_space: Leaf CartesianTensorProductSpace for columns.
-    """
-
-    def __init__(
-        self,
-        tpmats: list[TPMatrix],
-        test_space: CartesianTensorProductSpace,
-        trial_space: CartesianTensorProductSpace,
-    ) -> None:
-        self.tpmats = nnx.List(tpmats)
-        self.test_space = test_space
-        self.trial_space = trial_space
-        self.shape = (self.test_space.dim, self.trial_space.dim)
-        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
-        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
-
-        _grouped: dict[str, TPMatrices] = {}
-        for mat in tpmats:
-            idx = f"{mat.global_indices[0]},{mat.global_indices[1]}"
-            if idx not in _grouped:
-                _grouped[idx] = TPMatrices([mat])
-            else:
-                _grouped[idx].tpmats.append(mat)
-        self._combined_blocks = nnx.Dict(
-            {idx: tpmats_to_kron(list(tpm.tpmats)) for idx, tpm in _grouped.items()}
+    def __add__(self, other: Self) -> Self:
+        return self.__class__(
+            list(self.mats) + list(other.mats), self.test_space, self.trial_space
         )
 
-    def scale(self, alpha: complex | Array) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            [mat.scale(alpha) for mat in self.tpmats], self.test_space, self.trial_space
+    def __sub__(self, other: Self) -> Self:
+        scaled = cast(
+            list[MatrixT],
+            [cast(GlobalMatrix | TPMatrix, m).scale(-1) for m in other.mats],
         )
-
-    def __add__(self, other: BlockTPMatrix) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            list(self.tpmats) + list(other.tpmats), self.test_space, self.trial_space
-        )
-
-    def __sub__(self, other: BlockTPMatrix) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            list(self.tpmats) + [mat.scale(-1) for mat in other.tpmats],
-            self.test_space,
-            self.trial_space,
-        )
-
-
-class BlockMatrix(_BaseBlockMatrix):
-    """Block matrix for 1D CartesianProductSpace.
-
-    Each entry is a single Matrix or DiaMatrix together with its
-    (test_block, trial_block) indices.  Multiple entries that map the same
-    block pair are summed on construction.
-
-    Args:
-        mats: List of IndexedMatrix objects.
-        test_space: Leaf CartesianProductSpace for rows.
-        trial_space: Leaf CartesianProductSpace for columns.
-    """
-
-    def __init__(
-        self,
-        mats: list[IndexedMatrix],
-        test_space: CartesianProductSpace,
-        trial_space: CartesianProductSpace,
-    ) -> None:
-        self.mats = nnx.List(mats)
-        self.test_space = test_space
-        self.trial_space = trial_space
-        self.shape = (self.test_space.dim, self.trial_space.dim)
-        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
-        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
-
-        _grouped: dict[str, Matrix | DiaMatrix] = {}
-        for im in mats:
-            key = f"{im.i[0]},{im.i[1]}"
-            if key not in _grouped:
-                _grouped[key] = im.data
-            else:
-                _grouped[key] = _grouped[key] + im.data
-        self._combined_blocks = nnx.Dict(_grouped)
-
-    def scale(self, alpha: complex | Array) -> BlockMatrix:
-        return BlockMatrix(
-            [IndexedMatrix(im.i, im.data.scale(alpha)) for im in self.mats],
-            self.test_space,
-            self.trial_space,
-        )
-
-    def __add__(self, other: BlockMatrix) -> BlockMatrix:
-        return BlockMatrix(
-            list(self.mats) + list(other.mats),
-            self.test_space,
-            self.trial_space,
-        )
-
-    def __sub__(self, other: BlockMatrix) -> BlockMatrix:
-        return BlockMatrix(
-            list(self.mats)
-            + [IndexedMatrix(im.i, im.data.scale(-1)) for im in other.mats],
-            self.test_space,
-            self.trial_space,
+        return self.__class__(
+            list(self.mats) + scaled, self.test_space, self.trial_space
         )
 
 
@@ -321,7 +265,7 @@ class BlockArray(nnx.Pytree):
 
     Args:
         cartspace: descriptor for the (leaf) space.
-        indexed_arrays: List of IndexedArray objects.
+        indexed_arrays: List of GlobalArray objects.
         flat_array: 1D Array of length cartspace.dim.
         tuple_array: tuple of Arrays for flattened space, one item
             for each space in the flattened space. This
@@ -337,7 +281,7 @@ class BlockArray(nnx.Pytree):
     def __init__(
         self,
         cartspace: CartesianTensorProductSpace | CartesianProductSpace,
-        indexed_arrays: list[IndexedArray] | None = None,
+        indexed_arrays: list[GlobalArray] | None = None,
         flat_array: Array | None = None,
         tuple_array: tuple[Array, ...] | None = None,
     ) -> None:
@@ -372,19 +316,19 @@ class BlockArray(nnx.Pytree):
         a = [d.ravel() for d in self._broadcast_data()]
         return jnp.concatenate(tuple(a))
 
-    def _list_from_flat_array(self, x: Array) -> list[IndexedArray]:
+    def _list_from_flat_array(self, x: Array) -> list[GlobalArray]:
         s0: int = 0
-        d: list[IndexedArray] = []
+        d: list[GlobalArray] = []
         for i, s1 in enumerate(self.block_sizes):
-            d.append(IndexedArray(i, x[slice(s0, s0 + s1)].reshape(self.num_dofs[i])))
+            d.append(GlobalArray(i, x[slice(s0, s0 + s1)].reshape(self.num_dofs[i])))
             s0 += s1
         return d
 
-    def _list_from_tuple_array(self, x: tuple[Array, ...]) -> list[IndexedArray]:
-        return [IndexedArray(i, xi) for i, xi in enumerate(x)]
+    def _list_from_tuple_array(self, x: tuple[Array, ...]) -> list[GlobalArray]:
+        return [GlobalArray(i, xi) for i, xi in enumerate(x)]
 
-    def accumulate(self, b: IndexedArray | list[IndexedArray]) -> None:
-        b_list: list[IndexedArray] = [b] if isinstance(b, IndexedArray) else b
+    def accumulate(self, b: GlobalArray | list[GlobalArray]) -> None:
+        b_list: list[GlobalArray] = [b] if isinstance(b, GlobalArray) else b
         for bi in b_list:
             self.data[bi.i] += bi.data
 

--- a/src/jaxfun/la/blockmatrix.py
+++ b/src/jaxfun/la/blockmatrix.py
@@ -71,11 +71,12 @@ class BlockMatrix[
         else:
             _grouped: dict[str, Matrix | DiaMatrix] = {}
             for mi in mats:
-                key = f"{mi.global_indices[0]},{mi.global_indices[1]}"
+                gm = cast(GlobalMatrix, mi)
+                key = f"{gm.global_indices[0]},{gm.global_indices[1]}"
                 if key not in _grouped:
-                    _grouped[key] = cast(DiaMatrix | Matrix, mi.data)
+                    _grouped[key] = gm.data
                 else:
-                    _grouped[key] = _grouped[key] + mi.data
+                    _grouped[key] = _grouped[key] + gm.data
             self._combined_blocks = nnx.Dict(_grouped)
 
     def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:

--- a/src/jaxfun/la/blocktpmatrix.py
+++ b/src/jaxfun/la/blocktpmatrix.py
@@ -2,64 +2,57 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import jax
 import jax.numpy as jnp
 from flax import nnx
 from jax import Array
 
 from jaxfun.la.diamatrix import DiaMatrix
 from jaxfun.la.matrix import Matrix
-from jaxfun.la.matrixprotocol import BaseMatrix, IndexedArray, _CacheBox
+from jaxfun.la.matrixprotocol import (
+    BaseMatrix,
+    DiaMatrixSolveMethod,
+    IndexedArray,
+    IndexedMatrix,
+    _CacheBox,
+)
 from jaxfun.la.tpmatrix import TPMatrices, TPMatrix, tpmats_to_kron
 
 if TYPE_CHECKING:
     from jaxfun.galerkin import (
         CartesianProductSpace,
+        CartesianTensorProductSpace,
         JAXFunction,
     )
 
 type _SparseMatrixCache = _CacheBox[DiaMatrix]
 
 
-class BlockTPMatrix(BaseMatrix):
-    """Block matrix of TPMatrix objects.
+class _BaseBlockMatrix[SpaceT: CartesianTensorProductSpace | CartesianProductSpace](
+    BaseMatrix
+):
+    """Shared implementation for block matrices over a CartesianProductSpace.
 
-    Args:
-        tpmats: List of TPMatrix objects.
-        test_space: descriptor for the (leaf) test space.
-        trial_space: descriptor for the (leaf) trial space.
-
-    Attributes:
-        blocks: list of TPMatrix objects.
-        test_space, trial_space: VectorTensorProductSpace descriptors.
+    Subclasses supply ``_combined_blocks`` (an ``nnx.Dict`` mapping
+    ``"bi,bj"`` string keys to ``DiaMatrix | Matrix``), ``test_space``,
+    ``trial_space``, ``shape``, ``test_block_sizes`` and
+    ``trial_block_sizes``.  All heavy-lifting methods live here; only
+    construction, ``scale``, ``__add__`` and ``__sub__`` differ per subclass.
     """
 
-    def __init__(
-        self,
-        tpmats: list[TPMatrix],
-        test_space: CartesianProductSpace,
-        trial_space: CartesianProductSpace,
-    ) -> None:
-        self.tpmats = nnx.List(tpmats)
-        self.test_space = test_space
-        self.trial_space = trial_space
-        self.shape = (self.test_space.dim, self.trial_space.dim)
-        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
-        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
+    _combined_blocks: nnx.Dict
+    test_space: SpaceT
+    trial_space: SpaceT
+    test_block_sizes: tuple[int, ...]
+    trial_block_sizes: tuple[int, ...]
+    shape: tuple[int, int]
 
-        # Pre-compute one combined matrix per (test_block, trial_block) pair so
-        # that matvec, todense and tosparse each iterate over at most one entry
-        # per block instead of one entry per contributing TPMatrix.
-        _grouped: dict[str, TPMatrices] = {}
-        for mat in tpmats:
-            idx = f"{mat.global_indices[0]},{mat.global_indices[1]}"
-            if idx not in _grouped:
-                _grouped[idx] = TPMatrices([mat])
-            else:
-                _grouped[idx].tpmats.append(mat)
-        self._combined_blocks = nnx.Dict(
-            {idx: tpmats_to_kron(list(tpm.tpmats)) for idx, tpm in _grouped.items()}
-        )
+    def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:
+        shapes = self.test_space.num_dofs
+        out = [jnp.zeros(shape) for shape in shapes]
+        for s, block_mat in self._combined_blocks.items():
+            bi, bj = map(int, s.split(","))
+            out[bi] = out[bi] + (block_mat @ w[bj].ravel()).reshape(shapes[bi])
+        return tuple(out)
 
     @property
     def dtype(self) -> jnp.dtype:
@@ -68,43 +61,12 @@ class BlockTPMatrix(BaseMatrix):
             dtype = jnp.result_type(dtype, block_mat.dtype)
         return jnp.dtype(dtype)
 
-    def scale(self, alpha: complex | Array) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            [mat.scale(alpha) for mat in self.tpmats],
-            self.test_space,
-            self.trial_space,
-        )
-
-    def __add__(self, other: BlockTPMatrix) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            list(self.tpmats) + list(other.tpmats),
-            self.test_space,
-            self.trial_space,
-        )
-
-    def __sub__(self, other: BlockTPMatrix) -> BlockTPMatrix:
-        return BlockTPMatrix(
-            list(self.tpmats) + [mat.scale(-1) for mat in other.tpmats],
-            self.test_space,
-            self.trial_space,
-        )
-
-    @jax.jit
-    def _matmul_array(self, w: tuple[Array, ...]) -> tuple[Array, ...]:
-        out = []
-        flat_spaces = self.test_space.flatten()
-        for s, block_mat in self._combined_blocks.items():
-            bi, bj = map(int, s.split(","))
-            out.append((block_mat @ w[bj].ravel()).reshape(flat_spaces[bi].num_dofs))
-        return tuple(out)
-
-    def slice(self, indices: tuple[int, ...]) -> tuple[slice, ...]:  # ty:ignore[invalid-type-form]
-        """Return slice object for block matrix indices."""
+    def _block_slice(self, bi: int, bj: int) -> tuple[slice, slice]:
         N = self.test_block_sizes
         M = self.trial_block_sizes
         return (
-            slice(sum(N[: indices[0]]), sum(N[: indices[0] + 1])),
-            slice(sum(M[: indices[1]]), sum(M[: indices[1] + 1])),
+            slice(sum(N[:bi]), sum(N[: bi + 1])),
+            slice(sum(M[:bj]), sum(M[: bj + 1])),
         )
 
     def todense(self) -> Array:
@@ -112,7 +74,7 @@ class BlockTPMatrix(BaseMatrix):
         out = jnp.zeros(self.shape)
         for s, block_mat in self._combined_blocks.items():
             bi, bj = map(int, s.split(","))
-            out = out.at[self.slice((bi, bj))].add(block_mat.todense())
+            out = out.at[self._block_slice(bi, bj)].add(block_mat.todense())
         return out
 
     def to_matrix(self) -> Matrix:
@@ -152,7 +114,6 @@ class BlockTPMatrix(BaseMatrix):
         total_rows = sum(test_block_sizes)
         total_cols = sum(trial_block_sizes)
 
-        # Build per-block DiaMatrix and collect all global diagonal offsets.
         block_dias: dict[tuple[int, int], DiaMatrix] = {}
         global_offsets: set[int] = set()
         for s, block_kron in self._combined_blocks.items():
@@ -169,7 +130,6 @@ class BlockTPMatrix(BaseMatrix):
         sorted_offsets = tuple(sorted(global_offsets))
         offset_to_idx = {k: i for i, k in enumerate(sorted_offsets)}
 
-        # Allocate global DIA data array and scatter each block's diagonals.
         dtype = jnp.result_type(*[d.data.dtype for d in block_dias.values()])
         global_data = jnp.zeros((len(sorted_offsets), total_cols), dtype=dtype)
         for (bi, bj), block_dia in block_dias.items():
@@ -191,10 +151,9 @@ class BlockTPMatrix(BaseMatrix):
     def __call__(self, u: BlockArray | JAXFunction) -> BlockArray:
         """Apply block matrix to coefficient array u.
 
-        Uses the RCM-permuted :class:`~jaxfun.la.DiaMatrix` for a single
-        global matvec when the sparse cache has been populated (e.g. after
-        :meth:`solve` or an explicit :meth:`tosparse` call); otherwise falls
-        back to the per-block path.
+        Uses direct sparse matvec when the sparse cache has been populated
+        (e.g. after :meth:`solve` or an explicit :meth:`tosparse` call);
+        otherwise falls back to the per-block path.
         """
         if not isinstance(u, BlockArray):
             w = BlockArray(self.test_space, tuple_array=u.get_array())
@@ -204,12 +163,7 @@ class BlockTPMatrix(BaseMatrix):
         sparse_box: _SparseMatrixCache | None = getattr(self, "_sparse_cache", None)
         if sparse_box is not None:
             wf = w.flatten()
-            sparse = sparse_box.value
-            if getattr(sparse, "_rcm_cache", None) is not None:
-                A_perm, perm, inv_perm = sparse.rcm()
-                z = A_perm.matvec(wf[perm])[inv_perm]
-            else:
-                z = sparse.matvec(wf)
+            z = sparse_box.value.matvec(wf)
             return BlockArray(self.test_space, flat_array=z)
 
         return BlockArray(self.test_space, tuple_array=self._matmul_array(w.array))
@@ -222,26 +176,144 @@ class BlockTPMatrix(BaseMatrix):
         """Return number of rows (test space dimension)."""
         return self.shape[0]
 
-    def solve(self, b: BlockArray) -> BlockArray:  # ty:ignore[invalid-method-override]
+    def solve(
+        self,
+        b: BlockArray,
+        *,
+        pivot: bool = False,
+        method: DiaMatrixSolveMethod | str = DiaMatrixSolveMethod.AUTO,
+        auto_threshold: int = 100,
+    ) -> BlockArray:  # ty:ignore[invalid-method-override]
         """Solve ``M x = b``.
 
         When all factor matrices are :class:`~jaxfun.la.DiaMatrix` instances,
-        assembles the global sparse matrix via :meth:`tosparse`, applies the
-        reverse Cuthill-McKee permutation to minimise bandwidth, and solves
-        with the banded LU.  The permuted matrix and permutation vectors are
-        cached so repeated solves are cheap.
+        assembles the global sparse matrix via :meth:`tosparse`.
 
-        Falls back to a dense factorisation when any factor is a
-        :class:`~jaxfun.la.Matrix`.
+        Args:
+            b: Right-hand side BlockArray.
+            pivot: Passed to :meth:`lu_factor` (banded and RCM paths only).
+            method: One of ``"auto"``, ``"banded"``, ``"rcm"``, or
+                ``"dense"``.  Default ``"auto"``.
+            auto_threshold: Threshold for the ``"auto"`` method.  Default 100.
         """
         all_dia = all(isinstance(m, DiaMatrix) for m in self._combined_blocks.values())
         x = b.flatten()
         if all_dia:
-            A_perm, perm, inv_perm = self.tosparse().rcm()
-            x_perm = A_perm.solve(x[perm])
-            return BlockArray(b.cartspace, flat_array=x_perm[inv_perm])
+            uh = self.tosparse().lu_solve(
+                x, pivot=pivot, method=method, auto_threshold=auto_threshold
+            )
+            return BlockArray(b.cartspace, flat_array=uh)
         M = self.to_matrix()
         return BlockArray(b.cartspace, flat_array=M.solve(x))
+
+
+class BlockTPMatrix(_BaseBlockMatrix):
+    """Block matrix of TPMatrix objects for ND CartesianTensorProductSpace.
+
+    Args:
+        tpmats: List of TPMatrix objects.
+        test_space: Leaf CartesianTensorProductSpace for rows.
+        trial_space: Leaf CartesianTensorProductSpace for columns.
+    """
+
+    def __init__(
+        self,
+        tpmats: list[TPMatrix],
+        test_space: CartesianTensorProductSpace,
+        trial_space: CartesianTensorProductSpace,
+    ) -> None:
+        self.tpmats = nnx.List(tpmats)
+        self.test_space = test_space
+        self.trial_space = trial_space
+        self.shape = (self.test_space.dim, self.trial_space.dim)
+        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
+        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
+
+        _grouped: dict[str, TPMatrices] = {}
+        for mat in tpmats:
+            idx = f"{mat.global_indices[0]},{mat.global_indices[1]}"
+            if idx not in _grouped:
+                _grouped[idx] = TPMatrices([mat])
+            else:
+                _grouped[idx].tpmats.append(mat)
+        self._combined_blocks = nnx.Dict(
+            {idx: tpmats_to_kron(list(tpm.tpmats)) for idx, tpm in _grouped.items()}
+        )
+
+    def scale(self, alpha: complex | Array) -> BlockTPMatrix:
+        return BlockTPMatrix(
+            [mat.scale(alpha) for mat in self.tpmats], self.test_space, self.trial_space
+        )
+
+    def __add__(self, other: BlockTPMatrix) -> BlockTPMatrix:
+        return BlockTPMatrix(
+            list(self.tpmats) + list(other.tpmats), self.test_space, self.trial_space
+        )
+
+    def __sub__(self, other: BlockTPMatrix) -> BlockTPMatrix:
+        return BlockTPMatrix(
+            list(self.tpmats) + [mat.scale(-1) for mat in other.tpmats],
+            self.test_space,
+            self.trial_space,
+        )
+
+
+class BlockMatrix(_BaseBlockMatrix):
+    """Block matrix for 1D CartesianProductSpace.
+
+    Each entry is a single Matrix or DiaMatrix together with its
+    (test_block, trial_block) indices.  Multiple entries that map the same
+    block pair are summed on construction.
+
+    Args:
+        mats: List of IndexedMatrix objects.
+        test_space: Leaf CartesianProductSpace for rows.
+        trial_space: Leaf CartesianProductSpace for columns.
+    """
+
+    def __init__(
+        self,
+        mats: list[IndexedMatrix],
+        test_space: CartesianProductSpace,
+        trial_space: CartesianProductSpace,
+    ) -> None:
+        self.mats = nnx.List(mats)
+        self.test_space = test_space
+        self.trial_space = trial_space
+        self.shape = (self.test_space.dim, self.trial_space.dim)
+        self.test_block_sizes: tuple[int, ...] = self.test_space.block_sizes
+        self.trial_block_sizes: tuple[int, ...] = self.trial_space.block_sizes
+
+        _grouped: dict[str, Matrix | DiaMatrix] = {}
+        for im in mats:
+            key = f"{im.i[0]},{im.i[1]}"
+            if key not in _grouped:
+                _grouped[key] = im.data
+            else:
+                _grouped[key] = _grouped[key] + im.data
+        self._combined_blocks = nnx.Dict(_grouped)
+
+    def scale(self, alpha: complex | Array) -> BlockMatrix:
+        return BlockMatrix(
+            [IndexedMatrix(im.i, im.data.scale(alpha)) for im in self.mats],
+            self.test_space,
+            self.trial_space,
+        )
+
+    def __add__(self, other: BlockMatrix) -> BlockMatrix:
+        return BlockMatrix(
+            list(self.mats) + list(other.mats),
+            self.test_space,
+            self.trial_space,
+        )
+
+    def __sub__(self, other: BlockMatrix) -> BlockMatrix:
+        return BlockMatrix(
+            list(self.mats)
+            + [IndexedMatrix(im.i, im.data.scale(-1)) for im in other.mats],
+            self.test_space,
+            self.trial_space,
+        )
 
 
 class BlockArray(nnx.Pytree):
@@ -252,19 +324,19 @@ class BlockArray(nnx.Pytree):
         indexed_arrays: List of IndexedArray objects.
         flat_array: 1D Array of length cartspace.dim.
         tuple_array: tuple of Arrays for flattened space, one item
-            for each TensorProductSpace in the flattened space. This
+            for each space in the flattened space. This
             is, e.g., the output from forward/scalar_product.
 
     Attributes:
         data: nnx.List of Arrays representing each block.
         block_sizes: tuple of ints, dim of each block.
         num_dofs: tuple of tuple of ints, num_dof of each block.
-        cartspace: CartesianProductSpace.
+        cartspace: CartesianTensorProductSpace or CartesianProductSpace.
     """
 
     def __init__(
         self,
-        cartspace: CartesianProductSpace,
+        cartspace: CartesianTensorProductSpace | CartesianProductSpace,
         indexed_arrays: list[IndexedArray] | None = None,
         flat_array: Array | None = None,
         tuple_array: tuple[Array, ...] | None = None,

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1213,7 +1213,11 @@ class DiaMatrix(BaseMatrix):
         )
         return DiaMatrix(data=result_data, offsets=all_offsets, shape=(n, m))
 
-    def __add__(self, other):
+    @overload
+    def __add__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __add__(self, other: Matrix) -> Matrix: ...
+    def __add__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
         from jaxfun.la import Matrix
 
         if isinstance(other, DiaMatrix):
@@ -1222,13 +1226,30 @@ class DiaMatrix(BaseMatrix):
             return other + self
         return NotImplemented
 
-    def __sub__(self, other):
+    @overload
+    def __sub__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __sub__(self, other: Matrix) -> Matrix: ...
+    def __sub__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
         from jaxfun.la import Matrix
 
         if isinstance(other, DiaMatrix):
             return self._merge(other, -1.0)
         if isinstance(other, Matrix):
             return Matrix(self.todense() - other.data)
+        return NotImplemented
+
+    @overload
+    def __rsub__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __rsub__(self, other: Matrix) -> Matrix: ...
+    def __rsub__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
+        from jaxfun.la import Matrix
+
+        if isinstance(other, DiaMatrix):
+            return other._merge(self, -1.0)
+        if isinstance(other, Matrix):
+            return Matrix(other.data - self.todense())
         return NotImplemented
 
     @jax.jit
@@ -1602,7 +1623,11 @@ class DiagonalMatrix(DiaMatrix):
     def astype(self, dtype: jnp.dtype) -> DiagonalMatrix:
         return DiagonalMatrix(self.diagonal().astype(dtype))
 
-    def __add__(self, other):
+    @overload
+    def __add__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __add__(self, other: Matrix) -> Matrix: ...
+    def __add__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
         from jaxfun.la import Matrix
 
         if isinstance(other, DiaMatrix):
@@ -1615,11 +1640,39 @@ class DiagonalMatrix(DiaMatrix):
             return other + self
         return NotImplemented
 
-    def __sub__(self, other):
-        return self.__add__(-other)
+    @overload
+    def __sub__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __sub__(self, other: Matrix) -> Matrix: ...
+    def __sub__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
+        from jaxfun.la import Matrix
 
-    def __rsub__(self, other):
-        return (-self).__add__(other)
+        if isinstance(other, DiaMatrix):
+            self._check_same_shape(other)
+            if other.is_diagonal:
+                return DiagonalMatrix(self.diagonal() - other.diagonal())
+            return DiaMatrix.__sub__(self, other)
+        if isinstance(other, Matrix):
+            self._check_same_shape(other)
+            return Matrix(self.todense() - other.data)
+        return NotImplemented
+
+    @overload
+    def __rsub__(self, other: DiaMatrix) -> DiaMatrix: ...
+    @overload
+    def __rsub__(self, other: Matrix) -> Matrix: ...
+    def __rsub__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix:
+        from jaxfun.la import Matrix
+
+        if isinstance(other, DiaMatrix):
+            self._check_same_shape(other)
+            if other.is_diagonal:
+                return DiagonalMatrix(other.diagonal() - self.diagonal())
+            return DiaMatrix.__rsub__(self, other)
+        if isinstance(other, Matrix):
+            self._check_same_shape(other)
+            return Matrix(other.data - self.todense())
+        return NotImplemented
 
 
 @jax.jit(static_argnums=(1, 2, 3))

--- a/src/jaxfun/la/matrix.py
+++ b/src/jaxfun/la/matrix.py
@@ -338,7 +338,7 @@ class Matrix(BaseMatrix):
     def __len__(self) -> int:
         return min(self.shape)
 
-    def __add__(self, other) -> Matrix:
+    def __add__(self, other: DiaMatrix | Matrix) -> Matrix:
         from jaxfun.la import DiaMatrix
 
         if isinstance(other, Matrix):
@@ -347,6 +347,28 @@ class Matrix(BaseMatrix):
         if isinstance(other, DiaMatrix):
             self._check_same_shape(other)
             return Matrix(self.data + other.todense())
+        return NotImplemented
+
+    def __sub__(self, other: DiaMatrix | Matrix) -> Matrix:
+        from jaxfun.la import DiaMatrix
+
+        if isinstance(other, Matrix):
+            self._check_same_shape(other)
+            return Matrix(self.data - other.data)
+        if isinstance(other, DiaMatrix):
+            self._check_same_shape(other)
+            return Matrix(self.data - other.todense())
+        return NotImplemented
+
+    def __rsub__(self, other: DiaMatrix | Matrix) -> Matrix:
+        from jaxfun.la import DiaMatrix
+
+        if isinstance(other, Matrix):
+            self._check_same_shape(other)
+            return Matrix(other.data - self.data)
+        if isinstance(other, DiaMatrix):
+            self._check_same_shape(other)
+            return Matrix(other.todense() - self.data)
         return NotImplemented
 
     def __getitem__(self, idx: int | slice | tuple | Array) -> Array:

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -65,24 +65,6 @@ class _CacheBox[T]:
         return f"_CacheBox({self.value!r})"
 
 
-class IndexedArray(nnx.Pytree):
-    def __init__(self, i: int, data: Array):
-        self.data = data
-        self.i = i
-
-
-class IndexedMatrix(nnx.Pytree):
-    """A Matrix or DiaMatrix tagged with its (test_block, trial_block) indices.
-
-    Used in 1D CartesianProductSpace bilinear form assembly to carry block
-    index information through the assembly pipeline into BlockMatrix.
-    """
-
-    def __init__(self, i: tuple[int, int], data: Matrix | DiaMatrix):
-        self.data = data
-        self.i = i
-
-
 class BaseMatrix(ABC, nnx.Pytree):
     """Nominal base class for matrix-like operators in ``jaxfun.la``.
 

--- a/src/jaxfun/la/matrixprotocol.py
+++ b/src/jaxfun/la/matrixprotocol.py
@@ -71,6 +71,18 @@ class IndexedArray(nnx.Pytree):
         self.i = i
 
 
+class IndexedMatrix(nnx.Pytree):
+    """A Matrix or DiaMatrix tagged with its (test_block, trial_block) indices.
+
+    Used in 1D CartesianProductSpace bilinear form assembly to carry block
+    index information through the assembly pipeline into BlockMatrix.
+    """
+
+    def __init__(self, i: tuple[int, int], data: Matrix | DiaMatrix):
+        self.data = data
+        self.i = i
+
+
 class BaseMatrix(ABC, nnx.Pytree):
     """Nominal base class for matrix-like operators in ``jaxfun.la``.
 

--- a/src/jaxfun/la/operators.py
+++ b/src/jaxfun/la/operators.py
@@ -4,10 +4,10 @@ from math import prod
 from typing import TYPE_CHECKING, Self, overload
 
 import jax.numpy as jnp
+from flax import nnx
 from jax import Array
 
-from jaxfun.la import DiagonalMatrix
-from jaxfun.la.diamatrix import DiaMatrix, diags
+from jaxfun.la.diamatrix import DiagonalMatrix, DiaMatrix, diags
 from jaxfun.la.matrix import Matrix
 from jaxfun.la.matrixprotocol import BaseMatrix
 
@@ -21,6 +21,12 @@ def _as_state_shape(shape: int | tuple[int, ...]) -> tuple[int, ...]:
 
 def _dtype_or_default(dtype) -> jnp.dtype:
     return jnp.dtype(jnp.float32 if dtype is None else dtype)
+
+
+class GlobalArray(nnx.Pytree):
+    def __init__(self, i: int, data: Array):
+        self.data = data
+        self.i = i
 
 
 class SpecialMatrix(BaseMatrix):
@@ -244,3 +250,23 @@ class ZeroMatrix(SpecialMatrix):
 
     def __getitem__(self, key: tuple[int, int], /) -> Array:
         return jnp.zeros((), dtype=self.dtype)
+
+
+class GlobalMatrix(BaseMatrix):
+    data: DiaMatrix | Matrix
+
+    def __init__(self, global_indices: tuple[int, int], matrix: DiaMatrix | Matrix):
+        self.data = matrix
+        self.global_indices = global_indices
+
+    def scale(self, alpha: complex | Array) -> GlobalMatrix:
+        return GlobalMatrix(self.global_indices, self.data.scale(alpha))
+
+    def dtype(self) -> jnp.dtype:
+        return self.data.dtype
+
+    def solve(self, b: Array, axis: int = 0) -> Array:
+        return self.data.solve(b, axis=axis)
+
+    def todense(self) -> Array:
+        return self.data.todense()

--- a/src/jaxfun/la/operators.py
+++ b/src/jaxfun/la/operators.py
@@ -262,6 +262,7 @@ class GlobalMatrix(BaseMatrix):
     def scale(self, alpha: complex | Array) -> GlobalMatrix:
         return GlobalMatrix(self.global_indices, self.data.scale(alpha))
 
+    @property
     def dtype(self) -> jnp.dtype:
         return self.data.dtype
 

--- a/src/jaxfun/la/operators.py
+++ b/src/jaxfun/la/operators.py
@@ -29,6 +29,15 @@ class GlobalArray(nnx.Pytree):
         self.i = i
 
 
+class GlobalMatrix(nnx.Pytree):
+    def __init__(self, global_indices: tuple[int, int], matrix: DiaMatrix | Matrix):
+        self.data = nnx.data(matrix)
+        self.global_indices = nnx.static(global_indices)
+
+    def scale(self, alpha: complex | Array) -> GlobalMatrix:
+        return GlobalMatrix(self.global_indices, self.data.scale(alpha))
+
+
 class SpecialMatrix(BaseMatrix):
     """Base class for shape-preserving special matrix operators."""
 
@@ -325,100 +334,3 @@ class ZeroMatrix(SpecialMatrix):
 
     def __getitem__(self, key: tuple[int, int], /) -> Array:
         return jnp.zeros((), dtype=self.dtype)
-
-
-class _DataDelegatingMixin:
-    """Mixin that delegates all BaseMatrix operations to ``self.data``."""
-
-    data: DiaMatrix | Matrix
-
-    @property
-    def shape(self) -> tuple[int, int]:
-        return self.data.shape
-
-    @property
-    def dtype(self) -> jnp.dtype:
-        return self.data.dtype
-
-    def matvec(self, x: Array, axis: int = 0) -> Array:
-        return self.data.matvec(x, axis=axis)
-
-    def lu_factor(self, **kwargs):
-        return self.data.lu_factor(**kwargs)
-
-    def lu_solve(self, b: Array, axis: int = 0, **kwargs) -> Array:
-        return self.data.lu_solve(b, axis=axis, **kwargs)
-
-    def solve(self, b: Array, axis: int = 0, **kwargs) -> Array:
-        return self.data.solve(b, axis=axis, **kwargs)
-
-    @property
-    def T(self) -> BaseMatrix:
-        return self.data.T
-
-    def diagonal(self, k: int = 0) -> Array:
-        return self.data.diagonal(k)
-
-    def diagonal_or_none(self) -> Array | None:
-        return self.data.diagonal_or_none()
-
-    @property
-    def is_diagonal(self) -> bool:
-        return self.data.is_diagonal
-
-    def todense(self) -> Array:
-        return self.data.todense()
-
-    def tosparse(self, *, tol: int = 100) -> DiaMatrix:
-        return self.data.tosparse(tol=tol)
-
-    def to_matrix(self) -> Matrix:
-        return self.data.to_matrix()
-
-    def get_row(self, i: int | Array) -> Array:
-        return self.data.get_row(i)
-
-    def get_column(self, j: int | Array) -> Array:
-        return self.data.get_column(j)
-
-    @property
-    def size(self) -> int:
-        return self.data.size
-
-    def __call__(self, u: Array | JAXFunction) -> Array:
-        return self.data(u)
-
-    def __getitem__(self, key: tuple[int, int], /) -> Array:
-        return self.data[key]
-
-    def __matmul__(self, other) -> Array:
-        return self.data @ other
-
-    def __rmatmul__(self, other) -> Array:
-        return other @ self.data
-
-    def __add__(self, other):
-        return self.data + other
-
-    def __sub__(self, other):
-        return self.data - other
-
-    def __rsub__(self, other):
-        return other - self.data
-
-    def __len__(self) -> int:
-        return len(self.data)
-
-
-class GlobalMatrix(_DataDelegatingMixin, BaseMatrix):
-    data: DiaMatrix | Matrix
-
-    def __init__(self, global_indices: tuple[int, int], matrix: DiaMatrix | Matrix):
-        self.data = matrix
-        self.global_indices = global_indices
-
-    def scale(self, alpha: complex | Array) -> GlobalMatrix:
-        return GlobalMatrix(self.global_indices, self.data.scale(alpha))
-
-    def astype(self, dtype: jnp.dtype) -> GlobalMatrix:
-        return GlobalMatrix(self.global_indices, self.data.astype(dtype))

--- a/src/jaxfun/la/operators.py
+++ b/src/jaxfun/la/operators.py
@@ -95,11 +95,23 @@ class SpecialMatrix(BaseMatrix):
     def __call__(self, u: Array | JAXFunction) -> Array:
         raise NotImplementedError
 
-    def __matmul__(self, other: Array | JAXFunction) -> Array:
-        return self(other)
+    @overload
+    def __matmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __matmul__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix: ...
+    def __matmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | DiaMatrix | Matrix:
+        return self._as_array(other)
 
-    def __rmatmul__(self, other: Array | JAXFunction) -> Array:
-        return self(other)
+    @overload
+    def __rmatmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix: ...
+    def __rmatmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | DiaMatrix | Matrix:
+        return self._as_array(other)
 
     def __add__(self, other):
         return NotImplemented
@@ -143,57 +155,86 @@ class IdentityMatrix(SpecialMatrix):
         return self._as_array(u)
 
     @overload
+    def __matmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __matmul__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix: ...
+    def __matmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | DiaMatrix | Matrix:
+        if isinstance(other, DiaMatrix | Matrix):
+            self._check_matmul_shape(other)
+            return other
+        return self._as_array(other)
+
+    @overload
+    def __rmatmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: DiaMatrix | Matrix) -> DiaMatrix | Matrix: ...
+    def __rmatmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | DiaMatrix | Matrix:
+        if isinstance(other, DiaMatrix | Matrix):
+            if other.shape[1] != self.shape[0]:
+                raise ValueError(
+                    f"Shape mismatch for matrix product: {other.shape} @ {self.shape}"
+                )
+            return other
+        return self._as_array(other)
+
+    @overload
     def __add__(self, other: ZeroMatrix) -> IdentityMatrix: ...
     @overload
-    def __add__[T](self, other: T) -> T: ...
+    def __add__(self, other: IdentityMatrix) -> DiagonalMatrix: ...
+    @overload
+    def __add__[T: DiaMatrix | Matrix](self, other: T) -> T: ...
     def __add__(self, other):
         if isinstance(other, ZeroMatrix):
             self._check_same_shape(other)
             return self
+        if isinstance(other, DiaMatrix | Matrix):
+            self._check_same_shape(other)
+            return self.scale(1) + other
         if isinstance(other, IdentityMatrix):
             self._check_same_shape(other)
             return self.scale(1) + other.scale(1)
-        if isinstance(other, DiaMatrix):
-            self._check_same_shape(other)
-            return self.scale(1) + other
-        if isinstance(other, Matrix):
-            self._check_same_shape(other)
-            return Matrix(other.data + self.todense())
         return NotImplemented
 
     @overload
     def __sub__(self, other: ZeroMatrix) -> IdentityMatrix: ...
     @overload
-    def __sub__[T](self, other: T) -> T: ...
+    def __sub__(self, other: IdentityMatrix) -> ZeroMatrix: ...
+    @overload
+    def __sub__[T: DiaMatrix | Matrix](self, other: T) -> T: ...
     def __sub__(self, other):
         if isinstance(other, ZeroMatrix):
             self._check_same_shape(other)
             return self
-        if isinstance(other, IdentityMatrix):
-            self._check_same_shape(other)
-            return self.scale(1) - other.scale(1)
-        if isinstance(other, DiaMatrix):
+        if isinstance(other, DiaMatrix | Matrix):
             self._check_same_shape(other)
             return self.scale(1) - other
-        if isinstance(other, Matrix):
+        if isinstance(other, IdentityMatrix):
             self._check_same_shape(other)
-            return self.to_matrix() - other
+            dtype = jnp.result_type(self.dtype, other.dtype)
+            return ZeroMatrix(self.state_shape, dtype=dtype)
         return NotImplemented
 
     @overload
-    def __rsub__(self, other: ZeroMatrix) -> IdentityMatrix: ...
+    def __rsub__(self, other: ZeroMatrix) -> DiagonalMatrix: ...
     @overload
-    def __rsub__[T](self, other: T) -> T: ...
-    def __rsub__[T](self, other: T) -> Self | T:
+    def __rsub__(self, other: IdentityMatrix) -> ZeroMatrix: ...
+    @overload
+    def __rsub__[T: DiaMatrix | Matrix](self, other: T) -> T: ...
+    def __rsub__(self, other):
         if isinstance(other, ZeroMatrix):
             self._check_same_shape(other)
             return -self
-        if isinstance(other, DiaMatrix):
+        if isinstance(other, IdentityMatrix):
             self._check_same_shape(other)
-            return other - self.scale(1)
-        if isinstance(other, Matrix):
+            dtype = jnp.result_type(self.dtype, other.dtype)
+            return ZeroMatrix(self.state_shape, dtype=dtype)
+        if isinstance(other, DiaMatrix | Matrix):
             self._check_same_shape(other)
-            return Matrix(other.data - self.todense())  # ty:ignore[invalid-return-type]
+            return other.__sub__(self.scale(1))
         return NotImplemented
 
 
@@ -237,8 +278,42 @@ class ZeroMatrix(SpecialMatrix):
         w = self._as_array(u)
         return jnp.zeros_like(w)
 
+    @overload
+    def __matmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __matmul__(self, other: DiaMatrix | Matrix) -> Matrix: ...
+    def __matmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | Matrix:
+        if isinstance(other, DiaMatrix | Matrix):
+            self._check_matmul_shape(other)
+            n = self.shape[0]
+            k = other.shape[1]
+            dtype = jnp.result_type(self.dtype, other.dtype)
+            return Matrix(jnp.zeros((n, k), dtype=dtype))
+        w = self._as_array(other)
+        return jnp.zeros_like(w)
+
+    @overload
+    def __rmatmul__(self, other: Array | JAXFunction) -> Array: ...
+    @overload
+    def __rmatmul__(self, other: DiaMatrix | Matrix) -> Matrix: ...
+    def __rmatmul__(
+        self, other: Array | JAXFunction | DiaMatrix | Matrix
+    ) -> Array | Matrix:
+        if isinstance(other, DiaMatrix | Matrix):
+            n, m = self.shape
+            if other.shape[1] != n:
+                raise ValueError(
+                    f"Shape mismatch for matrix product: {other.shape} @ {self.shape}"
+                )
+            dtype = jnp.result_type(self.dtype, other.dtype)
+            return Matrix(jnp.zeros((other.shape[0], m), dtype=dtype))
+        w = self._as_array(other)
+        return jnp.zeros_like(w)
+
     def __add__[T](self, other: T) -> T:
-        if hasattr(other, "shape"):
+        if isinstance(other, BaseMatrix):
             self._check_same_shape(other)
         return other
 
@@ -252,7 +327,90 @@ class ZeroMatrix(SpecialMatrix):
         return jnp.zeros((), dtype=self.dtype)
 
 
-class GlobalMatrix(BaseMatrix):
+class _DataDelegatingMixin:
+    """Mixin that delegates all BaseMatrix operations to ``self.data``."""
+
+    data: DiaMatrix | Matrix
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.data.shape
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        return self.data.dtype
+
+    def matvec(self, x: Array, axis: int = 0) -> Array:
+        return self.data.matvec(x, axis=axis)
+
+    def lu_factor(self, **kwargs):
+        return self.data.lu_factor(**kwargs)
+
+    def lu_solve(self, b: Array, axis: int = 0, **kwargs) -> Array:
+        return self.data.lu_solve(b, axis=axis, **kwargs)
+
+    def solve(self, b: Array, axis: int = 0, **kwargs) -> Array:
+        return self.data.solve(b, axis=axis, **kwargs)
+
+    @property
+    def T(self) -> BaseMatrix:
+        return self.data.T
+
+    def diagonal(self, k: int = 0) -> Array:
+        return self.data.diagonal(k)
+
+    def diagonal_or_none(self) -> Array | None:
+        return self.data.diagonal_or_none()
+
+    @property
+    def is_diagonal(self) -> bool:
+        return self.data.is_diagonal
+
+    def todense(self) -> Array:
+        return self.data.todense()
+
+    def tosparse(self, *, tol: int = 100) -> DiaMatrix:
+        return self.data.tosparse(tol=tol)
+
+    def to_matrix(self) -> Matrix:
+        return self.data.to_matrix()
+
+    def get_row(self, i: int | Array) -> Array:
+        return self.data.get_row(i)
+
+    def get_column(self, j: int | Array) -> Array:
+        return self.data.get_column(j)
+
+    @property
+    def size(self) -> int:
+        return self.data.size
+
+    def __call__(self, u: Array | JAXFunction) -> Array:
+        return self.data(u)
+
+    def __getitem__(self, key: tuple[int, int], /) -> Array:
+        return self.data[key]
+
+    def __matmul__(self, other) -> Array:
+        return self.data @ other
+
+    def __rmatmul__(self, other) -> Array:
+        return other @ self.data
+
+    def __add__(self, other):
+        return self.data + other
+
+    def __sub__(self, other):
+        return self.data - other
+
+    def __rsub__(self, other):
+        return other - self.data
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+
+class GlobalMatrix(_DataDelegatingMixin, BaseMatrix):
     data: DiaMatrix | Matrix
 
     def __init__(self, global_indices: tuple[int, int], matrix: DiaMatrix | Matrix):
@@ -262,12 +420,5 @@ class GlobalMatrix(BaseMatrix):
     def scale(self, alpha: complex | Array) -> GlobalMatrix:
         return GlobalMatrix(self.global_indices, self.data.scale(alpha))
 
-    @property
-    def dtype(self) -> jnp.dtype:
-        return self.data.dtype
-
-    def solve(self, b: Array, axis: int = 0) -> Array:
-        return self.data.solve(b, axis=axis)
-
-    def todense(self) -> Array:
-        return self.data.todense()
+    def astype(self, dtype: jnp.dtype) -> GlobalMatrix:
+        return GlobalMatrix(self.global_indices, self.data.astype(dtype))

--- a/src/jaxfun/la/pinned.py
+++ b/src/jaxfun/la/pinned.py
@@ -233,7 +233,7 @@ class PinnedMatrix(PinnedSystem):
 
     def __init__(
         self,
-        matrix: Matrix | DiaMatrix,
+        matrix: Matrix,
         constraints: tuple[tuple[int, float], ...],
     ) -> None:
         PinnedSystem.__init__(self, matrix, constraints)

--- a/src/jaxfun/operators.py
+++ b/src/jaxfun/operators.py
@@ -29,6 +29,7 @@ from sympy.vector.vector import Vector
 
 from jaxfun.typing import (
     DyadicLike,
+    RankTag,
     TensorLike,
     VectorLike,
     cast_args,
@@ -231,38 +232,23 @@ def cross(v1: VectorLike, v2: VectorLike) -> VectorLike:
     return from_cartesian(cross(v1._sys.to_cartesian(v1), v2._sys.to_cartesian(v2)))
 
 
-type Rank = Literal[0, 1, 2]
 type AdderType = Add | VectorAdd | DyadicAdd
 
 
-@overload
-def _rank_of_dot(t1: VectorLike, t2: VectorLike) -> Literal[0]: ...
-@overload
-def _rank_of_dot(t1: VectorLike, t2: DyadicLike) -> Literal[1]: ...
-@overload
-def _rank_of_dot(t1: DyadicLike, t2: VectorLike) -> Literal[1]: ...
-@overload
-def _rank_of_dot(t1: DyadicLike, t2: DyadicLike) -> Literal[2]: ...
-def _rank_of_dot(t1: TensorLike, t2: TensorLike) -> Rank:
+def _rank_of_dot(t1: TensorLike, t2: TensorLike) -> RankTag:
     if _is_vectorlike(t1):
-        return 0 if _is_vectorlike(t2) else 1
+        return RankTag.SCALAR if _is_vectorlike(t2) else RankTag.VECTOR
     else:
-        return 1 if _is_vectorlike(t2) else 2
+        return RankTag.VECTOR if _is_vectorlike(t2) else RankTag.DYADIC
 
 
-@overload
-def _adder_for(rank: Literal[0]) -> type[Add]: ...
-@overload
-def _adder_for(rank: Literal[1]) -> type[VectorAdd]: ...
-@overload
-def _adder_for(rank: Literal[2]) -> type[DyadicAdd]: ...
-def _adder_for(rank: Rank) -> type[AdderType]:
+def _adder_for(rank: RankTag) -> type[AdderType]:
     match rank:
-        case 0:
+        case RankTag.SCALAR:
             return Add
-        case 1:
+        case RankTag.VECTOR:
             return VectorAdd
-        case 2:
+        case RankTag.DYADIC:
             return DyadicAdd
 
 
@@ -270,19 +256,22 @@ type BasisZero = BasisDependentZero | sp.core.numbers.Zero
 
 
 @overload
-def _zero_for_rank(rank: Literal[0]) -> sp.core.numbers.Zero: ...
+def _zero_for_rank(rank: Literal[RankTag.SCALAR]) -> sp.core.numbers.Zero: ...
 @overload
-def _zero_for_rank(rank: Literal[1]) -> VectorZero: ...
+def _zero_for_rank(rank: Literal[RankTag.VECTOR]) -> VectorZero: ...
 @overload
-def _zero_for_rank(rank: Literal[2]) -> DyadicZero: ...
-def _zero_for_rank(rank: Rank) -> BasisZero:
+def _zero_for_rank(rank: Literal[RankTag.DYADIC]) -> DyadicZero: ...
+@overload
+def _zero_for_rank(rank: RankTag) -> BasisZero: ...
+def _zero_for_rank(rank: RankTag) -> BasisZero:
     match rank:
-        case 0:
+        case RankTag.SCALAR:
             return sp.S.Zero
-        case 1:
+        case RankTag.VECTOR:
             return Vector.zero
-        case 2:
+        case RankTag.DYADIC:
             return Dyadic.zero
+    raise ValueError("rank must be 0, 1 or 2")
 
 
 def fromiter[T: AdderType](cls: type[T], args: Iterator[Expr], **assumptions) -> T:
@@ -438,7 +427,7 @@ def divergence(v: TensorLike) -> VectorLike | Expr:
         3
     """
     v = v.doit()
-    rank = 0 if _is_vectorlike(v) else 1
+    rank = RankTag.SCALAR if _is_vectorlike(v) else RankTag.VECTOR
     if not _is_tensorlike(v):
         raise TypeError("divergence only defined for tensors. Consider using Div.")
     if isinstance(v, BasisDependentZero) or v == sp.S.Zero:
@@ -499,12 +488,12 @@ def gradient(field: Expr | VectorLike, transpose: bool = False) -> TensorLike:
     """
     field = field.doit()
     coord_sys = _get_coord_systems(field)
-    rank = 2 if _is_vectorlike(field) else 1
+    rank = RankTag.DYADIC if _is_vectorlike(field) else RankTag.VECTOR
 
     if isinstance(field, BasisDependentZero) or field == sp.S.Zero:
-        return _zero_for_rank(rank)
+        return cast(TensorLike, _zero_for_rank(rank))
     if len(coord_sys) == 0:
-        return _zero_for_rank(rank)
+        return cast(TensorLike, _zero_for_rank(rank))
     if len(coord_sys) == 1:
         coord_sys = next(iter(coord_sys))
         x = cast_bs(coord_sys.base_scalars())
@@ -895,7 +884,7 @@ def diff_covariant_vector(
     x2i = self._sys._map_base_scalar_to_index
     arg = args[0]
     j = x2i[arg]
-    res = _zero_for_rank(1)
+    res = _zero_for_rank(rank=RankTag.VECTOR)
     for bi, vi in self.components.items():
         i = b2i[bi]
         di = df(vi, arg, **kwargs)
@@ -946,7 +935,7 @@ def diff_covariant_dyadic(
     x2i = self._sys._map_base_scalar_to_index
     arg = args[0]
     k = x2i[arg]
-    res = _zero_for_rank(2)
+    res = _zero_for_rank(RankTag.DYADIC)
     for bij, aij in self.components.items():
         i, j = bb2ij[bij]
         di = df(aij, arg, **kwargs)

--- a/src/jaxfun/pinns/loss.py
+++ b/src/jaxfun/pinns/loss.py
@@ -487,10 +487,12 @@ class ResidualVPINN(Residual):
     def _compute_test_function(self, x: Array) -> dict[str, Array]:
         # The test functions should be evaluated once per derivative count
         # FIXME: only implemented for 1D currently
-        assert not isinstance(
+        if isinstance(
             self.V,
             TensorProductSpace | CartesianProductSpace | CartesianTensorProductSpace,
-        ), "Only implemented for 1D spaces currently"
+        ):
+            raise NotImplementedError("For now only implemented for 1D spaces.")
+
         TD = {
             k: self.V.evaluate_basis_derivative(
                 self.V.map_reference_domain(x[:, 0]), int(k)

--- a/src/jaxfun/pinns/loss.py
+++ b/src/jaxfun/pinns/loss.py
@@ -14,7 +14,12 @@ from jax.flatten_util import ravel_pytree
 from jax.sharding import NamedSharding, PartitionSpec as P
 
 from jaxfun.coordinates import BaseScalar, get_system
-from jaxfun.galerkin import CartesianProductSpace, TensorProductSpace, TestFunction
+from jaxfun.galerkin import (
+    CartesianProductSpace,
+    CartesianTensorProductSpace,
+    TensorProductSpace,
+    TestFunction,
+)
 from jaxfun.galerkin.arguments import ArgumentTag, get_arg
 from jaxfun.typing import Array, Loss_Tuple
 from jaxfun.utils import lambdify
@@ -482,9 +487,10 @@ class ResidualVPINN(Residual):
     def _compute_test_function(self, x: Array) -> dict[str, Array]:
         # The test functions should be evaluated once per derivative count
         # FIXME: only implemented for 1D currently
-        assert not isinstance(self.V, TensorProductSpace | CartesianProductSpace), (
-            "Only implemented for 1D spaces currently"
-        )
+        assert not isinstance(
+            self.V,
+            TensorProductSpace | CartesianProductSpace | CartesianTensorProductSpace,
+        ), "Only implemented for 1D spaces currently"
         TD = {
             k: self.V.evaluate_basis_derivative(
                 self.V.map_reference_domain(x[:, 0]), int(k)

--- a/src/jaxfun/pinns/module.py
+++ b/src/jaxfun/pinns/module.py
@@ -29,7 +29,7 @@ from jaxfun.galerkin import (
 )
 from jaxfun.galerkin.arguments import ArgumentTag
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
-from jaxfun.typing import Activation
+from jaxfun.typing import Activation, RankTag
 from jaxfun.utils.common import Domain, lambdify
 
 from .embeddings import Embedding
@@ -676,7 +676,7 @@ class SpectralModule(BaseModule):
         elif isinstance(self.space, VectorTensorProductSpace):
             z = self.space.evaluate(x, cast(tuple[Array, ...], self.kernel))
 
-        if self.space.rank == 0:
+        if self.space.rank == RankTag.SCALAR:
             return jnp.expand_dims(z, -1)
         return z
 
@@ -972,7 +972,7 @@ class FlaxFunction(Function):
         return obj
 
     @property
-    def rank(self) -> int:
+    def rank(self) -> RankTag:
         """Return tensor rank of the represented field."""
         return self.functionspace.rank
 
@@ -1003,7 +1003,7 @@ class FlaxFunction(Function):
         V = self.functionspace
         args = self.get_args(Cartesian=False)
 
-        if V.rank == 0:
+        if V.rank == RankTag.SCALAR:
             function = cast(
                 Callable[..., AppliedUndef],
                 Function(
@@ -1017,7 +1017,7 @@ class FlaxFunction(Function):
             )
             return function(*args)
 
-        if V.rank == 1:
+        if V.rank == RankTag.VECTOR:
             b = V.system.base_vectors()
             return VectorAdd.fromiter(
                 Function(
@@ -1057,11 +1057,19 @@ class FlaxFunction(Function):
         return ", ".join([i.name for i in self.args[:-1]])
 
     def __str__(self) -> str:
-        name = "\033[1m%s\033[0m" % (self.name,) if self.rank == 1 else self.name  # noqa: UP031
+        name = (
+            "\033[1m%s\033[0m" % (self.name,)  # noqa: UP031
+            if self.rank == RankTag.VECTOR
+            else self.name
+        )
         return f"{name}({self.c_names}; {self.module.name})"
 
     def _latex(self, printer: Any = None) -> str:
-        name = r"\mathbf{ {%s} }" % (self.name,) if self.rank == 1 else self.name  # noqa: UP031
+        name = (
+            r"\mathbf{ {%s} }" % (self.name,)  # noqa: UP031
+            if self.rank == RankTag.VECTOR
+            else self.name
+        )
         return f"{name}({self.c_names}; {self.module.name})"
 
     def _pretty(self, printer: Any = None) -> prettyForm:
@@ -1073,7 +1081,7 @@ class FlaxFunction(Function):
     def __call__(self, x: Array) -> Array:
         """Evaluate underlying module; flatten scalar output if rank 0."""
         y = self.module(x)
-        if self.rank == 0 and y.shape[-1] == 1:
+        if self.rank == RankTag.SCALAR and y.shape[-1] == 1:
             return y[:, 0]
         return y
 

--- a/src/jaxfun/pinns/nnspaces.py
+++ b/src/jaxfun/pinns/nnspaces.py
@@ -13,7 +13,7 @@ from jaxfun.coordinates import (
 )
 from jaxfun.galerkin import Chebyshev
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
-from jaxfun.typing import Activation
+from jaxfun.typing import Activation, RankTag
 from jaxfun.utils.common import Domain
 
 
@@ -44,7 +44,7 @@ class NNSpace(BaseSpace):
     def __init__(
         self,
         dims: int = 1,
-        rank: int = 0,
+        rank: int | RankTag = RankTag.SCALAR,
         transient: bool = False,
         system: CoordSys | None = None,
         name: str = "NN",
@@ -52,10 +52,11 @@ class NNSpace(BaseSpace):
         """Initialize a neural network function space."""
         from jaxfun.coordinates import CartCoordSys, x, y, z
 
+        rank_tag = RankTag(rank) if isinstance(rank, int) else rank
         self.in_size = dims + int(transient)
-        self.out_size = dims**rank
+        self.out_size: int = int(dims**rank_tag.value)
         self.dims = dims
-        self.rank = rank
+        self.rank = rank_tag
         self.is_transient = transient
         system = (
             CartCoordSys("N", {1: (x,), 2: (x, y), 3: (x, y, z)}[dims])
@@ -100,7 +101,7 @@ class MLPSpace(NNSpace):
         self,
         hidden_size: list[int] | int,
         dims: int = 1,
-        rank: int = 0,
+        rank: int | RankTag = RankTag.SCALAR,
         system: CoordSys | None = None,
         transient: bool = False,
         act_fun: Activation = nnx.tanh,
@@ -115,7 +116,7 @@ class MLPSpace(NNSpace):
         self.act_fun = act_fun
 
 
-MLPVectorSpace = partial(MLPSpace, rank=1)
+MLPVectorSpace = partial(MLPSpace, rank=RankTag.VECTOR)
 
 
 class PirateSpace(NNSpace):
@@ -146,7 +147,7 @@ class PirateSpace(NNSpace):
         self,
         hidden_size: Sequence[int] | int,
         dims: int = 1,
-        rank: int = 0,
+        rank: int | RankTag = RankTag.SCALAR,
         system: CoordSys | None = None,
         name: str = "PirateNet",
         transient: bool = False,
@@ -208,7 +209,7 @@ class KANMLPSpace(NNSpace):
         spectral_size: int,
         hidden_size: int | list[int],
         dims: int = 1,
-        rank: int = 0,
+        rank: int | RankTag = RankTag.SCALAR,
         system: CoordSys | None = None,
         name: str = "KANMLP",
         transient: bool = False,
@@ -266,7 +267,7 @@ class sPIKANSpace(NNSpace):
         spectral_size: list[int] | int,
         hidden_size: list[int] | int,
         dims: int = 1,
-        rank: int = 0,
+        rank: int | RankTag = RankTag.SCALAR,
         system: CoordSys | None = None,
         name: str = "sPIKAN",
         transient: bool = False,

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -28,7 +28,7 @@ from sympy.vector import (
 )
 from typing_extensions import TypedDict
 
-from jaxfun.la import BaseMatrix, BlockArray, IndexedArray, IndexedMatrix
+from jaxfun.la import BaseMatrix, BlockArray, GlobalArray, GlobalMatrix
 from jaxfun.la.matrixprotocol import (
     DiaMatrixSolveMethod as DiaMatrixSolveMethod,
     SolverNotApplicable as SolverNotApplicable,
@@ -155,7 +155,7 @@ type DomainType = Literal["inside", "boundary", "intersection", "all"]
 type InnerBilinearResult = Array | BaseMatrix
 type InnerBilinearResults = list[Array | BaseMatrix]
 type InnerLinearResults = list[Array]
-type InnerItems = tuple[list[BaseMatrix | IndexedMatrix], list[IndexedArray]]
+type InnerItems = tuple[list[BaseMatrix | GlobalMatrix], list[GlobalArray]]
 type GalerkinAssembledForm = (
     BaseMatrix | Array | BlockArray | tuple[BaseMatrix, Array | BlockArray]
 )

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from enum import StrEnum
+from enum import Enum, StrEnum, unique
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -149,6 +149,14 @@ class TestSpaceKind(StrEnum):
             return cls(value)  # match by value: "Galerkin", "Petrov-Galerkin"
         except ValueError:
             raise ValueError(f"{value!r} is not a valid {cls.__name__}") from None
+
+
+@unique
+class RankTag(Enum):
+    SCALAR = 0
+    VECTOR = 1
+    DYADIC = 2
+    NONE = -1
 
 
 type DomainType = Literal["inside", "boundary", "intersection", "all"]

--- a/src/jaxfun/typing.py
+++ b/src/jaxfun/typing.py
@@ -28,7 +28,7 @@ from sympy.vector import (
 )
 from typing_extensions import TypedDict
 
-from jaxfun.la import BaseMatrix, BlockArray, IndexedArray
+from jaxfun.la import BaseMatrix, BlockArray, IndexedArray, IndexedMatrix
 from jaxfun.la.matrixprotocol import (
     DiaMatrixSolveMethod as DiaMatrixSolveMethod,
     SolverNotApplicable as SolverNotApplicable,
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from jaxfun.coordinates import BaseDyadic, BaseScalar, BaseVector
     from jaxfun.galerkin import (
         CartesianProductSpace,
+        CartesianTensorProductSpace,
         DirectSum,
         DirectSumTPS,
         TensorProductSpace,
@@ -52,6 +53,7 @@ type FunctionSpaceType = (
     OrthogonalSpace
     | TensorProductSpace
     | VectorTensorProductSpace
+    | CartesianTensorProductSpace
     | CartesianProductSpace
     | DirectSum
     | DirectSumTPS
@@ -61,6 +63,7 @@ type TestSpaceType = (
     OrthogonalSpace
     | TensorProductSpace
     | VectorTensorProductSpace
+    | CartesianTensorProductSpace
     | CartesianProductSpace
 )
 type ComputationalSpaceType = (
@@ -152,7 +155,7 @@ type DomainType = Literal["inside", "boundary", "intersection", "all"]
 type InnerBilinearResult = Array | BaseMatrix
 type InnerBilinearResults = list[Array | BaseMatrix]
 type InnerLinearResults = list[Array]
-type InnerItems = tuple[list[BaseMatrix], list[IndexedArray]]
+type InnerItems = tuple[list[BaseMatrix | IndexedMatrix], list[IndexedArray]]
 type GalerkinAssembledForm = (
     BaseMatrix | Array | BlockArray | tuple[BaseMatrix, Array | BlockArray]
 )

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -36,6 +36,7 @@ from jaxfun.galerkin.composite import DirectSum
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
 from jaxfun.la import BlockArray, BlockMatrix, GlobalArray
+from jaxfun.typing import RankTag
 from jaxfun.utils.common import ulp
 
 pytestmark = pytest.mark.integration
@@ -84,7 +85,7 @@ def test_heterogeneous_space_properties():
     W, T0, T1 = _two_component_space(N)
     assert isinstance(W, CartesianTensorProductSpace)
     assert not isinstance(W, VectorTensorProductSpace)
-    assert W.rank == -1
+    assert W.rank == RankTag.NONE
     assert W.dims == 2
     assert W.num_components == 2
     assert W.dim == T0.dim + T1.dim
@@ -395,7 +396,7 @@ def test_1d_cartesian_product_space_properties():
     assert isinstance(C, CartesianProductSpace)
     assert not isinstance(C, CartesianTensorProductSpace)
     assert C.dims == 1
-    assert C.rank == -1
+    assert C.rank == RankTag.NONE
     assert C.num_components == 2
     assert C.dim == L0.dim + L1.dim
     assert C.block_sizes == (L0.dim, L1.dim)

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -611,7 +611,7 @@ def test_1d_coupled_system_solve():
     H = A + B
     h = cast(BlockArray, a)
 
-    uh = H.solve(h, method="banded", pivot=True)
+    uh = H.solve(h, method="banded", pivot=True, auto_threshold=200)
     assert isinstance(uh, BlockArray)
 
     # Residual check

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -35,7 +35,7 @@ from jaxfun.galerkin.cartesianproductspace import (
 from jaxfun.galerkin.composite import DirectSum
 from jaxfun.galerkin.functionspace import FunctionSpace
 from jaxfun.galerkin.orthogonal import OrthogonalSpace
-from jaxfun.la import BlockArray, BlockMatrix, BlockTPMatrix, IndexedArray
+from jaxfun.la import BlockArray, BlockMatrix, GlobalArray
 from jaxfun.utils.common import ulp
 
 pytestmark = pytest.mark.integration
@@ -182,9 +182,9 @@ def test_block_array_arithmetic():
 def test_block_array_accumulate():
     W, T0, T1 = _two_component_space(N)
     ba = BlockArray(W)
-    ba.accumulate(IndexedArray(0, jnp.ones(T0.num_dofs)))
-    ba.accumulate(IndexedArray(0, jnp.ones(T0.num_dofs)))
-    ba.accumulate(IndexedArray(1, jnp.ones(T1.num_dofs) * 5.0))
+    ba.accumulate(GlobalArray(0, jnp.ones(T0.num_dofs)))
+    ba.accumulate(GlobalArray(0, jnp.ones(T0.num_dofs)))
+    ba.accumulate(GlobalArray(1, jnp.ones(T1.num_dofs) * 5.0))
     assert jnp.allclose(ba[0], 2.0)
     assert jnp.allclose(ba[1], 5.0)
 
@@ -216,12 +216,12 @@ def test_trialfunction_testfunction_unpack_nested():
 # 4. inner() over heterogeneous CartesianProductSpace
 #
 # Each inner() call handles one (test_block, trial_block) coupling.
-# Combine the resulting BlockTPMatrix objects with +.
+# Combine the resulting BlockMatrix objects with +.
 # ---------------------------------------------------------------------------
 
 
-def test_inner_per_block_returns_blocktpmatrix():
-    """Each individual inner() call over a component of W returns a BlockTPMatrix."""
+def test_inner_per_block_returns_blockmatrix():
+    """Each individual inner() call over a component of W returns a BlockMatrix."""
     W, T0, T1 = _two_component_space(N)
     u, p = TrialFunction(W, name="up")
     v, q = TestFunction(W, name="vq")
@@ -229,14 +229,14 @@ def test_inner_per_block_returns_blocktpmatrix():
     A0 = inner(v * u, sparse=True, kind="bilinear", num_quad_points=(N, N))
     A1 = inner(q * p, sparse=True, kind="bilinear", num_quad_points=(N, N))
 
-    assert isinstance(A0, BlockTPMatrix)
-    assert isinstance(A1, BlockTPMatrix)
+    assert isinstance(A0, BlockMatrix)
+    assert isinstance(A1, BlockMatrix)
     assert A0.shape == (W.dim, W.dim)
     assert A1.shape == (W.dim, W.dim)
 
 
 def test_inner_block_sum_is_block_diagonal():
-    """Adding per-block matrices gives a block-diagonal BlockTPMatrix."""
+    """Adding per-block matrices gives a block-diagonal BlockMatrix."""
     W, T0, T1 = _two_component_space(N)
     u, p = TrialFunction(W, name="up")
     v, q = TestFunction(W, name="vq")
@@ -244,7 +244,7 @@ def test_inner_block_sum_is_block_diagonal():
     A = inner(v * u, sparse=True, kind="bilinear", num_quad_points=(N, N)) + inner(
         q * p, sparse=True, kind="bilinear", num_quad_points=(N, N)
     )
-    assert isinstance(A, BlockTPMatrix)
+    assert isinstance(A, BlockMatrix)
     dense = A.todense()
     assert dense.shape == (W.dim, W.dim)
     s0 = T0.dim
@@ -272,7 +272,7 @@ def test_inner_system_heterogeneous_solve():
     A = A0 + A1
     b = cast(BlockArray, b0) + cast(BlockArray, b1)
 
-    assert isinstance(A, BlockTPMatrix)
+    assert isinstance(A, BlockMatrix)
     assert isinstance(b, BlockArray)
 
     x_joint = A.solve(b)

--- a/tests/galerkin/test_cartesian_product.py
+++ b/tests/galerkin/test_cartesian_product.py
@@ -29,9 +29,13 @@ from jaxfun.galerkin import (
 from jaxfun.galerkin.cartesianproductspace import (
     CartesianProduct,
     CartesianProductSpace,
+    CartesianTensorProductSpace,
     VectorTensorProductSpace,
 )
-from jaxfun.la import BlockArray, BlockTPMatrix, IndexedArray
+from jaxfun.galerkin.composite import DirectSum
+from jaxfun.galerkin.functionspace import FunctionSpace
+from jaxfun.galerkin.orthogonal import OrthogonalSpace
+from jaxfun.la import BlockArray, BlockMatrix, BlockTPMatrix, IndexedArray
 from jaxfun.utils.common import ulp
 
 pytestmark = pytest.mark.integration
@@ -78,7 +82,7 @@ def _stokes_like_space(N: int):
 
 def test_heterogeneous_space_properties():
     W, T0, T1 = _two_component_space(N)
-    assert isinstance(W, CartesianProductSpace)
+    assert isinstance(W, CartesianTensorProductSpace)
     assert not isinstance(W, VectorTensorProductSpace)
     assert W.rank == -1
     assert W.dims == 2
@@ -352,3 +356,268 @@ def test_forward_backward_roundtrip():
     assert ua.shape == u_stacked.shape
     assert jnp.linalg.norm(ua[0] - u0) < jnp.sqrt(ulp(100))
     assert jnp.linalg.norm(ua[1] - u1) < jnp.sqrt(ulp(100))
+
+
+# ===========================================================================
+# 1D CartesianProductSpace and BlockMatrix
+# ===========================================================================
+#
+# These tests cover CartesianProduct of OrthogonalSpace (or DirectSum)
+# components, which produces a CartesianProductSpace (dims=1), and the
+# corresponding BlockMatrix assembled by inner().
+#
+# API note: like the ND case, each inner() call handles one
+# (test_block, trial_block) coupling; combine results with +.
+# ===========================================================================
+
+
+def _1d_two_component_space(N: int):
+    """C = CartesianProduct(L0, L1) — two Legendre spaces of different sizes."""
+    L0 = Legendre.Legendre(N)
+    L1 = Legendre.Legendre(N - 2)
+    return CartesianProduct(L0, L1, name="C"), L0, L1
+
+
+def _1d_two_component_space_with_bcs(N: int):
+    """C = CartesianProduct(D, S) — Legendre with and without Dirichlet BCs."""
+    D = FunctionSpace(N, Legendre.Legendre, bcs={"left": {"D": 0}, "right": {"D": 0}})
+    S = FunctionSpace(N, Legendre.Legendre)
+    return CartesianProduct(D, S, name="C"), D, S
+
+
+# ---------------------------------------------------------------------------
+# 7. 1D Space structure
+# ---------------------------------------------------------------------------
+
+
+def test_1d_cartesian_product_space_properties():
+    C, L0, L1 = _1d_two_component_space(N)
+    assert isinstance(C, CartesianProductSpace)
+    assert not isinstance(C, CartesianTensorProductSpace)
+    assert C.dims == 1
+    assert C.rank == -1
+    assert C.num_components == 2
+    assert C.dim == L0.dim + L1.dim
+    assert C.block_sizes == (L0.dim, L1.dim)
+
+
+def test_1d_cartesian_product_flatten_and_global_index():
+    C, _, _ = _1d_two_component_space(N)
+    flat = C.flatten()
+    assert len(flat) == 2
+    assert all(isinstance(s, OrthogonalSpace) for s in flat)
+    s0, s1 = flat
+    assert isinstance(s0, OrthogonalSpace) and isinstance(s1, OrthogonalSpace)
+    assert s0.global_index == 0
+    assert s1.global_index == 1
+    assert s0.leaf is C
+    assert s1.leaf is C
+
+
+def test_1d_cartesian_product_num_dofs_normalized():
+    """num_dofs wraps bare int from OrthogonalSpace into a 1-tuple."""
+    C, L0, L1 = _1d_two_component_space(N)
+    nd = C.num_dofs
+    assert nd == ((L0.num_dofs,), (L1.num_dofs,))
+
+
+# ---------------------------------------------------------------------------
+# 8. 1D BlockArray
+# ---------------------------------------------------------------------------
+
+
+def test_1d_block_array_from_flat_roundtrip():
+    C, L0, L1 = _1d_two_component_space(N)
+    x0 = jnp.arange(L0.dim, dtype=float)
+    x1 = jnp.arange(L1.dim, dtype=float) + L0.dim
+    flat = BlockArray(C, tuple_array=(x0, x1)).flatten()
+    ba = BlockArray(C, flat_array=flat)
+    assert jnp.allclose(ba[0], x0)
+    assert jnp.allclose(ba[1], x1)
+
+
+def test_1d_block_array_arithmetic():
+    C, L0, L1 = _1d_two_component_space(N)
+    a = BlockArray(C, tuple_array=(jnp.ones(L0.dim), jnp.ones(L1.dim) * 2.0))
+    b = BlockArray(C, tuple_array=(jnp.ones(L0.dim) * 3.0, jnp.ones(L1.dim) * 4.0))
+    assert jnp.allclose((a + b)[0], 4.0) and jnp.allclose((a + b)[1], 6.0)
+    assert jnp.allclose((a - b)[0], -2.0) and jnp.allclose((a - b)[1], -2.0)
+    assert jnp.allclose((2.0 * a)[0], 2.0) and jnp.allclose((a * 2.0)[1], 4.0)
+    assert jnp.allclose((-a)[0], -1.0)
+
+
+# ---------------------------------------------------------------------------
+# 9. 1D TrialFunction / TestFunction unpacking
+# ---------------------------------------------------------------------------
+
+
+def test_1d_trial_test_function_unpack():
+    C, L0, L1 = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    assert u.functionspace.dim == L0.dim
+    assert p.functionspace.dim == L1.dim
+    assert v.functionspace.dim == L0.dim
+    assert q.functionspace.dim == L1.dim
+
+
+def test_1d_component_global_index_after_unpack():
+    """After unpacking, each component's global_index matches its block position."""
+    C, _, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    fs_u = u.functionspace
+    fs_p = p.functionspace
+    assert isinstance(fs_u, OrthogonalSpace | DirectSum)
+    assert isinstance(fs_p, OrthogonalSpace | DirectSum)
+    assert fs_u.global_index == 0
+    assert fs_p.global_index == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. inner() over 1D CartesianProductSpace → BlockMatrix
+# ---------------------------------------------------------------------------
+
+
+def test_1d_inner_bilinear_returns_block_matrix():
+    C, _, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    A0 = inner(v * u, kind="bilinear")
+    A1 = inner(q * p, kind="bilinear")
+    assert isinstance(A0, BlockMatrix)
+    assert isinstance(A1, BlockMatrix)
+    assert A0.shape == (C.dim, C.dim)
+    assert A1.shape == (C.dim, C.dim)
+
+
+def test_1d_inner_block_sum_is_block_diagonal():
+    """Block-diagonal L2 mass matrix has zero off-diagonal coupling blocks."""
+    C, L0, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    A = inner(v * u, kind="bilinear") + inner(q * p, kind="bilinear")
+    assert isinstance(A, BlockMatrix)
+    dense = A.todense()
+    assert dense.shape == (C.dim, C.dim)
+    s0 = L0.dim
+    assert jnp.allclose(dense[:s0, s0:], 0.0, atol=1e-12)
+    assert jnp.allclose(dense[s0:, :s0], 0.0, atol=1e-12)
+
+
+def test_1d_inner_linear_block_routing():
+    """inner(x*q) places the result in block 1 (q is the block-1 test function)."""
+    C, _, _ = _1d_two_component_space(N)
+    _, q = TestFunction(C, name="vq")
+    x = C.system.x
+    b = cast(BlockArray, inner(x * q, kind="linear"))
+    assert jnp.linalg.norm(b[0]) < ulp(100), "block 0 should be zero"
+    assert jnp.linalg.norm(b[1]) > ulp(100), "block 1 should be nonzero"
+
+
+def test_1d_inner_linear_block_routing_first_block():
+    """inner(x*v) places the result in block 0 (v is the block-0 test function)."""
+    C, _, _ = _1d_two_component_space(N)
+    v, _ = TestFunction(C, name="vq")
+    x = C.system.x
+    b = cast(BlockArray, inner(x * v, kind="linear"))
+    assert jnp.linalg.norm(b[0]) > ulp(100), "block 0 should be nonzero"
+    assert jnp.linalg.norm(b[1]) < ulp(100), "block 1 should be zero"
+
+
+# ---------------------------------------------------------------------------
+# 11. BlockMatrix linear algebra
+# ---------------------------------------------------------------------------
+
+
+def test_1d_block_matrix_matvec():
+    C, L0, L1 = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    A = inner(v * u, kind="bilinear") + inner(q * p, kind="bilinear")
+    ones = BlockArray(C, flat_array=jnp.ones(C.dim))
+    result = A @ ones
+    assert isinstance(result, BlockArray)
+    assert result[0].shape == (L0.dim,)
+    assert result[1].shape == (L1.dim,)
+
+
+def test_1d_block_matrix_scale():
+    C, _, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    A = inner(v * u, kind="bilinear") + inner(q * p, kind="bilinear")
+    assert isinstance(A, BlockMatrix)
+    A2 = A.scale(2.0)
+    assert isinstance(A2, BlockMatrix)
+    assert jnp.allclose(A2.todense(), 2.0 * A.todense(), atol=ulp(100))
+
+
+def test_1d_block_matrix_add_sub():
+    C, _, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    A = inner(v * u, kind="bilinear") + inner(q * p, kind="bilinear")
+    assert isinstance(A, BlockMatrix)
+    A2 = A + A
+    assert jnp.allclose(A2.todense(), 2.0 * A.todense(), atol=ulp(100))
+    A0 = A2 - A
+    assert jnp.allclose(A0.todense(), A.todense(), atol=ulp(100))
+
+
+def test_1d_block_matrix_solve_residual():
+    """Solve A x = b and verify ‖A x - b‖ < tol."""
+    C, _, _ = _1d_two_component_space(N)
+    u, p = TrialFunction(C, name="up")
+    v, q = TestFunction(C, name="vq")
+    x = C.system.x
+    A = inner(v * u, kind="bilinear") + inner(q * p, kind="bilinear")
+    assert isinstance(A, BlockMatrix)
+    b0 = cast(BlockArray, inner(x * v, kind="linear"))
+    b1 = cast(BlockArray, inner(x * q, kind="linear"))
+    b = b0 + b1
+    uh = A.solve(b)
+    assert isinstance(uh, BlockArray)
+    res = A @ uh
+    assert jnp.linalg.norm(res.flatten() - b.flatten()) < ulp(100)
+
+
+# ---------------------------------------------------------------------------
+# 12. Coupled 1D system — mixed formulation
+#
+# Poisson in first-order form:  s = u',  -s' = f
+#   Test with v:  (s, v) = (u', v)  →  inner(s*v) = inner(u.diff(x)*v)
+#   Test with q: -(s', q) = (f, q)  →  inner(s.diff(x)*q) = -inner(f*q)
+# Manufactured solution: u_e(x) = sin(πx), domain [-1,1].
+# ---------------------------------------------------------------------------
+
+
+def test_1d_coupled_system_solve():
+    """Mixed Poisson assembled over a 1D CartesianProductSpace.
+
+    System (first-order form): s' = u'',  u' = s.
+    Manufactured solution: u_e = sin(πx), BCs homogeneous Dirichlet.
+    Mirrors the coupled1D.py example.
+    """
+    C, D, _ = _1d_two_component_space_with_bcs(N)
+    u, s = TrialFunction(C, name="us")
+    v, q = TestFunction(C, name="vq")
+    x = C.system.x
+    ue = sp.sin(sp.pi * x)
+
+    A, a = inner(s.diff(x) * v - ue.diff(x, 2) * v, kind="system", sparse=True)
+    B = inner(u.diff(x) * q - s * q, kind="bilinear", sparse=True)
+
+    H = A + B
+    h = cast(BlockArray, a)
+
+    uh = H.solve(h, method="banded", pivot=True)
+    assert isinstance(uh, BlockArray)
+
+    # Residual check
+    assert jnp.linalg.norm((H @ uh).flatten() - h.flatten()) < ulp(100)
+
+    # Solution accuracy: evaluate u (block 0) on quadrature mesh
+    xj = D.mesh()
+    u_phys = C.backward(uh)[0]
+    ue_phys = jnp.sin(jnp.pi * xj)
+    assert jnp.linalg.norm(u_phys - ue_phys) < jnp.sqrt(ulp(100))

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -70,7 +70,7 @@ def test_forward_backward_2d_spmd(space0, space1) -> None:
 )
 def test_scalar_product_2d_spmd(space0, space1) -> None:
     T = TensorProduct(space0(8), space1(8))
-    u = jax.device_put(jnp.ones(T.shape()), physical_sharding)
+    u = jax.device_put(jnp.ones(T.shape), physical_sharding)
     uh = T.scalar_product(u)
     assert uh.sharding == spectral_sharding
 
@@ -109,7 +109,7 @@ def test_forward_backward_3d_spmd(space0, space1, space2) -> None:
 )
 def test_scalar_product_3d_spmd(space0, space1, space2) -> None:
     T = TensorProduct(space0(8), space1(8), space2(8))
-    u = jax.device_put(jnp.ones(T.shape()), physical_sharding)
+    u = jax.device_put(jnp.ones(T.shape), physical_sharding)
     uh = T.scalar_product(u)
     assert uh.sharding == spectral_sharding
 

--- a/tests/galerkin/test_tensorproductspace.py
+++ b/tests/galerkin/test_tensorproductspace.py
@@ -115,7 +115,7 @@ def test_vectortensorproductspace_padded_backward_forward_truncation_roundtrip()
     )
     u = JAXFunction(coeffs, V)
 
-    ua = V.backward(cast(tuple[Array, ...], u.array), N=(pad, pad))
+    ua = V.backward(cast(tuple[Array, ...], u.array), N=pad)
     coeffs_rt = V.forward(ua)
 
     assert ua[0].shape == pad and ua[1].shape == pad

--- a/tests/la/test_tpmatrices_solvers.py
+++ b/tests/la/test_tpmatrices_solvers.py
@@ -20,7 +20,7 @@ from jaxfun.galerkin.inner import inner
 from jaxfun.la import (
     BaseMatrix,
     BlockArray,
-    BlockTPMatrix,
+    BlockMatrix,
     TPMatrices,
     TPMatrix,
     tpmats_to_kron,
@@ -329,7 +329,7 @@ def test_tpmatrices_solve_fourier_fourier_legendre_3d():
 
 
 # ---------------------------------------------------------------------------
-# BlockTPMatrix
+# BlockMatrix
 # ---------------------------------------------------------------------------
 
 BCS_VEC = {"left": {"D": 0}, "right": {"D": 0}}
@@ -349,7 +349,7 @@ def _vector_block_system(N: int, poly):
     u = TrialFunction(V)
     v = TestFunction(V)
     A = inner(Dot(v, u), sparse=True)
-    assert isinstance(A, BlockTPMatrix)
+    assert isinstance(A, BlockMatrix)
     assert isinstance(A, BaseMatrix)
     rng = np.random.default_rng(0)
     x_true = jnp.array(rng.standard_normal(A.shape[1]))
@@ -358,7 +358,7 @@ def _vector_block_system(N: int, poly):
 
 
 @POLY_SPACES
-def test_blocktpmatrix_tosparse_returns_diamatrix(poly):
+def test_blockmatrix_tosparse_returns_diamatrix(poly):
     A, b, _ = _vector_block_system(8, poly)
     sparse = A.tosparse()
     assert A.ndim == 2
@@ -367,7 +367,7 @@ def test_blocktpmatrix_tosparse_returns_diamatrix(poly):
 
 
 @POLY_SPACES
-def test_blocktpmatrix_solve_sparse_matches_dense(poly):
+def test_blockmatrix_solve_sparse_matches_dense(poly):
     A, b, x_true = _vector_block_system(8, poly)
     # Dense reference
     x_dense = A.to_matrix().solve(b.flatten())
@@ -378,7 +378,7 @@ def test_blocktpmatrix_solve_sparse_matches_dense(poly):
 
 
 @POLY_SPACES
-def test_blocktpmatrix_rcm_reduces_bandwidth(poly):
+def test_blockmatrix_rcm_reduces_bandwidth(poly):
     A, _, _ = _vector_block_system(8, poly)
     sparse = A.tosparse()
     A_perm, _, _ = sparse.rcm()
@@ -388,7 +388,7 @@ def test_blocktpmatrix_rcm_reduces_bandwidth(poly):
 
 
 @POLY_SPACES
-def test_blocktpmatrix_call_matches_dense_matvec(poly):
+def test_blockmatrix_call_matches_dense_matvec(poly):
     A, b, x_true = _vector_block_system(8, poly)
     # Warm the RCM cache via solve
     _ = A.solve(b)
@@ -398,7 +398,7 @@ def test_blocktpmatrix_call_matches_dense_matvec(poly):
 
 
 @POLY_SPACES
-def test_blocktpmatrix_solve_cached_rcm(poly):
+def test_blockmatrix_solve_cached_rcm(poly):
     """Second solve reuses cached RCM without reassembly."""
     A, b, _ = _vector_block_system(8, poly)
     x1 = A.solve(b)

--- a/tests/pinns/test_kan_spikan.py
+++ b/tests/pinns/test_kan_spikan.py
@@ -6,6 +6,7 @@ from flax import nnx
 
 from jaxfun.coordinates import BaseTime, CartCoordSys, x
 from jaxfun.pinns import module as mod, nnspaces as nns
+from jaxfun.typing import RankTag
 
 pytestmark = pytest.mark.pinn
 
@@ -31,7 +32,7 @@ def test_kanlayer_forward_shape_and_params():
 def test_kanmlpspace_basic_attributes():
     V = nns.KANMLPSpace(spectral_size=5, hidden_size=[8, 4], dims=2)
     assert V.dims == 2
-    assert V.rank == 0
+    assert V.rank == RankTag.SCALAR
     assert V.out_size == 1
     assert V.in_size >= 2
     bv = V.base_variables()
@@ -62,7 +63,7 @@ def test_spikanspace_basic_attributes():
         name="sPIKAN",
     )
     assert V.dims == 2
-    assert V.rank == 1
+    assert V.rank == RankTag.VECTOR
     assert V.out_size == 2
     assert V.in_size == 2
     bv = V.base_variables()
@@ -72,7 +73,7 @@ def test_spikanspace_basic_attributes():
 def test_spikanspace_hidden_size_1():
     V = nns.sPIKANSpace(spectral_size=6, hidden_size=1, dims=1, rank=0)
     assert V.dims == 1
-    assert V.rank == 0
+    assert V.rank == RankTag.SCALAR
     assert V.out_size == 1
     assert V.in_size == 1
     assert V.act_fun(1) == 1
@@ -81,7 +82,7 @@ def test_spikanspace_hidden_size_1():
 def test_kanmplspace_hidden_size_1():
     V = nns.KANMLPSpace(spectral_size=6, hidden_size=1, dims=1, rank=0)
     assert V.dims == 1
-    assert V.rank == 0
+    assert V.rank == RankTag.SCALAR
     assert V.out_size == 1
     assert V.in_size == 1
     assert V.act_fun(1) == 1

--- a/tests/pinns/test_nnspaces.py
+++ b/tests/pinns/test_nnspaces.py
@@ -4,6 +4,7 @@ import sympy as sp
 
 from jaxfun.coordinates import BaseScalar, BaseTime
 from jaxfun.pinns.nnspaces import MLPSpace, MLPVectorSpace, NNSpace, PirateSpace
+from jaxfun.typing import RankTag
 
 pytestmark = pytest.mark.pinn
 
@@ -15,7 +16,7 @@ def test_nnspace_basic_attributes_and_out_size():
     # out_size computed as dims ** rank
     assert ns.out_size == 3**2
     assert ns.dims == 3
-    assert ns.rank == 2
+    assert ns.rank == RankTag.DYADIC
     assert ns.is_transient is False
     # base_variables should contain spatial BaseScalar objects only
     bv = ns.base_variables()
@@ -52,7 +53,7 @@ def test_mlpspace_sets_hidden_and_activation_callable():
 def test_mlpvectorspace_partial_sets_rank_one():
     vec = MLPVectorSpace(hidden_size=5, dims=2, transient=False, name="vecspace")
     # partial should have applied rank=1
-    assert vec.rank == 1
+    assert vec.rank == RankTag.VECTOR
     # hidden_size should be stored as given
     assert vec.hidden_size == 5
 


### PR DESCRIPTION
## Summary

Extends `CartesianProduct` to support 1D mixed-variable formulations, in addition to the existing ND support. Previously `CartesianProduct` only accepted `TensorProductSpace` components; it now also accepts `OrthogonalSpace` / `DirectSum` components and returns the appropriate class.

Also consolidates `BlockTPMatrix` and the old `CartesianProductSpace` (ND-only) into a cleaner class hierarchy, and unifies the block-matrix infrastructure into a single `BlockMatrix` that handles both 1D and ND Cartesian product spaces.

## Types of Changes

- [x] Bug fix
- [x] New feature
- [x] Refactor / cleanup

## Related Issues

Refs #49

## Description of Changes

**Class hierarchy**

- `CartesianBaseSpace` (new abstract base) holds all shared logic (`evaluate_mesh`, `backward`, `forward`, `scalar_product`, `to_orthogonal`, `from_orthogonal`, `block_sizes`, `dim`, `shape`, `num_dofs`).
- `CartesianTensorProductSpace` (renamed from `CartesianProductSpace`) — ND composite, components are `TensorProductSpace` / `DirectSumTPS`.
- `CartesianProductSpace` (new) — 1D composite, components are `OrthogonalSpace` / `DirectSum`. Overrides `backward`, `evaluate_mesh`, and `backward_primitive` with scalar `N: int | None` signatures appropriate for 1D spaces.
- `VectorTensorProductSpace` now inherits from `CartesianTensorProductSpace`.
- `CartesianProduct` factory dispatches based on `dims`: all-1D → `CartesianProductSpace`, all-ND → `CartesianTensorProductSpace` (or `VectorTensorProductSpace` for `rank=1`). Mixed dims are rejected with `AssertionError`.

**Block matrix infrastructure**

- `BlockTPMatrix` removed; replaced by a single generic `BlockMatrix[MatrixT, SpaceT]` that handles both `TPMatrix`-based (ND) and `GlobalMatrix`-based (1D) blocks.
- `IndexedArray` removed; replaced by `GlobalArray` and `GlobalMatrix` (in `la/operators.py`), which carry a `global_indices` tag used to route contributions into the correct block during assembly.
- `BlockMatrix.tosparse()` assembles a global `DiaMatrix` by placing each block at the correct diagonal offset, with result caching.

**1D inner product assembly**

- `inner()` over a `CartesianProductSpace` now produces a `BlockMatrix` of `GlobalMatrix` blocks (bilinear) or a `BlockArray` (linear), routed by `global_index` on each component space.
- `OrthogonalSpace` and `DirectSum` gain `leaf` and `global_index` attributes set during `CartesianProductSpace.__init__`.

**Other**

- `TensorProductSpace.shape` converted from method to `@property`; now returns `space.num_quad_points` per axis (not raw mode count `N`).
- `OrthogonalSpace` gains `to_orthogonal` / `from_orthogonal` identity methods and `shape` property for API symmetry with `Composite`.
- `Composite` and `DirectSum` gain `evaluate_mesh` methods.
- Example `examples/coupled1D.py` added, demonstrating a 1D mixed Poisson formulation.

## Screenshots / Logs


## Breaking Changes

- [x] Yes

`CartesianProductSpace` is now the **1D** class. The previous ND class is now `CartesianTensorProductSpace`. Code that imports or does `isinstance(..., CartesianProductSpace)` for ND spaces must be updated to use `CartesianTensorProductSpace`.

`BlockTPMatrix` is removed; replace with `BlockMatrix`. `IndexedArray` is removed; replace with `GlobalArray`.

`TensorProductSpace.shape` is now a `@property` (previously a method); callers using `T.shape()` must drop the parentheses.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [ ] Coverage does not decrease
- [ ] Git history is clean (squash/fixup before merge)

## Additional Notes

N/A