### PR TITLE
Fixing evaluation of FlaxFunction to include sin, cos, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ from jaxfun.operators import Div, Grad
 
 # Create an MLP neural network space with two hidden layers
 V = MLPSpace([12, 12], dims=2, rank=0, name="V")
-u = FlaxFunction(V, name="u") # The trial function, which here is a neural network
+u = FlaxFunction(V, name="u")  # The trial function, which here is a neural network
 
 # Get mesh points on and inside the unit square
 N = 50

--- a/examples/DrivenCavity.py
+++ b/examples/DrivenCavity.py
@@ -20,7 +20,7 @@ f = (1 - x) ** 2 * (1 + x) ** 2
 N = 24
 bcsx = {"left": {"D": 0}, "right": {"D": 0}}
 bcsy = {"left": {"D": 0}, "right": {"D": f}}
-Re = 10.0
+Re = 100.0
 rho = 1.0
 nu = Constant("nu", 2.0 / Re)
 

--- a/examples/Helmholtz_vpinn.py
+++ b/examples/Helmholtz_vpinn.py
@@ -37,7 +37,7 @@ wj = mesh.get_weights(N, domain="inside", kind="legendre")
 xb = mesh.get_points(N, domain="boundary")
 
 # fv = (Div(Grad(w)) + w - (Div(Grad(ue)) + ue)) * v
-fv = -Dot(Grad(w), Grad(v)) + w**3 * v - (-Dot(Grad(ue), Grad(v)) + ue**3 * v)
+fv = -Dot(Grad(w), Grad(v)) + w * v - (-Dot(Grad(ue), Grad(v)) + ue * v)
 loss_fn = Loss((fv, xj, 0, wj), (w, xb))
 trainer = Trainer(loss_fn)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "flax>=0.12",
-  "jax>=0.10",
+  "flax>=0.12.8",
+  "jax>=0.11",
   "marimo>=0.19.10",
   "matplotlib>=3.9.3",
-  "optax>=0.2.6",
+  "optax>=0.2.8",
   "pre-commit>=4.3",
   "pytest-xdist[psutil]>=3.8",
   "sympy>=1.14",
@@ -88,7 +88,7 @@ dev = [
   "ipython>=8.37.0",
   "pytest>=8.4.1",
   "pyvista>=0.46.2",
-  "ruff>=0.15.0",
+  "ruff>=0.16.0",
   "soap-jax",
   "mpi4py>=4.1.1",
   "ipykernel>=6.30.1",

--- a/src/jaxfun/galerkin/arguments.py
+++ b/src/jaxfun/galerkin/arguments.py
@@ -70,6 +70,26 @@ def get_arg(p: Any) -> ArgumentTag:
     return getattr(p, "argument", ArgumentTag.NONE)
 
 
+def is_jaxfunc_leaf(expr: Basic) -> bool:
+    """Return True when ``expr`` is itself a bare node tagged ArgumentTag.JAXFUNC.
+
+    Applies equally to a Galerkin JAXFunction and a PINN FlaxFunction: both are
+    tagged the same way, only through get_arg / ArgumentTag.
+    """
+    return get_arg(expr) is ArgumentTag.JAXFUNC
+
+
+def is_derivative_of_jaxfunc_leaf(expr: Basic) -> bool:
+    """Return True for a Derivative whose differentiated expression is itself a bare
+    JAXFUNC-tagged leaf, e.g. Derivative(u, x) but not Derivative(sin(u), x)."""
+    return isinstance(expr, sp.Derivative) and is_jaxfunc_leaf(expr.expr)
+
+
+def is_jaxfunc_primitive(expr: Basic) -> bool:
+    """Return True for a bare JAXFUNC-tagged leaf or a direct Derivative of one."""
+    return is_jaxfunc_leaf(expr) or is_derivative_of_jaxfunc_leaf(expr)
+
+
 def get_BasisFunction(
     name: str,
     *,

--- a/src/jaxfun/integrators/nonlinear.py
+++ b/src/jaxfun/integrators/nonlinear.py
@@ -61,7 +61,7 @@ class NonlinearCompiler:
             evaluator = self.compile_node(expanded)
         elif is_jaxfunc_primitive(node):
             evaluator = self.compile_primitive(node)
-        elif not _contains_jaxfunction(node):
+        elif not contains_jaxfunction(node):
             evaluator = self.memoize(
                 node,
                 lambda _cache, N=None, node=node: self.get_static_value(node, N),
@@ -268,7 +268,7 @@ def replace_trial_with_jaxfunction(
     return cast(sp.Expr, expr.replace(trial, jax_func))
 
 
-def _contains_jaxfunction(expr: sp.Basic) -> bool:
+def contains_jaxfunction(expr: sp.Basic) -> bool:
     """Return True when any subexpression depends on the JAX-backed field."""
     return any(
         is_jaxfunc_leaf(node) for node in sp.core.traversal.preorder_traversal(expr)

--- a/src/jaxfun/integrators/nonlinear.py
+++ b/src/jaxfun/integrators/nonlinear.py
@@ -9,9 +9,14 @@ import sympy as sp
 from sympy.core.function import AppliedUndef
 
 from jaxfun.galerkin import TestFunction, TrialFunction
-from jaxfun.galerkin.arguments import ArgumentTag, JAXFunction, get_arg
+from jaxfun.galerkin.arguments import (
+    JAXFunction,
+    is_derivative_of_jaxfunc_leaf,
+    is_jaxfunc_leaf,
+    is_jaxfunc_primitive,
+)
 from jaxfun.typing import Array, Padding, ScalarSpaceType
-from jaxfun.utils import lambdify
+from jaxfun.utils import JAX_FUNCTION_BY_NAME, lambdify
 
 type NodeValueCache = dict[sp.Basic, Array]
 type NodeEvaluator = Callable[[NodeValueCache, Padding], Array]
@@ -24,28 +29,6 @@ class NonlinearCompileContext:
     spatial_symbols: tuple[sp.Symbol, ...]
     functionspace: ScalarSpaceType
     jaxfunction: AppliedUndef
-
-
-_JAX_FUNCTION_BY_NAME: dict[str, Callable[..., Array]] = {
-    "Abs": jnp.abs,
-    "acos": jnp.arccos,
-    "acosh": jnp.arccosh,
-    "asin": jnp.arcsin,
-    "asinh": jnp.arcsinh,
-    "atan": jnp.arctan,
-    "atan2": jnp.arctan2,
-    "atanh": jnp.arctanh,
-    "cos": jnp.cos,
-    "cosh": jnp.cosh,
-    "exp": jnp.exp,
-    "log": jnp.log,
-    "sign": jnp.sign,
-    "sin": jnp.sin,
-    "sinh": jnp.sinh,
-    "sqrt": jnp.sqrt,
-    "tan": jnp.tan,
-    "tanh": jnp.tanh,
-}
 
 
 class NonlinearCompiler:
@@ -73,10 +56,10 @@ class NonlinearCompiler:
 
         # Product/chain-rule derivatives must be expanded symbolically before
         # evaluation; only direct d^k(u)/dx^k terms are primitive lookups.
-        if isinstance(node, sp.Derivative) and not _is_direct_jax_derivative(node):
+        if isinstance(node, sp.Derivative) and not is_derivative_of_jaxfunc_leaf(node):
             expanded = sp.expand(node.doit())
             evaluator = self.compile_node(expanded)
-        elif _is_jaxfunction_primitive(node):
+        elif is_jaxfunc_primitive(node):
             evaluator = self.compile_primitive(node)
         elif not _contains_jaxfunction(node):
             evaluator = self.memoize(
@@ -107,7 +90,7 @@ class NonlinearCompiler:
         """Compile a primitive field or spatial derivative evaluation."""
         space = self.context.functionspace
         jaxf = cast(JAXFunction[ScalarSpaceType], self.context.jaxfunction)
-        if _is_jaxfunction_leaf(node):
+        if is_jaxfunc_leaf(node):
 
             def evaluate_leaf(
                 _cache: NodeValueCache,
@@ -119,7 +102,7 @@ class NonlinearCompiler:
 
             return self.memoize(node, evaluate_leaf)
 
-        assert _is_direct_jax_derivative(node)
+        assert is_derivative_of_jaxfunc_leaf(node)
         derivative = cast(sp.Derivative, node)
         known = set(self.context.spatial_symbols)
         unknown = tuple(var for var in derivative.variables if var not in known)
@@ -201,7 +184,7 @@ class NonlinearCompiler:
                 jnp.asarray(child_eval[0](cache, N)), 0.5
             )
 
-        jnp_function = _JAX_FUNCTION_BY_NAME.get(node.func.__name__)
+        jnp_function = JAX_FUNCTION_BY_NAME.get(node.func.__name__)
         if jnp_function is None:
             return self.compile_lambdified(node, child_eval)
 
@@ -285,27 +268,11 @@ def replace_trial_with_jaxfunction(
     return cast(sp.Expr, expr.replace(trial, jax_func))
 
 
-def _is_jaxfunction_leaf(expr: sp.Basic) -> bool:
-    """Return True when ``expr`` is the base JAXFunction field."""
-    return get_arg(expr) is ArgumentTag.JAXFUNC
-
-
 def _contains_jaxfunction(expr: sp.Basic) -> bool:
     """Return True when any subexpression depends on the JAX-backed field."""
     return any(
-        _is_jaxfunction_leaf(node)
-        for node in sp.core.traversal.preorder_traversal(expr)
+        is_jaxfunc_leaf(node) for node in sp.core.traversal.preorder_traversal(expr)
     )
-
-
-def _is_direct_jax_derivative(expr: sp.Basic) -> bool:
-    """Return True for direct spatial derivatives of the JAXFunction field."""
-    return isinstance(expr, sp.Derivative) and _is_jaxfunction_leaf(expr.expr)
-
-
-def _is_jaxfunction_primitive(expr: sp.Basic) -> bool:
-    """Return True for primitive field/derivative nodes handled directly."""
-    return _is_jaxfunction_leaf(expr) or _is_direct_jax_derivative(expr)
 
 
 def compile_nonlinear_evaluator(

--- a/src/jaxfun/pinns/loss.py
+++ b/src/jaxfun/pinns/loss.py
@@ -20,9 +20,9 @@ from jaxfun.galerkin import (
     TensorProductSpace,
     TestFunction,
 )
-from jaxfun.galerkin.arguments import ArgumentTag, get_arg
+from jaxfun.galerkin.arguments import ArgumentTag, get_arg, is_jaxfunc_primitive
 from jaxfun.typing import Array, Loss_Tuple
-from jaxfun.utils import lambdify
+from jaxfun.utils import JAX_FUNCTION_BY_NAME, lambdify
 
 from .module import CartesianModule, Comp
 
@@ -697,7 +697,9 @@ class Loss:
             >>> loss_fn = Loss((eq, xj), (u, xb, 0, 10))
         """
 
-        self.residuals: tuple[Residual, ...] = process_input(*fs, residuals=[])
+        self.residuals: tuple[Residual | ResidualVPINN, ...] = process_input(
+            *fs, residuals=[]
+        )
 
         # Store the unique collocation points and their order for later use
         xs: dict[int, Array] = {id(eq.x): eq.x for eq in self.residuals}
@@ -1098,6 +1100,30 @@ def get_fn(f: sp.Expr, s: tuple[BaseScalar | sp.Symbol, ...] | None) -> Residual
             return get_fn(f0, s)(x, mod, Js, x_id) ** p0
 
         return res_fun
+
+    elif type(f).__name__ in JAX_FUNCTION_BY_NAME and len(f.args) == 1:
+        # Elementwise nonlinear function (sin, exp, tanh, ...) wrapping an expression
+        # that contains a FlaxFunction, e.g. sin(u) or (after sympy's automatic chain
+        # rule via .doit()) cos(u) in cos(u) * Derivative(u, x).
+        inner_fn = get_fn(cast(sp.Expr, f.args[0]), s)
+        jnp_fn = JAX_FUNCTION_BY_NAME[type(f).__name__]
+
+        def res_fun(
+            x: Array,
+            mod: nnx.Module | None = None,
+            Js: dict[tuple[int, int, int], Array] | None = None,
+            x_id: int | None = None,
+        ) -> Array:
+            return jnp_fn(inner_fn(x, mod, Js, x_id))
+
+        return res_fun
+
+    if not is_jaxfunc_primitive(f):
+        raise NotImplementedError(
+            f"get_fn cannot evaluate {f!r}: expected a bare FlaxFunction application, "
+            "a Derivative of one, a Mul, a Pow, or one of the elementwise functions in "
+            "JAX_FUNCTION_BY_NAME applied to a single FlaxFunction-containing argument"
+        )
 
     assert len(v) == 1
     v = v.pop()

--- a/src/jaxfun/pinns/mesh.py
+++ b/src/jaxfun/pinns/mesh.py
@@ -41,6 +41,7 @@ type SampleMethodLike = SampleMethod | str
 type KindType = SampleMethodLike | Sequence[SampleMethodLike] | None
 type NPointsType = int | tuple[int, ...]
 type ParameterMesh = MultiParameterMesh | SingleParameterMesh
+type TimeMarchingDomainType = DomainType | Literal["initial-time", "end-time"]
 
 
 def _coerce_sample_method(kind: SampleMethodLike) -> SampleMethod:
@@ -507,7 +508,7 @@ class TimeMarchingMesh(CartesianProductMesh):
     def get_points(
         self,
         *N: NPointsType,
-        domain: DomainType = "all",
+        domain: TimeMarchingDomainType = "all",
         kind: KindType = "uniform",
     ) -> Array:
         """Return sampled points.
@@ -521,10 +522,10 @@ class TimeMarchingMesh(CartesianProductMesh):
         """
         if domain == "initial-time":
             xi = super().get_points(*N, domain="boundary", kind=kind)
-            return xi[xi[:, -1] <= self.submeshes[-1].left + 1e-7]
+            return xi[xi[:, -1] <= cast(Line, self.submeshes[-1]).left + 1e-7]
         elif domain == "end-time":
             xi = super().get_points(*N, domain="boundary", kind=kind)
-            return xi[xi[:, -1] >= self.submeshes[-1].right - 1e-7]
+            return xi[xi[:, -1] >= cast(Line, self.submeshes[-1]).right - 1e-7]
         return super().get_points(*N, domain=domain, kind=kind)
 
     def get_spatial_mesh(self) -> ParameterMesh:
@@ -600,9 +601,6 @@ class Line(SingleParameterMesh):
         elif kind == SampleMethod.RANDOM:
             x = jax.random.uniform(self.key, (N - 2,))
 
-        else:
-            raise NotImplementedError
-
         return jnp.hstack(
             (
                 jnp.array([self.left]),
@@ -666,7 +664,6 @@ class Line(SingleParameterMesh):
             return jnp.hstack(
                 (jnp.array([1.0]), jnp.pi / (N - 2) * jnp.ones(N - 2), jnp.array([1.0]))
             )
-        raise NotImplementedError
 
     def get_weights_inside_domain(
         self, N: int, kind: SampleMethodLike | None = None

--- a/src/jaxfun/pinns/module.py
+++ b/src/jaxfun/pinns/module.py
@@ -56,9 +56,12 @@ class BaseModule(nnx.Module):
     name: str
 
     def __hash__(self) -> int:
-        # Use static hash for module (does not reflect a change of state)
+        # Use static hash for module (does not reflect a change of state).
+        # Based on type + name rather than the graphdef itself: some modules
+        # (e.g. MLP.act_fun) carry plain lists as static metadata, and current
+        # flax GraphDef.__hash__ requires all metadata to be hashable.
         if not hasattr(self, "_hash"):
-            self._hash = hash(nnx.graphdef(self)) + hash(self.name)
+            self._hash = hash((type(self), self.name))
         return self._hash
 
     def __eq__(self, other: object) -> bool:
@@ -1212,11 +1215,11 @@ class FlaxFunction(Function):
 class CartesianModule(BaseModule):
     """Module for a Cartesian product space: stacks outputs of all component sub-modules
 
-    Used for both CartesianNNSpace (NN sub-modules) and CartesianTensorProductSpace
-    (SpectralModule sub-modules). Each component is stored in an nnx.List so the
-    optimizer sees one unified parameter tree. The call returns a horizontally stacked
-    (N, total_out_size) array; vector_index slicing in loss._lookup_or_eval selects
-    each variable's columns.
+    Used for both CartesianNNSpace (NN sub-modules) and CartesianTensorProductSpace and
+    CartesianProductSpace (SpectralModule sub-modules). Each component is stored in an
+    nnx.List so the optimizer sees one unified parameter tree. The call returns a
+    horizontally stacked (N, total_out_size) array; vector_index slicing in
+    loss._lookup_or_eval selects each variable's columns.
     """
 
     def __init__(

--- a/src/jaxfun/utils/__init__.py
+++ b/src/jaxfun/utils/__init__.py
@@ -1,4 +1,5 @@
 from .common import (
+    JAX_FUNCTION_BY_NAME as JAX_FUNCTION_BY_NAME,
     Domain as Domain,
     diff as diff,
     diffx as diffx,

--- a/src/jaxfun/utils/common.py
+++ b/src/jaxfun/utils/common.py
@@ -26,10 +26,33 @@ __all__ = (
     "diffx",
     "Domain",
     "jacn",
+    "JAX_FUNCTION_BY_NAME",
     "matmat",
     "tosparse",
     "lambdify",
 )
+
+
+JAX_FUNCTION_BY_NAME: dict[str, Callable[..., Array]] = {
+    "Abs": jnp.abs,
+    "acos": jnp.arccos,
+    "acosh": jnp.arccosh,
+    "asin": jnp.arcsin,
+    "asinh": jnp.arcsinh,
+    "atan": jnp.arctan,
+    "atan2": jnp.arctan2,
+    "atanh": jnp.arctanh,
+    "cos": jnp.cos,
+    "cosh": jnp.cosh,
+    "exp": jnp.exp,
+    "log": jnp.log,
+    "sign": jnp.sign,
+    "sin": jnp.sin,
+    "sinh": jnp.sinh,
+    "sqrt": jnp.sqrt,
+    "tan": jnp.tan,
+    "tanh": jnp.tanh,
+}
 
 
 def jit_vmap[FuncT: Callable[..., Array]](

--- a/tests/galerkin/test_approximations.py
+++ b/tests/galerkin/test_approximations.py
@@ -97,7 +97,7 @@ def test_backward_primitive(jspace: type[Jacobi], domain: Domain):
     df = D.backward_primitive(uf.array, 1)
     error = jnp.linalg.norm(df - du.backward())
     assert error < jnp.sqrt(ulp(10))
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         du = JAXFunction(sp.diff(f, x, 2), D)
         df = D.backward_primitive(uf.array, 2)
         error = jnp.linalg.norm(df - du.backward())
@@ -115,7 +115,7 @@ def test_backward_primitive_composite(jspace: type[Jacobi], domain: Domain):
     df = D.backward_primitive(uf.array, 1)
     error = jnp.linalg.norm(df - du.backward())
     assert error < jnp.sqrt(ulp(10))
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         du = JAXFunction(sp.diff(f, x, 2), D.orthogonal)
         df = D.backward_primitive(uf.array, 2)
         error = jnp.linalg.norm(df - du.backward())
@@ -139,7 +139,7 @@ def test_backward_primitive_directsum(jspace: type[Jacobi], domain: Domain):
     df = D.backward_primitive(uf.array, 1)
     error = jnp.linalg.norm(df - du.backward())
     assert error < jnp.sqrt(ulp(100))
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         du = JAXFunction(sp.diff(f, x, 2), D.orthogonal)
         df = D.backward_primitive(uf.array, 2)
         error = jnp.linalg.norm(df - du.backward())
@@ -165,7 +165,7 @@ def test_backward_primitive_2d(space):
 def test_backward_primitive_directsum_2d(jspace: type[Jacobi], domain: Domain):
     from jaxfun.coordinates import x, y
 
-    if not jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if not jax.config.jax_enable_x64:
         pytest.skip("x64 is disabled")
 
     N = 24

--- a/tests/galerkin/test_backward_primitive_eval.py
+++ b/tests/galerkin/test_backward_primitive_eval.py
@@ -30,7 +30,7 @@ def test_fourier_backward_primitive_matches_analytical() -> None:
         expected = lambdify(x, deriv)(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
         assert float(rel) < ulp(100), f"k={k}: rel={float(rel)}"
-    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         got = V.backward_primitive(uh, k=3)
         expected = lambdify(x, sp.diff(ue, x, 3))(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
@@ -50,7 +50,7 @@ def test_chebyshev_backward_primitive_matches_analytical() -> None:
         expected = lambdify(x, deriv)(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
         assert float(rel) < ulp(1000), f"k={k}: rel={float(rel)}"
-    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         got = V.backward_primitive(uh, k=2)
         expected = lambdify(x, sp.diff(ue, x, 2))(xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
@@ -94,7 +94,7 @@ def test_tensorproduct_fourier_backward_primitive_matches_analytical() -> None:
         expected = lambdify((x, y), deriv)(*xj)
         rel = jnp.linalg.norm(got - expected) / jnp.linalg.norm(expected)
         assert float(rel) < ulp(100), f"k={k}: rel={float(rel)}"
-    if jax.config.jax_enable_x64:  # ty: ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         k2 = (0, 2)
         got = V.backward_primitive(uh, k=k2)
         deriv = sp.diff(sp.diff(ue, x, k2[0]), y, k2[1])

--- a/tests/galerkin/test_forward_backward_spmd.py
+++ b/tests/galerkin/test_forward_backward_spmd.py
@@ -127,7 +127,7 @@ def test_backward_primitive_tps_2d(domain):
     error = jnp.linalg.norm(df - du.backward())
 
     assert error < jnp.sqrt(ulp(100))
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         du = JAXFunction(sp.diff(f, x, 2, y, 1), T)
         df = T.backward_primitive(uf.get_array(), (2, 1))
         error = jnp.linalg.norm(df - du.backward())
@@ -136,7 +136,7 @@ def test_backward_primitive_tps_2d(domain):
 
 @pytest.mark.parametrize("domain", [(-1, 1), (0, 2), (-2, 2)])
 def test_backward_primitive_tps_3d(domain):
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         N = 16
         D = FunctionSpace(N, Legendre.Legendre, domain=domain)
         T = TensorProduct(D, D, D)

--- a/tests/galerkin/test_tensorproductspace_extra.py
+++ b/tests/galerkin/test_tensorproductspace_extra.py
@@ -111,7 +111,7 @@ def test_directsumtps_biharmonic_dirichlet_3d():
     x, y, z = T.system.base_scalars()
     ue = T.system.expr_psi_to_base_scalar(ue)
 
-    if jax.config.jax_enable_x64:  # ty:ignore[unresolved-attribute]
+    if jax.config.jax_enable_x64:
         A, b = inner(
             (Div(Grad(u)) + u.diff(z, 4)) * v - (Div(Grad(ue)) + ue.diff(z, 4)) * v,
             kind="system",

--- a/tests/integrators/test_backward_euler.py
+++ b/tests/integrators/test_backward_euler.py
@@ -207,10 +207,10 @@ def test_rk4_nonlinear_rhs_caches_repeated_primitives(
 
     primitive_orders = {
         0
-        if integrator_nonlinear._is_jaxfunction_leaf(node)
+        if integrator_nonlinear.is_jaxfunc_leaf(node)
         else int(sp.sympify(node).derivative_count)  # ty:ignore[unresolved-attribute]
         for node in sp.core.traversal.preorder_traversal(integrator.nonlinear_expr)
-        if integrator_nonlinear._is_jaxfunction_primitive(node)
+        if integrator_nonlinear.is_jaxfunc_primitive(node)
     }
 
     # The derivative primitive should be evaluated once even though it appears

--- a/tests/la/test_kron.py
+++ b/tests/la/test_kron.py
@@ -258,7 +258,7 @@ class TestTpmatsToKron:
         import jax
         import pytest
 
-        if not jax.config.x64_enabled:  # ty:ignore[unresolved-attribute]
+        if not jax.config.x64_enabled:
             pytest.skip("requires float64 (run with jax_enable_x64=True)")
 
         A, _ = _biharmonic_tpmats(N=10)
@@ -320,7 +320,7 @@ class TestKronSolve:
         import jax
         import pytest
 
-        if not jax.config.x64_enabled:  # ty:ignore[unresolved-attribute]
+        if not jax.config.x64_enabled:
             pytest.skip("requires float64 (run with jax_enable_x64=True)")
 
         A, b = _biharmonic_tpmats(N=12)

--- a/tests/pinns/test_loss.py
+++ b/tests/pinns/test_loss.py
@@ -19,6 +19,7 @@ from jaxfun.pinns.loss import (
     get_flaxfunctions,
     get_fn,
     get_testfunction,
+    jacn,
 )
 from jaxfun.pinns.module import FlaxFunction, MLPSpace
 
@@ -475,6 +476,81 @@ def test_get_fn_with_mul_and_flaxfunction(flax_func):
     x = jnp.array([[1.0, 2.0]])
     result = fn(x, flax_func.module)
     assert result.shape[0] == x.shape[0]
+
+
+def test_get_fn_sin_of_flaxfunction(flax_func):
+    s = flax_func.functionspace.system.base_scalars()
+    fn = get_fn(sp.sin(flax_func).doit(), s)
+    x = jnp.array([[1.0, 2.0], [0.5, -0.5]])
+    result = fn(x, flax_func.module)
+    expected = jnp.sin(flax_func.module(x)[:, 0])
+    assert jnp.allclose(result, expected)
+
+
+def test_get_fn_exp_of_flaxfunction(flax_func):
+    s = flax_func.functionspace.system.base_scalars()
+    fn = get_fn(sp.exp(flax_func).doit(), s)
+    x = jnp.array([[1.0, 2.0]])
+    result = fn(x, flax_func.module)
+    expected = jnp.exp(flax_func.module(x)[:, 0])
+    assert jnp.allclose(result, expected)
+
+
+def test_get_fn_tanh_of_flaxfunction(flax_func):
+    s = flax_func.functionspace.system.base_scalars()
+    fn = get_fn(sp.tanh(flax_func).doit(), s)
+    x = jnp.array([[1.0, 2.0]])
+    result = fn(x, flax_func.module)
+    expected = jnp.tanh(flax_func.module(x)[:, 0])
+    assert jnp.allclose(result, expected)
+
+
+def test_get_fn_elementwise_function_composed_with_mul(flax_func):
+    # exp(2 * u): the inner argument recurses through the existing Mul branch
+    s = flax_func.functionspace.system.base_scalars()
+    fn = get_fn(sp.exp(2 * flax_func).doit(), s)
+    x = jnp.array([[1.0, 2.0]])
+    result = fn(x, flax_func.module)
+    expected = jnp.exp(2 * flax_func.module(x)[:, 0])
+    assert jnp.allclose(result, expected)
+
+
+def test_get_fn_chain_rule_derivative_of_sin_of_flaxfunction(flax_func):
+    # sympy auto-applies the chain rule on .diff(): sin(u).diff(x) -> cos(u) * u_x
+    x_sym = flax_func.functionspace.system.base_scalars()[0]
+    s = flax_func.functionspace.system.base_scalars()
+    f = sp.sin(flax_func).diff(x_sym)
+    fn = get_fn(f.doit(), s)
+
+    x = jnp.array([[1.0, 2.0], [0.3, -0.7]])
+    result = fn(x, flax_func.module)
+
+    u_val = flax_func.module(x)[:, 0]
+    du_dx = jacn(flax_func.module, 1)(x)[:, 0, 0]
+    expected = jnp.cos(u_val) * du_dx
+    assert jnp.allclose(result, expected)
+
+
+def test_get_fn_raises_on_multiarg_function_of_flaxfunction(flax_func):
+    # atan2(u, x) has one FlaxFunction and one plain coordinate: get_flaxfunctions
+    # finds exactly one FlaxFunction, but atan2 is not a bare application/Derivative
+    # of it, so this must raise rather than silently drop the atan2 wrapper.
+    x_sym = flax_func.functionspace.system.base_scalars()[0]
+    s = flax_func.functionspace.system.base_scalars()
+    f = sp.atan2(flax_func, x_sym)
+    with pytest.raises(NotImplementedError, match="get_fn cannot evaluate"):
+        get_fn(f.doit(), s)
+
+
+def test_get_fn_raises_on_undoit_derivative_of_wrapped_flaxfunction(flax_func):
+    # An un-doit'd Derivative(sin(u), x): isinstance(f, sp.Derivative) is True, but
+    # f.args[0] is sin(u), not a bare FlaxFunction application, so this must raise
+    # rather than silently compute du/dx instead of d(sin(u))/dx = cos(u) * du/dx.
+    x_sym = flax_func.functionspace.system.base_scalars()[0]
+    s = flax_func.functionspace.system.base_scalars()
+    f = sp.Derivative(sp.sin(flax_func), x_sym, evaluate=False)
+    with pytest.raises(NotImplementedError, match="get_fn cannot evaluate"):
+        get_fn(f, s)
 
 
 def test_loss_with_vector_equation_and_array_target():

--- a/uv.lock
+++ b/uv.lock
@@ -222,23 +222,6 @@ wheels = [
 ]
 
 [[package]]
-name = "chex"
-version = "0.1.91"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "jax" },
-    { name = "jaxlib" },
-    { name = "numpy" },
-    { name = "toolz" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/7d/812f01e7b2ddf28a0caa8dde56bd951a2c8f691c9bbfce38d469458d1502/chex-0.1.91.tar.gz", hash = "sha256:65367a521415ada905b8c0222b0a41a68337fcadf79a1fb6fc992dbd95dd9f76", size = 90302, upload-time = "2025-09-01T21:49:32.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl", hash = "sha256:6fc4cbfc22301c08d4a7ef706045668410100962eba8ba6af03fa07f4e5dcf9b", size = 100965, upload-time = "2025-09-01T21:49:31.141Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -468,19 +451,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dataclasses-json"
-version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow" },
-    { name = "typing-inspect" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -624,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "flax"
-version = "0.12.3"
+version = "0.12.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax" },
@@ -632,16 +602,15 @@ dependencies = [
     { name = "numpy" },
     { name = "optax" },
     { name = "orbax-checkpoint" },
-    { name = "orbax-export" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tensorstore" },
     { name = "treescope" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/ae/6cbdc663dd3b66dfb0f556342813639d8d04d2fdb7660dbfa75e4000ebf1/flax-0.12.3.tar.gz", hash = "sha256:8b9ca031d0a4759b0719718de578b27703a8b2d6105552b30f98989ce1be04f0", size = 5016605, upload-time = "2026-01-27T21:03:51.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b3/d2effc3a26f61135a90c7b282473b8c7963d124856ce860743a12c99a0da/flax-0.12.8.tar.gz", hash = "sha256:1bb438775b967a3f1f42b9c3d4ddf1d2883cd6406589f9cecdc244634036bdc4", size = 15710344, upload-time = "2026-07-20T18:29:40.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/13/b3d5c22d8d4f266eba54795130afda106b12cce0fb92f3e196984725e024/flax-0.12.3-py3-none-any.whl", hash = "sha256:add0432489da2a532357d8a3a014a349d70774156a5a0a594706ba4319efa599", size = 490531, upload-time = "2026-01-27T21:03:50.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/da/2bda90cbe3bab93a5ce37263d6a461ee12e851d8d32b1a86bc3e682d651a/flax-0.12.8-py3-none-any.whl", hash = "sha256:807931d369cbc716fc447801ab39cd6c3c2614d573387a2319a028675dd34fe5", size = 531332, upload-time = "2026-07-20T18:29:38.971Z" },
 ]
 
 [[package]]
@@ -907,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "jax"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaxlib" },
@@ -916,9 +885,9 @@ dependencies = [
     { name = "opt-einsum" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/f0/bcb81d28267d2054d0daed766c7fa16bcee5e481331b4d1e14f5fbe662be/jax-0.10.0.tar.gz", hash = "sha256:0119c767de1645f407df72345d28a3837dc904f1d698911c121d8f2b396fdece", size = 2663397, upload-time = "2026-04-22T13:22:28.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/20/90a137c178de8f2b9170bd4dfb934e261213fdaac67e5c5183b132be85e7/jax-0.11.0.tar.gz", hash = "sha256:a2feb7cfa48bb35d36b8ecec16a4ec24044dec01935f779b28b017213697b195", size = 2813185, upload-time = "2026-07-16T19:00:14.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/aa/dfac6d72cc35bc07e7587115b6946e333ef4ccb2e6cd26ecf639438c5d26/jax-0.10.0-py3-none-any.whl", hash = "sha256:76c42ba163c8db3dc2e449e225b888c0edfb623ded31efdc96d85e0fda1d26e8", size = 3094950, upload-time = "2026-04-16T12:32:11.576Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/26a1305f8978bc41f889a4172198c7d8976e8e394fc4d03597d9edfd6b7e/jax-0.11.0-py3-none-any.whl", hash = "sha256:b31ed66c4321d5c9e48b861f51a72ed5f7960c93514296202d2041cbb9ac45bf", size = 3255281, upload-time = "2026-07-16T18:58:25.02Z" },
 ]
 
 [[package]]
@@ -956,11 +925,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "flax", specifier = ">=0.12" },
-    { name = "jax", specifier = ">=0.10" },
+    { name = "flax", specifier = ">=0.12.8" },
+    { name = "jax", specifier = ">=0.11" },
     { name = "marimo", specifier = ">=0.19.10" },
     { name = "matplotlib", specifier = ">=3.9.3" },
-    { name = "optax", specifier = ">=0.2.6" },
+    { name = "optax", specifier = ">=0.2.8" },
     { name = "pre-commit", specifier = ">=4.3" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8" },
     { name = "sympy", specifier = ">=1.14" },
@@ -977,7 +946,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pyvista", specifier = ">=0.46.2" },
-    { name = "ruff", specifier = ">=0.15.0" },
+    { name = "ruff", specifier = ">=0.16.0" },
     { name = "shapely", specifier = ">=2.1.0" },
     { name = "soap-jax", git = "https://github.com/mikaem/SOAP_JAX" },
     { name = "ty", specifier = ">=0.0.63" },
@@ -986,7 +955,7 @@ dev = [
 
 [[package]]
 name = "jaxlib"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
@@ -994,24 +963,21 @@ dependencies = [
     { name = "scipy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/279cb4dc009fe87a8315d1b182f520693236ad07b852152df344ea4e4021/jaxlib-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c1d9b463327c7a2333f210114ecb04f28fefc51ba8233a85a2280cce75bdb42", size = 60137156, upload-time = "2026-04-16T12:33:30.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cd/59ead5a90df739d1b8c1d1d00443558fd30adf5abb0319966ce340d49ff3/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:aa1d70f1a4e27eb403654e71e2fb28d5786d3e9b77fc1847e8c5389880927ca4", size = 79398938, upload-time = "2026-04-16T12:33:34.14Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/20/9b07fc8b327b222b6f72a4978eb4f2ebe856ee71237d63c4d808ec3945e0/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:b0bfb865a07df2e6d7418c0b0c292dd294b5500523b1dd5872b180db2aa480d4", size = 85028702, upload-time = "2026-04-16T12:33:37.815Z" },
-    { url = "https://files.pythonhosted.org/packages/08/3b/4f798fffed4229a2d7de07c1f4feabac7676a26c695a418796dbe29bae7f/jaxlib-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:25bf167e0d8b594e0ec50783ff4892c0b7ec37236c88b2b425a7c252823f8680", size = 64221923, upload-time = "2026-04-16T12:33:41.343Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/b6/b66b0abb9df8f9f8f19a5244b849cb07fc7389a4a5e1fb7794f7cefd7f26/jaxlib-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:384635fff55899a295bbc82ee6c6f773a300e787dc472ca92bbe79abfaac8369", size = 60138213, upload-time = "2026-04-16T12:33:45.13Z" },
-    { url = "https://files.pythonhosted.org/packages/30/1e/844e525a72a08a2744ae2722e2332a0159a6d0efdc1e561cf378f7259a01/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:6d8d78b7070b34e4c5bba5f7e10927e7f4aac9b69be17e9b0a5898553a4338f3", size = 79401054, upload-time = "2026-04-16T12:33:49.263Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/95/305854c2ef2b645f7df1666be66b1167c392cc39384d09aca2e9499b71bf/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:d303dc31b65e8b793d5600f81b1583be03dc9b876a4c10b3e259b6609a1cbe3b", size = 85027218, upload-time = "2026-04-16T12:33:54.325Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/63/a5e1dcb65dca6efbae7189f185588fc939e17c284f272254fbeb68a39817/jaxlib-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:3869be623c2f3391be2ee86f8b412372b102492e67cac0a5f0ab1037bbc3a5cc", size = 64221972, upload-time = "2026-04-16T12:46:24.762Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d6/411e580b70f64a5a4b095cb2c03c1e2c7b3b35c6754e5cacd4a8f8a2d480/jaxlib-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9050ce2ae7eeca62b1a235065056cad62cac590ddc035486faa4472a47eed9f6", size = 60250897, upload-time = "2026-04-16T12:46:13.185Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5c/f40ac9d40eb39c359f268e087ff1f21bdad664f86691c52a288d0f9152e8/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:59e07aab3bdfaad9bdd3cf32e0d3d4f228837b9b231c53f5ae1c0fc284481094", size = 79518774, upload-time = "2026-04-16T12:46:16.684Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/dea7a0ea64a5551244e2140ef6ad36e2dff308b6f5facaa6f1c1272bb47f/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:3088503812cfe49f34a3083d3b7ef5cb3aaf33d89ceb1b3f647fa52713aee59d", size = 85134776, upload-time = "2026-04-16T12:46:20.855Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/25/e1e52a21786b321fb6a2edf9ef9971aa70f06bb2738aef9afd6d8f46a441/jaxlib-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98b26672943672742873f65bc03216819fc55325c99f146590d007c0172bff30", size = 60141273, upload-time = "2026-04-16T12:46:27.922Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/3b/21e3382ce6f4ee84bcce52810f3786ae3663991ec863acadcd0765b6f767/jaxlib-0.10.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:ad47e072430979ec21637aa487d4dc464028b8e9be27268f37de69536c76e341", size = 79416404, upload-time = "2026-04-16T12:46:31.326Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/8e/b2a08ffc51c93842de71f7f988865cebfa7f43d6721957812dc8cc8b9d40/jaxlib-0.10.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:2a42cf04c0f88bc03b150a17fa7ddbb2f40e096667ec8a1b840ed87913e6e735", size = 85035152, upload-time = "2026-04-16T12:46:36.129Z" },
-    { url = "https://files.pythonhosted.org/packages/24/08/26e6a3ecf0a95f1ec0dcd7a668d5c9a72e581c40fe4ae51e102ca63174c5/jaxlib-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:450b771c01b3662c3497e2dceada3f6fc893112ae637ef85ef1dcc7dc68892a8", size = 66661443, upload-time = "2026-04-16T12:46:51.088Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d7/06383d19217824134c4a6119d2efe7b53cde6a0a66fb1d643d9f725d2697/jaxlib-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f62026c9fb1f05998592082a6dcb62f70b466342bc139f711802a9b184ba9a46", size = 60253088, upload-time = "2026-04-16T12:46:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ce/f66f955c01cce1ffda0cfbb1c02bb9234e0cac1d40b46fe17c315155d62f/jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:e66bdc0b57ed5649950799d3f0d67a6bb67f03d06b49ea3fced0bdd6140a9943", size = 79517974, upload-time = "2026-04-16T12:46:43.147Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/74/b358923d0cce13fc7608051d0cc60ce3379f14350dc42540bdbabdbffab2/jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:4dccd9065b30954879869641472d5d12fe4d7914175a5cad56293af8429ce7e0", size = 85134286, upload-time = "2026-04-16T12:46:47.416Z" },
+    { url = "https://files.pythonhosted.org/packages/04/13/629fd9f50e15424358b7c53b6ec729e2d7163d64942817bee9adeee04ed1/jaxlib-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5bf0b3bfc2ef4778580047389dacb51ae000e50c6b3b6f98d10788927066c97", size = 62546563, upload-time = "2026-07-16T18:59:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1d/a85feebcfc6fa702bcaadd74f3c13283e1613f7598de5ca69bdbaf4c2671/jaxlib-0.11.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1b767c4d7ad4dfc6358313b63ae6d83c3571d3ce966de04d8aaf29eb44633786", size = 82155667, upload-time = "2026-07-16T18:59:20.477Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f0/89c34a4877628edea6585699e42f7d3ed4c1e50140ade9c6efce85a0ab84/jaxlib-0.11.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:7ea9dc06d94f536deabcf304513143bc89f51173ddfd786d44f8ac303efdf643", size = 87263507, upload-time = "2026-07-16T18:59:24.258Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6b/e6caeaff6bd1537becbbcde8985fd65a71374e33f9e8c1aa3371bd16c349/jaxlib-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:166ca16586a8aeb23f9c5e322845f3789037ed294f0a1539404a50f7c5fb13cf", size = 67743601, upload-time = "2026-07-16T18:59:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3b/cc587eaa7d66aad1cddc77f5e10bca086a7d252891d359e64795521f5a2b/jaxlib-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:88b349aa95e452caa30a6723320e93ec7bd1ab249e9f0bf29000da1b5efae733", size = 62547263, upload-time = "2026-07-16T18:59:31.414Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/8c71ff16e019554a07dfcc206034b0182fba00bca1d7aaada7bcdb32b595/jaxlib-0.11.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:112a01c584707a7d0e8634fd55dd7efffe812966e60c2d3ac84e8c24e4571336", size = 82152577, upload-time = "2026-07-16T18:59:35.392Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/82e456879df00e8bed7074028b0e1ddf2ce4e58dd83b699b9e9ef8306542/jaxlib-0.11.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:33dd9405cab05ee4f3ecc3a91289323e9bd2f08d25990e5d45ffb8524f519506", size = 87263717, upload-time = "2026-07-16T18:59:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/87/96670370fd97cb79ad84d8becc8878e6b4aa52fd052cf5f3c063add9e7af/jaxlib-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:aced7b1ca4e338b5248821a397d2d53008894672be6fee762f391cfdd7272e1e", size = 67744784, upload-time = "2026-07-16T18:59:43.711Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/8fa567a498ce9e1966d035efd6a4be92e4a8b788b321549ec06fbb7ff25c/jaxlib-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e6c0e2374943ba7191fe196e22067b789894c58cf6ddd24c9971ae642de58ee", size = 62546481, upload-time = "2026-07-16T18:59:48.212Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/159e82715919b8945107c35051ac4fa6e2578640c484e17ea6590914b1a5/jaxlib-0.11.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:483429cc7fa7fd6a20cb50f666c8d2d499efb7e9ba3163811c01f051ad6057c4", size = 82171230, upload-time = "2026-07-16T18:59:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e6/b6e4154b24d5a6bdcae715ad32030e7954bd793c590afa91b693d70e2719/jaxlib-0.11.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:6125da8532610641b7d3ea7926217cdab52dccb294ef6615455e2b6ecb9e2ee6", size = 87271644, upload-time = "2026-07-16T18:59:55.428Z" },
+    { url = "https://files.pythonhosted.org/packages/be/79/949b0e7860787c0996af475a57b8a060fbd6b9c91b009005d91d12b4aecd/jaxlib-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:19888d25c2bba4240ccffe39ee4e5490a544a0bbcdcc1c171e558d3efed57d84", size = 70245063, upload-time = "2026-07-16T18:59:59.016Z" },
+    { url = "https://files.pythonhosted.org/packages/09/18/04d82793d804a6766ca73e4ed30ef928aea252db7c86f73b2faf11fe9e90/jaxlib-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c38a393d37b4a70569224dc8273d8ae6ccea837e45410ed53ca03e15d6fad58", size = 62642149, upload-time = "2026-07-16T19:00:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2e/418dae82175154f6b5f53aec8909bda800dcbc9c65d94373de146b06e3b1/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:5ed7c54a6ef02eea19c0a02e3f603e4f9ad77248098bb9fc3feffca7f4814b83", size = 82261560, upload-time = "2026-07-16T19:00:06.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ff/2edc74b4de40ac4222ee48b3805a6ea5e40f34abe4cd10b65bc0fa0864db/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:005ae3a663193d3a89eafadc073880c67d6b829e0ad989690275d02b5adc810a", size = 87367515, upload-time = "2026-07-16T19:00:10.661Z" },
 ]
 
 [[package]]
@@ -1450,18 +1416,6 @@ wheels = [
 ]
 
 [[package]]
-name = "marshmallow"
-version = "3.26.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
-]
-
-[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1704,15 +1658,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "narwhals"
 version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1860,18 +1805,17 @@ wheels = [
 
 [[package]]
 name = "optax"
-version = "0.2.6"
+version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "chex" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/3b/90c11f740a3538200b61cd2b7d9346959cb9e31e0bdea3d2f886b7262203/optax-0.2.6.tar.gz", hash = "sha256:ba8d1e12678eba2657484d6feeca4fb281b8066bdfd5efbfc0f41b87663109c0", size = 269660, upload-time = "2025-09-15T22:41:24.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f9/e3d11ae6f298ee941a0690e353a323d158ba5dedc436e75621c310845c5c/optax-0.2.8.tar.gz", hash = "sha256:5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0", size = 301193, upload-time = "2026-03-20T23:30:05.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/ec/19c6cc6064c7fc8f0cd6d5b37c4747849e66040c6ca98f86565efc2c227c/optax-0.2.6-py3-none-any.whl", hash = "sha256:f875251a5ab20f179d4be57478354e8e21963373b10f9c3b762b94dcb8c36d91", size = 367782, upload-time = "2025-09-15T22:41:22.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl", hash = "sha256:e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4", size = 402960, upload-time = "2026-03-20T23:30:03.886Z" },
 ]
 
 [[package]]
@@ -1897,26 +1841,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6c/5f/1733e1143696319f311bc4de48da2e306a1f62f0925f9fe9d797b8ba8abe/orbax_checkpoint-0.11.32.tar.gz", hash = "sha256:523dcf61e93c7187c6b80fd50f3177114c0b957ea62cbb5c869c0b3e3d1a7dfc", size = 431601, upload-time = "2026-01-20T16:46:06.307Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/17/aae3144258f30920741ec91dbff0ff54665e572da50e6445ef437e08ec32/orbax_checkpoint-0.11.32-py3-none-any.whl", hash = "sha256:f0bfe9f9b1ce2c32c8f5dfab63393e51de525d41352abc17c7e21f9cc731d7a9", size = 634424, upload-time = "2026-01-20T16:46:04.382Z" },
-]
-
-[[package]]
-name = "orbax-export"
-version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "dataclasses-json" },
-    { name = "etils" },
-    { name = "jax" },
-    { name = "jaxlib" },
-    { name = "jaxtyping" },
-    { name = "numpy" },
-    { name = "orbax-checkpoint" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/c8/ed7ac3c3c687bf129d7469b016c2b3d8777379f4ea453474e50ee41ce5cb/orbax_export-0.0.8.tar.gz", hash = "sha256:544eef564e2a6f17cd11b1167febe348b7b7cf56d9575de994a33d5613dd568a", size = 124980, upload-time = "2025-09-17T15:41:14.264Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/a9/3a755a58c8b6a36fe7e9e66bb6b93967ff49cdbc77cca8eacb2cf66435e9/orbax_export-0.0.8-py3-none-any.whl", hash = "sha256:f8037e1666ad28411cdb08d0668a2737b1281a32902c623ceda12109a089bc36", size = 180487, upload-time = "2025-09-17T15:41:12.928Z" },
 ]
 
 [[package]]
@@ -2782,27 +2706,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -3126,15 +3050,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toolz"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
-]
-
-[[package]]
 name = "tornado"
 version = "6.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3227,19 +3142,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`get_fn` in `jaxfun/pinns/loss.py` could not evaluate a nonlinear elementwise function (`sin`, `cos`, `exp`, `tanh`, ...) applied to a `FlaxFunction`, e.g. `sin(u)` or the chain-rule term `cos(u) * Derivative(u, x)` produced by `sp.diff`. This change adds that evaluation path and shares the JAXFUNC-primitive detection helpers between the Galerkin nonlinear integrator and the PINN loss module instead of duplicating them.

## Types of Changes

- [x] Bug fix
- [x] Refactor / cleanup
- [x] Build / CI
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Other (describe):

## Related Issues

Fixes # \
Refs #

## Description of Changes

- `jaxfun/pinns/loss.py`: `get_fn` gains a branch for `type(f).__name__ in JAX_FUNCTION_BY_NAME and len(f.args) == 1` that recurses into the wrapped argument and applies the matching `jnp` function elementwise. Also raises `NotImplementedError` with a descriptive message for expressions `get_fn` cannot handle (e.g. multi-arg functions like `atan2(u, x)`, or un-`doit`'d derivatives of a wrapped `FlaxFunction`) instead of falling through silently.
- `jaxfun/galerkin/arguments.py`: extracted `is_jaxfunc_leaf`, `is_derivative_of_jaxfunc_leaf`, `is_jaxfunc_primitive` helpers (previously private duplicates lived in `jaxfun/integrators/nonlinear.py`); both the Galerkin nonlinear compiler and the PINN loss module now use the shared versions.
- `jaxfun/utils/common.py`: moved the `_JAX_FUNCTION_BY_NAME` sympy-name -> `jnp` function lookup table out of `jaxfun/integrators/nonlinear.py` into `jaxfun/utils/common.py` as public `JAX_FUNCTION_BY_NAME`, reused by `loss.py`.
- `jaxfun/pinns/module.py`: `BaseModule.__hash__` now hashes `(type(self), self.name)` instead of `hash(nnx.graphdef(self)) + hash(self.name)` — some modules (e.g. `MLP.act_fun`) carry plain lists as static metadata, and `GraphDef.__hash__` requires all metadata to be hashable, so hashing could previously raise.
- `jaxfun/pinns/mesh.py`: added `TimeMarchingDomainType` for `TimeMarchingMesh.get_points`'s `domain` argument (accepts `"initial-time"`/`"end-time"` in addition to the base `DomainType`); added `cast(Line, ...)` at two call sites accessing `.left`/`.right` on a `submeshes[-1]` typed more generally; removed two now-unreachable `raise NotImplementedError` branches in `Line` (the preceding `if/elif` chain is exhaustive over `SampleMethod`, which `_coerce_sample_method` already validates against).
- `pyproject.toml` / `uv.lock`: bump `jax` >=0.10 -> >=0.11, `flax` >=0.12 -> >=0.12.8, `optax` >=0.2.6 -> >=0.2.8, `ruff` >=0.15.0 -> >=0.16.0 (lockfile also drops `chex`/`orbax-export`/`dataclasses-json`/`marshmallow`/`typing-inspect`/`mypy-extensions`/`toolz` transitive deps no longer pulled in by the bumped versions).
- Test files: removed now-unnecessary `# ty:ignore[unresolved-attribute]` comments on `jax.config.jax_enable_x64` / `jax.config.x64_enabled` accesses (resolved by the jax bump); added `tests/pinns/test_loss.py` coverage for `sin`/`exp`/`tanh` of a `FlaxFunction`, composition with `Mul`, the chain-rule-derivative case, and the two `NotImplementedError` cases.
- `examples/DrivenCavity.py` / `examples/Helmholtz_vpinn.py`: unrelated example tuning — `Re` 10.0 -> 100.0, and the VPINN Helmholtz residual changed from a cubic nonlinearity (`w**3`) back to linear (`w`), matching the file's own comment/name. Flagging since these aren't obviously connected to the `FlaxFunction` fix — worth a one-line note on why, or splitting out if unintentional.

## Screenshots / Logs (if applicable)

N/A

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

`JAX_FUNCTION_BY_NAME` is now public API in `jaxfun.utils` (was a private module-level dict in `jaxfun.integrators.nonlinear`); no other public signatures changed.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (README, examples, docstrings)
- [x] Added type hints
- [x] Linting & formatting pass locally (`ruff check` on touched files — full `pre-commit run --all-files` not run)
- [x] All new and existing tests pass (`uv run pytest`: 790 passed, 9 skipped; `uv run pytest -m pinn tests/pinns/test_loss.py`: 68 passed)
- [ ] Coverage does not decrease (not measured)
- [x] Git history is clean (single commit)

## Additional Notes

- `ty check` passes on all touched source files.
