### PR TITLE
Introduce IMEX Runge-Kutta time steppers into existing integrators module 

### DIFF
--- a/examples/cahn_hilliard2D_etdrk4.py
+++ b/examples/cahn_hilliard2D_etdrk4.py
@@ -20,7 +20,7 @@ import numpy as np
 from matplotlib.animation import FuncAnimation
 
 from jaxfun import Div, Domain, Grad
-from jaxfun.galerkin import TensorProductSpace
+from jaxfun.galerkin import TensorProduct
 from jaxfun.galerkin.arguments import TestFunction, TrialFunction
 from jaxfun.galerkin.Fourier import Fourier
 from jaxfun.integrators import ETDRK4
@@ -74,7 +74,7 @@ elif "CH_FAST" in os.environ:
 dt = T / steps
 
 F = Fourier(N, Domain(0.0, 1.0))
-V = TensorProductSpace((F, F), name="V")
+V = TensorProduct(F, F, name="V")
 v = TestFunction(V, name="v")
 u = TrialFunction(V, name="u", transient=True)
 

--- a/examples/ginzburg_landau_imex.py
+++ b/examples/ginzburg_landau_imex.py
@@ -1,0 +1,145 @@
+# Solve the Ginzburg-Landau equation with IMEX Runge-Kutta in time
+#
+#   u_t - Δu - u + (1 + 1.5j) u * |u|^2 = 0,
+#   (x, y) in [-50, 50] x [-50, 50] periodic
+#
+# Spatial discretization: 2D Fourier Galerkin (spectral)
+# Time discretization: IMEXRungeKutta (ARS443)
+# ruff: noqa: E402
+import os
+import sys
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+
+if "PYTEST" not in os.environ:
+    jax.config.update("jax_enable_x64", True)
+
+import matplotlib.pyplot as plt
+import sympy as sp
+from matplotlib.animation import FuncAnimation
+
+from jaxfun import Div, Domain, Grad
+from jaxfun.galerkin import TensorProduct
+from jaxfun.galerkin.arguments import JAXFunction, TestFunction, TrialFunction
+from jaxfun.galerkin.Fourier import Fourier
+from jaxfun.integrators import ARS443, IMEXRungeKutta
+
+N = 128
+T = 100.0
+steps = 5000
+n_states = 200
+
+if "PYTEST" in os.environ:
+    N = 24
+    T = 2e-3
+    steps = 8
+    n_states = 4
+
+dt = T / steps
+
+F = Fourier(N, Domain(-50, 50))
+V = TensorProduct(F, F, name="V")
+v = TestFunction(V, name="v")
+u = TrialFunction(V, name="u", transient=True)
+
+x, y = V.system.base_scalars()
+t = V.system.base_time()
+
+equation = u.diff(t) - Div(Grad(u)) - u + (1 + 1.5j) * u * sp.Abs(u) ** 2
+weak_form = v * equation
+
+ue = (x + y) * sp.exp(-0.03 * (x**2 + y**2))
+u0_hat = JAXFunction(ue, V, name="u0")
+
+integrator = IMEXRungeKutta(
+    V,
+    weak_form,
+    tableau=ARS443,
+    time=(0.0, T),
+    initial=cast(jax.Array, u0_hat.array),
+    sparse=True,
+    sparse_tol=1000,
+)
+states = integrator.solve(
+    dt=dt,
+    steps=steps,
+    n_batches=n_states,
+    return_batch_snapshots=True,
+    # N=(196, 196),
+    progress=True,
+)
+times = jnp.linspace(0.0, T, states.shape[0])
+
+
+@jax.jit
+def backward_saved_states(coefficients):
+    return jax.vmap(lambda u_hat: V.backward(u_hat).real)(coefficients)
+
+
+x_plot, y_plot = V.mesh(broadcast=False)
+u_states = backward_saved_states(states)
+
+if "PYTEST" in os.environ:
+    assert states.shape == (n_states + 1,) + V.num_dofs
+    assert bool(jnp.isfinite(u_states).all())
+    sys.exit(0)
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4), constrained_layout=True)
+vmin = float(u_states.min())
+vmax = float(u_states.max())
+
+im0 = axes[0].imshow(
+    u_states[0].T,
+    origin="lower",
+    extent=(float(x_plot[0]), float(x_plot[-1]), float(y_plot[0]), float(y_plot[-1])),
+    cmap="RdBu_r",
+    vmin=vmin,
+    vmax=vmax,
+    aspect="equal",
+)
+im1 = axes[1].imshow(
+    u_states[-1].T,
+    origin="lower",
+    extent=(float(x_plot[0]), float(x_plot[-1]), float(y_plot[0]), float(y_plot[-1])),
+    cmap="RdBu_r",
+    vmin=vmin,
+    vmax=vmax,
+    aspect="equal",
+)
+
+axes[0].set_title("u(x, y, 0)")
+axes[1].set_title(f"u(x, y, T), T={times[-1]:.3e}")
+for ax in axes:
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+
+fig.colorbar(im1, ax=axes[:2], shrink=0.9)
+fig.suptitle("Ginzburg-Landau Equation (IMEX RK)")
+
+fig_anim, ax_anim = plt.subplots(figsize=(5, 4))
+im = ax_anim.imshow(
+    u_states[0].T,
+    origin="lower",
+    extent=(float(x_plot[0]), float(x_plot[-1]), float(y_plot[0]), float(y_plot[-1])),
+    cmap="RdBu_r",
+    vmin=vmin,
+    vmax=vmax,
+    aspect="equal",
+    interpolation="nearest",
+)
+fig_anim.colorbar(im, ax=ax_anim, shrink=0.9)
+ax_anim.set_xlabel("x")
+ax_anim.set_ylabel("y")
+title = ax_anim.set_title(f"Ginzburg-Landau (t={times[0]:.3e})")
+
+
+def update(frame: int):
+    im.set_data(u_states[frame].T)
+    title.set_text(f"Ginzburg-Landau (t={times[frame]:.3e})")
+    return (im,)
+
+
+_anim = FuncAnimation(fig_anim, update, frames=len(times), interval=50, blit=False)
+plt.show()

--- a/src/jaxfun/integrators/__init__.py
+++ b/src/jaxfun/integrators/__init__.py
@@ -1,4 +1,17 @@
 from .backward_euler import BackwardEuler as BackwardEuler
 from .base import BaseIntegrator as BaseIntegrator
 from .etdrk4 import ETDRK4 as ETDRK4
+from .imex_rk import IMEXRungeKutta as IMEXRungeKutta
 from .rk4 import RK4 as RK4
+from .tableau import (
+    ARK2_1_3L2SA as ARK2_1_3L2SA,
+    ARK3_2_4L2SA as ARK3_2_4L2SA,
+    ARK4_3_6L2SA as ARK4_3_6L2SA,
+    ARK5_4_8L2SA as ARK5_4_8L2SA,
+    ARS222 as ARS222,
+    ARS443 as ARS443,
+    IMEX_EULER as IMEX_EULER,
+    IMEX_SSP2_222 as IMEX_SSP2_222,
+    ButcherTableau as ButcherTableau,
+    IMEXTableau as IMEXTableau,
+)

--- a/src/jaxfun/integrators/imex_rk.py
+++ b/src/jaxfun/integrators/imex_rk.py
@@ -1,0 +1,140 @@
+"""Diagonally-implicit IMEX Runge-Kutta time integration."""
+
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+import sympy as sp
+from flax import nnx
+
+from jaxfun.la import BaseMatrix
+from jaxfun.typing import Array, Padding, ScalarSpaceType
+
+from .base import BaseIntegrator, _warm_operator_solve_cache
+from .tableau import IMEXTableau
+
+
+class IMEXRungeKutta(BaseIntegrator):
+    """Diagonally-implicit IMEX Runge-Kutta integrator for semilinear systems.
+
+    The stiff linear part of the weak form is solved implicitly (one linear
+    solve per stage with nonzero diagonal Butcher coefficient), while the
+    nonlinear part is evaluated explicitly, combined stage by stage according
+    to `tableau`.
+    """
+
+    def __init__(
+        self,
+        V: ScalarSpaceType,
+        equation: sp.Expr,
+        *,
+        tableau: IMEXTableau,
+        initial: sp.Expr | Array,
+        time: tuple[float, float] | None = None,
+        **params,
+    ):
+        """Construct an IMEX Runge-Kutta integrator for a semilinear weak form."""
+        super().__init__(V, equation, initial=initial, time=time, **params)
+        self.tableau = nnx.static(tableau)
+
+    def setup(self, dt: float) -> None:
+        """Precompute one implicit system operator per distinct diagonal coefficient."""
+        tableau: IMEXTableau = self.tableau
+        ops: list[BaseMatrix] = []
+        for a_ii in tableau.distinct_diagonal_coeffs:
+            op = self.mass_operator - dt * a_ii * self.linear_operator
+            _warm_operator_solve_cache(op)
+            ops.append(op)
+        self._stage_operators: tuple[BaseMatrix, ...] = nnx.data(tuple(ops))
+
+    def _stage_operator(self, a_ii: float) -> BaseMatrix:
+        """Return the cached implicit system operator for diagonal coeff `a_ii`."""
+        idx = self.tableau.distinct_diagonal_coeffs.index(a_ii)
+        return self._stage_operators[idx]
+
+    @jax.jit(static_argnums=(0, 3))
+    def step(self, u_hat: Array, dt: float, N: Padding = None) -> Array:
+        """Advance one IMEX Runge-Kutta step in coefficient space.
+
+        Three final-combination paths, selected by `tableau`'s (static)
+        stiff-accuracy properties:
+
+        - Globally stiffly accurate (`is_stiffly_accurate`): the last stage
+          already equals the accepted solution; return it directly.
+        - Implicit-only stiffly accurate (`implicit_is_stiffly_accurate`
+          without the former): the ``b_i``-weighted combination folds
+          algebraically into the last stage, leaving only a
+          ``(b_e - explicit.A[-1])``-weighted correction over the cached
+          nonlinear stage values (no linear-operator terms needed at all).
+        - Otherwise: the general weighted combination over both ``b_e`` and
+          ``b_i``.
+
+        The last stage's nonlinear/linear evaluations are skipped entirely
+        when the chosen path doesn't need them (never needed for the fully
+        stiffly-accurate path; the linear evaluation is additionally never
+        needed for the implicit-only path).
+        """
+        tableau: IMEXTableau = self.tableau
+        a_e, a_i = tableau.explicit.A, tableau.implicit.A
+        b_e, b_i, c_i = tableau.explicit.b, tableau.implicit.b, tableau.implicit.c
+
+        full_gsa = tableau.is_stiffly_accurate
+        implicit_only_sa = (not full_gsa) and tableau.implicit_is_stiffly_accurate
+        last = tableau.stages - 1
+
+        m_u = self.apply_mass(u_hat)
+        forcing = (
+            jnp.asarray(self.linear_forcing)
+            if self.linear_forcing is not None
+            else None
+        )
+
+        stages: list[Array] = []
+        nonlinear_stage: list[Array | None] = []
+        linear_stage: list[Array | None] = []
+
+        for i in range(tableau.stages):
+            a_ii = a_i[i][i]
+            rhs = m_u
+            for j in range(i):
+                if a_e[i][j] != 0.0:
+                    rhs = rhs + dt * a_e[i][j] * cast(Array, nonlinear_stage[j])
+                if a_i[i][j] != 0.0:
+                    rhs = rhs + dt * a_i[i][j] * cast(Array, linear_stage[j])
+            if forcing is not None and c_i[i] != 0.0:
+                rhs = rhs + dt * c_i[i] * forcing
+
+            if a_ii == 0.0:
+                stage = self.apply_mass_inverse(rhs)
+            else:
+                stage = self._stage_operator(a_ii).solve(rhs)
+
+            stages.append(stage)
+            is_last = i == last
+            skip_nonlinear = is_last and full_gsa
+            skip_linear = is_last and (full_gsa or implicit_only_sa)
+            nonlinear_stage.append(
+                None if skip_nonlinear else self.nonlinear_rhs_scalar_product(stage, N)
+            )
+            linear_stage.append(None if skip_linear else (self.linear_operator @ stage))
+
+        if full_gsa:
+            return stages[-1]
+
+        if implicit_only_sa:
+            rhs = self.apply_mass(stages[-1])
+            for j in range(tableau.stages):
+                weight = b_e[j] - a_e[-1][j]
+                if weight != 0.0:
+                    rhs = rhs + dt * weight * cast(Array, nonlinear_stage[j])
+            return self.apply_mass_inverse(rhs)
+
+        rhs = m_u
+        for j in range(tableau.stages):
+            if b_e[j] != 0.0:
+                rhs = rhs + dt * b_e[j] * cast(Array, nonlinear_stage[j])
+            if b_i[j] != 0.0:
+                rhs = rhs + dt * b_i[j] * cast(Array, linear_stage[j])
+        if forcing is not None:
+            rhs = rhs + dt * forcing
+        return self.apply_mass_inverse(rhs)

--- a/src/jaxfun/integrators/tableau.py
+++ b/src/jaxfun/integrators/tableau.py
@@ -1,0 +1,614 @@
+"""Butcher tableaux for implicit-explicit (IMEX) Runge-Kutta time integration."""
+
+import math
+from dataclasses import dataclass
+
+_TOL = 1e-10
+
+
+@dataclass(frozen=True)
+class ButcherTableau:
+    """A single (explicit or diagonally implicit) Runge-Kutta tableau.
+
+    Args:
+        A: Stage coefficients, ``A[i][j]`` weights stage ``j``'s contribution
+            to stage ``i``. Square, ``stages x stages``.
+        b: Output weights combining stage contributions into the final state.
+        c: Stage abscissae. Must satisfy ``sum(A[i]) == c[i]`` for every row.
+    """
+
+    A: tuple[tuple[float, ...], ...]
+    b: tuple[float, ...]
+    c: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        s = len(self.c)
+        if len(self.A) != s or any(len(row) != s for row in self.A):
+            raise ValueError("Butcher tableau `A` must be square with `len(c)` rows")
+        if len(self.b) != s:
+            raise ValueError("Butcher tableau `b` must have `len(c)` entries")
+        for i, row in enumerate(self.A):
+            if abs(sum(row) - self.c[i]) > _TOL:
+                raise ValueError(
+                    f"Row {i} of `A` sums to {sum(row)}, expected c[{i}]={self.c[i]}"
+                )
+
+    @property
+    def stages(self) -> int:
+        """Number of stages `s`."""
+        return len(self.c)
+
+
+@dataclass(frozen=True)
+class IMEXTableau:
+    """A paired explicit/diagonally-implicit tableau for IMEX Runge-Kutta.
+
+    The explicit tableau must be strictly lower triangular (``A[i][i] == 0``);
+    the implicit tableau must be lower triangular (``A[i][j] == 0`` for
+    ``j > i``), i.e. diagonally implicit. The two tableaux need not share
+    abscissae `c` -- shared `c` is a convention used by some IMEX families
+    (e.g. Kennedy-Carpenter ARK) but not required in general (e.g.
+    Pareschi-Russo IMEX-SSP schemes use distinct explicit/implicit `c`).
+    """
+
+    explicit: ButcherTableau
+    implicit: ButcherTableau
+
+    def __post_init__(self) -> None:
+        if self.explicit.stages != self.implicit.stages:
+            raise ValueError("Explicit and implicit tableaux must have equal stages")
+        for i, row in enumerate(self.explicit.A):
+            if abs(row[i]) > _TOL:
+                raise ValueError(
+                    f"Explicit tableau must have zero diagonal, "
+                    f"got A[{i}][{i}]={row[i]}"
+                )
+        for i, row in enumerate(self.implicit.A):
+            if any(abs(row[j]) > _TOL for j in range(i + 1, len(row))):
+                raise ValueError(
+                    "Implicit tableau must be lower triangular (diagonally implicit)"
+                )
+
+    @property
+    def stages(self) -> int:
+        """Number of stages `s`, shared by both tableaux."""
+        return self.explicit.stages
+
+    @property
+    def explicit_is_stiffly_accurate(self) -> bool:
+        """Whether the explicit tableau alone satisfies ``A[-1] == b``."""
+        return all(
+            abs(a - bi) <= _TOL
+            for a, bi in zip(self.explicit.A[-1], self.explicit.b, strict=True)
+        )
+
+    @property
+    def implicit_is_stiffly_accurate(self) -> bool:
+        """Whether the implicit tableau alone satisfies ``A[-1] == b``.
+
+        Weaker than `is_stiffly_accurate` (which requires both tableaux) --
+        Kennedy-Carpenter ARK schemes satisfy this but not the full GSA
+        property, since their explicit tableau's own last row differs from
+        `b`. When this holds but `is_stiffly_accurate` does not, `step` can
+        still fold the ``b_i``-weighted final combination into the
+        already-computed last stage, leaving only a ``(b_e - explicit.A[-1])``
+        -weighted correction over the cached nonlinear stage values.
+        """
+        return all(
+            abs(a - bi) <= _TOL
+            for a, bi in zip(self.implicit.A[-1], self.implicit.b, strict=True)
+        )
+
+    @property
+    def is_stiffly_accurate(self) -> bool:
+        """Whether the last stage equals the accepted solution.
+
+        True when the last row of both the explicit and the implicit `A`
+        equals the corresponding `b` (globally stiffly accurate), letting
+        `step` reuse the last stage value directly instead of recomputing a
+        separate output combination.
+        """
+        return self.explicit_is_stiffly_accurate and self.implicit_is_stiffly_accurate
+
+    @property
+    def distinct_diagonal_coeffs(self) -> tuple[float, ...]:
+        """Unique nonzero diagonal coefficients of the implicit tableau.
+
+        Determines how many distinct implicit system operators `setup` must
+        build and cache: stages that share a diagonal coefficient (common in
+        ESDIRK-type schemes) reuse the same cached operator.
+        """
+        seen: list[float] = []
+        for i in range(self.stages):
+            a_ii = self.implicit.A[i][i]
+            if abs(a_ii) > _TOL and not any(abs(a_ii - s) <= _TOL for s in seen):
+                seen.append(a_ii)
+        return tuple(seen)
+
+
+IMEX_EULER = IMEXTableau(
+    explicit=ButcherTableau(
+        A=((0.0, 0.0), (1.0, 0.0)),
+        b=(1.0, 0.0),
+        c=(0.0, 1.0),
+    ),
+    implicit=ButcherTableau(
+        A=((0.0, 0.0), (0.0, 1.0)),
+        b=(0.0, 1.0),
+        c=(0.0, 1.0),
+    ),
+)
+"""First-order IMEX Euler: forward Euler (explicit) paired with backward Euler
+(implicit). Degenerates exactly to :class:`~jaxfun.integrators.BackwardEuler`."""
+
+
+def _imex_ssp2_222() -> IMEXTableau:
+    """Return the Pareschi-Russo IMEX-SSP2(2,2,2) L-stable scheme."""
+    gamma = 1.0 - 1.0 / math.sqrt(2.0)
+    return IMEXTableau(
+        explicit=ButcherTableau(
+            A=((0.0, 0.0), (1.0, 0.0)),
+            b=(0.5, 0.5),
+            c=(0.0, 1.0),
+        ),
+        implicit=ButcherTableau(
+            A=((gamma, 0.0), (1.0 - gamma, gamma)),
+            b=(0.5, 0.5),
+            c=(gamma, 1.0),
+        ),
+    )
+
+
+IMEX_SSP2_222 = _imex_ssp2_222()
+"""Second-order, 2-stage, L-stable IMEX-SSP2(2,2,2) scheme (Pareschi & Russo,
+J. Sci. Comput. 25, 2005), with gamma = 1 - 1/sqrt(2)."""
+
+
+ARK3_2_4L2SA = IMEXTableau(
+    explicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0),
+            (0.8717330430169179988320389023871136850586, 0.0, 0.0, 0.0),
+            (
+                0.52758901197630041156180797140291790433,
+                0.07241098802369958843819202859708209566999,
+                0.0,
+                0.0,
+            ),
+            (
+                0.3990960076760701320627260736092142797856,
+                -0.437557654613519443722846363831022571942,
+                1.038461646937449311660120290221808292156,
+                0.0,
+            ),
+        ),
+        b=(
+            0.1876410243467238251612921441668043913795,
+            -0.5952974735769549480478230275858851737782,
+            0.9717899277217721234705114322255239398694,
+            0.4358665215084589994160194511935568425293,
+        ),
+        c=(0.0, 0.8717330430169179988320389023871136850586, 0.6, 1.0),
+    ),
+    implicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0),
+            (
+                0.4358665215084589994160194511935568425293,
+                0.4358665215084589994160194511935568425293,
+                0.0,
+                0.0,
+            ),
+            (
+                0.2576482460664272457999960162840797092643,
+                -0.09351476757488624521601546747763655179361,
+                0.4358665215084589994160194511935568425293,
+                0.0,
+            ),
+            (
+                0.1876410243467238251612921441668043913795,
+                -0.5952974735769549480478230275858851737782,
+                0.9717899277217721234705114322255239398694,
+                0.4358665215084589994160194511935568425293,
+            ),
+        ),
+        b=(
+            0.1876410243467238251612921441668043913795,
+            -0.5952974735769549480478230275858851737782,
+            0.9717899277217721234705114322255239398694,
+            0.4358665215084589994160194511935568425293,
+        ),
+        c=(0.0, 0.8717330430169179988320389023871136850586, 0.6, 1.0),
+    ),
+)
+"""Kennedy-Carpenter ARK3(2)4L[2]SA: 4-stage, 3rd-order (2nd-order embedded),
+L-stable, stiffly-accurate ESDIRK-paired additive RK scheme. Coefficients
+transcribed from the SUNDIALS ARKODE source
+(``ARKODE_ARK324L2SA_ERK_4_2_3`` / ``ARKODE_ARK324L2SA_DIRK_4_2_3``)."""
+
+
+ARK4_3_6L2SA = IMEXTableau(
+    explicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (1.0 / 2.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (13861.0 / 62500.0, 6889.0 / 62500.0, 0.0, 0.0, 0.0, 0.0),
+            (
+                -116923316275.0 / 2393684061468.0,
+                -2731218467317.0 / 15368042101831.0,
+                9408046702089.0 / 11113171139209.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                -451086348788.0 / 2902428689909.0,
+                -2682348792572.0 / 7519795681897.0,
+                12662868775082.0 / 11960479115383.0,
+                3355817975965.0 / 11060851509271.0,
+                0.0,
+                0.0,
+            ),
+            (
+                647845179188.0 / 3216320057751.0,
+                73281519250.0 / 8382639484533.0,
+                552539513391.0 / 3454668386233.0,
+                3354512671639.0 / 8306763924573.0,
+                4040.0 / 17871.0,
+                0.0,
+            ),
+        ),
+        b=(
+            82889.0 / 524892.0,
+            0.0,
+            15625.0 / 83664.0,
+            69875.0 / 102672.0,
+            -2260.0 / 8211.0,
+            1.0 / 4.0,
+        ),
+        c=(0.0, 1.0 / 2.0, 83.0 / 250.0, 31.0 / 50.0, 17.0 / 20.0, 1.0),
+    ),
+    implicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (1.0 / 4.0, 1.0 / 4.0, 0.0, 0.0, 0.0, 0.0),
+            (8611.0 / 62500.0, -1743.0 / 31250.0, 1.0 / 4.0, 0.0, 0.0, 0.0),
+            (
+                5012029.0 / 34652500.0,
+                -654441.0 / 2922500.0,
+                174375.0 / 388108.0,
+                1.0 / 4.0,
+                0.0,
+                0.0,
+            ),
+            (
+                15267082809.0 / 155376265600.0,
+                -71443401.0 / 120774400.0,
+                730878875.0 / 902184768.0,
+                2285395.0 / 8070912.0,
+                1.0 / 4.0,
+                0.0,
+            ),
+            (
+                82889.0 / 524892.0,
+                0.0,
+                15625.0 / 83664.0,
+                69875.0 / 102672.0,
+                -2260.0 / 8211.0,
+                1.0 / 4.0,
+            ),
+        ),
+        b=(
+            82889.0 / 524892.0,
+            0.0,
+            15625.0 / 83664.0,
+            69875.0 / 102672.0,
+            -2260.0 / 8211.0,
+            1.0 / 4.0,
+        ),
+        c=(0.0, 1.0 / 2.0, 83.0 / 250.0, 31.0 / 50.0, 17.0 / 20.0, 1.0),
+    ),
+)
+"""Kennedy-Carpenter ARK4(3)6L[2]SA: 6-stage, 4th-order (3rd-order embedded),
+L-stable, stiffly-accurate ESDIRK-paired additive RK scheme. Coefficients
+transcribed from the SUNDIALS ARKODE source
+(``ARKODE_ARK436L2SA_ERK_6_3_4`` / ``ARKODE_ARK436L2SA_DIRK_6_3_4``)."""
+
+
+ARS443 = IMEXTableau(
+    explicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0),
+            (1.0 / 2.0, 0.0, 0.0, 0.0, 0.0),
+            (11.0 / 18.0, 1.0 / 18.0, 0.0, 0.0, 0.0),
+            (5.0 / 6.0, -5.0 / 6.0, 1.0 / 2.0, 0.0, 0.0),
+            (1.0 / 4.0, 7.0 / 4.0, 3.0 / 4.0, -7.0 / 4.0, 0.0),
+        ),
+        b=(1.0 / 4.0, 7.0 / 4.0, 3.0 / 4.0, -7.0 / 4.0, 0.0),
+        c=(0.0, 1.0 / 2.0, 2.0 / 3.0, 1.0 / 2.0, 1.0),
+    ),
+    implicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0 / 2.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0 / 6.0, 1.0 / 2.0, 0.0, 0.0),
+            (0.0, -1.0 / 2.0, 1.0 / 2.0, 1.0 / 2.0, 0.0),
+            (0.0, 3.0 / 2.0, -3.0 / 2.0, 1.0 / 2.0, 1.0 / 2.0),
+        ),
+        b=(0.0, 3.0 / 2.0, -3.0 / 2.0, 1.0 / 2.0, 1.0 / 2.0),
+        c=(0.0, 1.0 / 2.0, 2.0 / 3.0, 1.0 / 2.0, 1.0),
+    ),
+)
+"""Ascher-Ruuth-Spiteri ARS(4,4,3): 5-stage (1 trivial explicit-first-stage +
+4 real stages), 3rd-order, L-stable, *globally* stiffly-accurate additive RK
+scheme -- unlike the Kennedy-Carpenter ARK schemes above, both the explicit
+and implicit tableaux independently satisfy ``A[-1] == b``
+(``is_stiffly_accurate`` is True), so `step` can skip the final combination
+and reuse the last stage directly. Coefficients transcribed from Ascher,
+Ruuth & Spiteri, "Implicit-explicit Runge-Kutta methods for time-dependent
+partial differential equations", Appl. Numer. Math. 25 (1997), Section 2.8,
+"A four-stage, third-order combination (4,4,3)" -- cross-checked against the
+PETSc ``TSARKIMEXARS443`` source for the `A`/`At` matrices (PETSc's `b`
+default differs from the paper's and is *not* used here; the paper's own
+printed `b` rows, each equal to their table's last row, are used directly)."""
+
+
+def _ars222() -> IMEXTableau:
+    """Return the Ascher-Ruuth-Spiteri (2,2,2) L-stable GSA scheme."""
+    gamma = (2.0 - math.sqrt(2.0)) / 2.0
+    delta = 1.0 - 1.0 / (2.0 * gamma)
+    return IMEXTableau(
+        explicit=ButcherTableau(
+            A=(
+                (0.0, 0.0, 0.0),
+                (gamma, 0.0, 0.0),
+                (delta, 1.0 - delta, 0.0),
+            ),
+            b=(delta, 1.0 - delta, 0.0),
+            c=(0.0, gamma, 1.0),
+        ),
+        implicit=ButcherTableau(
+            A=(
+                (0.0, 0.0, 0.0),
+                (0.0, gamma, 0.0),
+                (0.0, 1.0 - gamma, gamma),
+            ),
+            b=(0.0, 1.0 - gamma, gamma),
+            c=(0.0, gamma, 1.0),
+        ),
+    )
+
+
+ARS222 = _ars222()
+"""Ascher-Ruuth-Spiteri (2,2,2): 3-stage (1 trivial explicit-first-stage + 2
+real stages), 2nd-order, L-stable, *globally* stiffly-accurate additive RK
+scheme (``is_stiffly_accurate`` is True). Pairs the same 2-stage L-stable
+DIRK used in Section 2.5 of the source paper with a 3-stage explicit
+companion whose weights are chosen (via `delta = 1 - 1/(2*gamma)`) to equal
+its own last row, satisfying the paper's condition (2.3) -- distinct from
+`IMEX_SSP2_222` (Pareschi & Russo), which pairs the same DIRK with a
+different, non-GSA 2-stage explicit table. Coefficients transcribed from
+Ascher, Ruuth & Spiteri, "Implicit-explicit Runge-Kutta methods for
+time-dependent partial differential equations", Appl. Numer. Math. 25
+(1997), Section 2.6, "L-stable, two-stage, second-order DIRK (2,2,2)"."""
+
+
+def _ark2_1_3l2sa() -> IMEXTableau:
+    """Return the Kennedy-Carpenter ARK2(1)3L[2]SA scheme."""
+    gamma = 1.0 - 1.0 / math.sqrt(2.0)
+    alpha = (3.0 + 2.0 * math.sqrt(2.0)) / 6.0
+    delta = 1.0 / (2.0 * math.sqrt(2.0))
+    two_gamma = 2.0 * gamma
+    return IMEXTableau(
+        explicit=ButcherTableau(
+            A=(
+                (0.0, 0.0, 0.0),
+                (two_gamma, 0.0, 0.0),
+                (1.0 - alpha, alpha, 0.0),
+            ),
+            b=(delta, delta, gamma),
+            c=(0.0, two_gamma, 1.0),
+        ),
+        implicit=ButcherTableau(
+            A=(
+                (0.0, 0.0, 0.0),
+                (gamma, gamma, 0.0),
+                (delta, delta, gamma),
+            ),
+            b=(delta, delta, gamma),
+            c=(0.0, two_gamma, 1.0),
+        ),
+    )
+
+
+ARK2_1_3L2SA = _ark2_1_3l2sa()
+"""Kennedy-Carpenter ARK2(1)3L[2]SA: 3-stage, 2nd-order (1st-order embedded),
+L-stable, ESDIRK-paired additive RK scheme. Like `ARK3_2_4L2SA`/
+`ARK4_3_6L2SA`, only the implicit part is stiffly accurate
+(``implicit_is_stiffly_accurate`` True, ``is_stiffly_accurate`` False), so
+`step` uses the partial (implicit-only) shortcut rather than the full
+last-stage reuse. Coefficients transcribed from the SUNDIALS ARKODE source
+(``ARKODE_ARK2_ERK_3_1_2`` / ``ARKODE_ARK2_DIRK_3_1_2``)."""
+
+
+ARK5_4_8L2SA = IMEXTableau(
+    explicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (41.0 / 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (
+                367902744464.0 / 2072280473677.0,
+                677623207551.0 / 8224143866563.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                1268023523408.0 / 10340822734521.0,
+                0.0,
+                1029933939417.0 / 13636558850479.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                14463281900351.0 / 6315353703477.0,
+                0.0,
+                66114435211212.0 / 5879490589093.0,
+                -54053170152839.0 / 4284798021562.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                14090043504691.0 / 34967701212078.0,
+                0.0,
+                15191511035443.0 / 11219624916014.0,
+                -18461159152457.0 / 12425892160975.0,
+                -281667163811.0 / 9011619295870.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                19230459214898.0 / 13134317526959.0,
+                0.0,
+                21275331358303.0 / 2942455364971.0,
+                -38145345988419.0 / 4862620318723.0,
+                -1.0 / 8.0,
+                -1.0 / 8.0,
+                0.0,
+                0.0,
+            ),
+            (
+                -19977161125411.0 / 11928030595625.0,
+                0.0,
+                -40795976796054.0 / 6384907823539.0,
+                177454434618887.0 / 12078138498510.0,
+                782672205425.0 / 8267701900261.0,
+                -69563011059811.0 / 9646580694205.0,
+                7356628210526.0 / 4942186776405.0,
+                0.0,
+            ),
+        ),
+        b=(
+            -872700587467.0 / 9133579230613.0,
+            0.0,
+            0.0,
+            22348218063261.0 / 9555858737531.0,
+            -1143369518992.0 / 8141816002931.0,
+            -39379526789629.0 / 19018526304540.0,
+            32727382324388.0 / 42900044865799.0,
+            41.0 / 200.0,
+        ),
+        c=(
+            0.0,
+            41.0 / 100.0,
+            2935347310677.0 / 11292855782101.0,
+            1426016391358.0 / 7196633302097.0,
+            92.0 / 100.0,
+            24.0 / 100.0,
+            3.0 / 5.0,
+            1.0,
+        ),
+    ),
+    implicit=ButcherTableau(
+        A=(
+            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (41.0 / 200.0, 41.0 / 200.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            (
+                41.0 / 400.0,
+                -567603406766.0 / 11931857230679.0,
+                41.0 / 200.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                683785636431.0 / 9252920307686.0,
+                0.0,
+                -110385047103.0 / 1367015193373.0,
+                41.0 / 200.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                3016520224154.0 / 10081342136671.0,
+                0.0,
+                30586259806659.0 / 12414158314087.0,
+                -22760509404356.0 / 11113319521817.0,
+                41.0 / 200.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
+            (
+                218866479029.0 / 1489978393911.0,
+                0.0,
+                638256894668.0 / 5436446318841.0,
+                -1179710474555.0 / 5321154724896.0,
+                -60928119172.0 / 8023461067671.0,
+                41.0 / 200.0,
+                0.0,
+                0.0,
+            ),
+            (
+                1020004230633.0 / 5715676835656.0,
+                0.0,
+                25762820946817.0 / 25263940353407.0,
+                -2161375909145.0 / 9755907335909.0,
+                -211217309593.0 / 5846859502534.0,
+                -4269925059573.0 / 7827059040749.0,
+                41.0 / 200.0,
+                0.0,
+            ),
+            (
+                -872700587467.0 / 9133579230613.0,
+                0.0,
+                0.0,
+                22348218063261.0 / 9555858737531.0,
+                -1143369518992.0 / 8141816002931.0,
+                -39379526789629.0 / 19018526304540.0,
+                32727382324388.0 / 42900044865799.0,
+                41.0 / 200.0,
+            ),
+        ),
+        b=(
+            -872700587467.0 / 9133579230613.0,
+            0.0,
+            0.0,
+            22348218063261.0 / 9555858737531.0,
+            -1143369518992.0 / 8141816002931.0,
+            -39379526789629.0 / 19018526304540.0,
+            32727382324388.0 / 42900044865799.0,
+            41.0 / 200.0,
+        ),
+        c=(
+            0.0,
+            41.0 / 100.0,
+            2935347310677.0 / 11292855782101.0,
+            1426016391358.0 / 7196633302097.0,
+            92.0 / 100.0,
+            24.0 / 100.0,
+            3.0 / 5.0,
+            1.0,
+        ),
+    ),
+)
+"""Kennedy-Carpenter ARK5(4)8L[2]SA: 8-stage, 5th-order (4th-order embedded),
+L-stable, stiffly-accurate ESDIRK-paired additive RK scheme -- like
+`ARK3_2_4L2SA`/`ARK4_3_6L2SA`/`ARK2_1_3L2SA`, only the implicit part is
+stiffly accurate. Coefficients transcribed from the SUNDIALS ARKODE source
+(``ARKODE_ARK548L2SA_ERK_8_4_5`` / ``ARKODE_ARK548L2SA_DIRK_8_4_5``), and
+independently cross-checked via exact `fractions.Fraction` row-sum
+arithmetic before being written here."""

--- a/src/jaxfun/la/diamatrix.py
+++ b/src/jaxfun/la/diamatrix.py
@@ -1497,7 +1497,7 @@ class DiaMatrix(BaseMatrix):
         n, m = self.shape
         nd = len(self.offsets)
         return (
-            f"DiaMatrix(shape=({n}, {m}), dtype={self.dtype}, "
+            f"{self.__class__.__name__}(shape=({n}, {m}), dtype={self.dtype}, "
             f"n_diags={nd}, nnz={self.nnz}, offsets={self.offsets})"
         )
 

--- a/tests/integrators/test_imex_rk.py
+++ b/tests/integrators/test_imex_rk.py
@@ -1,0 +1,263 @@
+import jax.numpy as jnp
+import pytest
+import sympy as sp
+
+from jaxfun import Domain
+from jaxfun.galerkin.arguments import TestFunction, TrialFunction
+from jaxfun.galerkin.Chebyshev import Chebyshev as Cheb
+from jaxfun.galerkin.Fourier import Fourier as FourierSpace
+from jaxfun.galerkin.functionspace import FunctionSpace
+from jaxfun.integrators import (
+    ARK2_1_3L2SA,
+    ARK3_2_4L2SA,
+    ARK4_3_6L2SA,
+    ARK5_4_8L2SA,
+    ARS222,
+    ARS443,
+    ETDRK4,
+    IMEX_EULER,
+    IMEX_SSP2_222,
+    BackwardEuler,
+    IMEXRungeKutta,
+)
+from jaxfun.integrators.tableau import IMEXTableau
+from jaxfun.operators import Constant, Div, Grad
+from jaxfun.utils.common import lambdify, n
+
+pytestmark = pytest.mark.integration
+
+
+def test_imex_euler_matches_backward_euler() -> None:
+    """A single-stage IMEX-Euler tableau must reduce exactly to BackwardEuler."""
+    N = 32
+    c = Constant("c", 1.0)
+    T = 0.2
+    steps = 200
+    dt = T / steps
+
+    V = FunctionSpace(N, FourierSpace, name="V", fun_str="E")
+    v = TestFunction(V, name="v")
+    u = TrialFunction(V, name="u", transient=True)
+    (x,) = V.system.base_scalars()
+    t = V.system.base_time()
+
+    u0 = sp.sin(x)
+    weak_form = v * (u.diff(t) + c * u.diff(x))
+
+    be = BackwardEuler(
+        V, weak_form, time=(0.0, T), initial=u0, sparse=True, sparse_tol=1000
+    )
+    be_result = be.solve(dt=dt, steps=steps, progress=False)
+
+    imex = IMEXRungeKutta(
+        V,
+        weak_form,
+        tableau=IMEX_EULER,
+        time=(0.0, T),
+        initial=u0,
+        sparse=True,
+        sparse_tol=1000,
+    )
+    imex_result = imex.solve(dt=dt, steps=steps, progress=False)
+
+    # Mathematically identical update, but a different summation order over
+    # 200 complex64 steps accumulates float32 rounding differences.
+    rel_error = jnp.linalg.norm(imex_result - be_result) / jnp.linalg.norm(be_result)
+    assert float(rel_error) < 1e-4
+
+
+def _chebyshev_diffusion_error(
+    tableau: IMEXTableau, *, M: int, nu_val: float, T: float, steps: int
+) -> float:
+    nu = Constant("nu", nu_val)
+    bcs = {"left": {"D": 0}, "right": {"D": 0}}
+    V = FunctionSpace(M, Cheb, bcs=bcs, name="V", fun_str="psi", scaling=n + 1)
+
+    v = TestFunction(V, name="v")
+    u = TrialFunction(V, name="u", transient=True)
+    (x,) = V.system.base_scalars()
+    t = V.system.base_time()
+
+    u0 = sp.sin(sp.pi * (x + 1) / 2)
+    weak_form = v * (u.diff(t) - nu * Div(Grad(u)))
+
+    integrator = IMEXRungeKutta(
+        V,
+        weak_form,
+        tableau=tableau,
+        time=(0.0, T),
+        initial=u0,
+        sparse=True,
+        sparse_tol=1000,
+    )
+    dt = T / steps
+    uhat_t = integrator.solve(dt=dt, steps=steps, progress=False)
+
+    xj = V.mesh()
+    u_num = V.backward(uhat_t).real
+    k = sp.pi / 2
+    u_ex = lambdify(x, sp.sin(k * (x + 1)) * sp.exp(-nu_val * float(k**2) * T))(xj)
+    return float(jnp.linalg.norm(u_num - u_ex))
+
+
+@pytest.mark.parametrize(
+    "tableau,order,base_steps,T",
+    [
+        (ARK2_1_3L2SA, 2, 4, 0.4),
+        (ARS222, 2, 4, 0.4),
+        (ARK3_2_4L2SA, 3, 3, 0.4),
+        (ARK4_3_6L2SA, 4, 1, 0.4),
+        (ARS443, 3, 2, 0.4),
+        (ARK5_4_8L2SA, 5, 2, 1.2),
+    ],
+    ids=[
+        "ark2_1_3l2sa",
+        "ars222",
+        "ark3_2_4l2sa",
+        "ark4_3_6l2sa",
+        "ars443",
+        "ark5_4_8l2sa",
+    ],
+)
+def test_imex_rk_empirical_convergence_order(
+    tableau: IMEXTableau, order: int, base_steps: int, T: float
+) -> None:
+    """Halving dt on a purely linear (implicit-only) problem should reduce the
+    error by roughly 2**order, empirically validating both the stage-loop
+    machinery and the transcribed tableau coefficients.
+
+    ARK2(1)3L[2]SA/ARS222/ARK3(2)4L[2]SA/ARK4(3)6L[2]SA/ARS443/ARK5(4)8L[2]SA's
+    DIRK companions are themselves full-order SDIRK methods, so this
+    purely-linear (no explicit/nonlinear contribution) problem is a valid
+    standalone check for them specifically. This is *not* generally true for
+    IMEX pairs (e.g. IMEX-SSP2(2,2,2)'s DIRK companion is only 1st order
+    alone -- its 2nd order claim only holds for the joint explicit+implicit
+    problem), so this test is not parametrized over IMEX_SSP2_222; see
+    `test_imex_ssp2_222_kdv_soliton_is_accurate` instead. ARS222/ARS443 are
+    additionally globally stiffly accurate (`tableau.is_stiffly_accurate` is
+    True), so this also exercises `step`'s last-stage shortcut path
+    (`IMEX_EULER` is the other GSA scheme, already covered by
+    `test_imex_euler_matches_backward_euler`). `T` is widened for
+    `ARK5_4_8L2SA` (5th order) since its temporal error hits the float32
+    noise floor almost immediately at the default `T`, well before two
+    dt-halvings show clean asymptotic scaling.
+    """
+    M = 16
+    nu_val = 0.5
+
+    err1 = _chebyshev_diffusion_error(
+        tableau, M=M, nu_val=nu_val, T=T, steps=base_steps
+    )
+    err2 = _chebyshev_diffusion_error(
+        tableau, M=M, nu_val=nu_val, T=T, steps=2 * base_steps
+    )
+    observed_order = float(jnp.log2(err1 / err2))
+    assert observed_order > order - 0.75
+
+
+def test_imex_ssp2_222_kdv_soliton_is_accurate() -> None:
+    """Smoke/accuracy check for IMEX-SSP2(2,2,2) on a genuine stiff-linear +
+    nonstiff-nonlinear problem (its DIRK companion alone is only 1st order, so
+    a pure-linear empirical-order check like the ARK3/ARK4 test above is not
+    meaningful for this scheme -- see the note there)."""
+    N = 64
+    L = 20.0
+    domain = Domain(-L, L)
+    mu_val = 0.4
+    mu = Constant("mu", mu_val)
+    wave_speed = 0.5
+    x0 = -5.0
+    steps = 40
+    dt = 1.25e-4
+    T = steps * dt
+
+    V = FunctionSpace(N, FourierSpace, name="V", fun_str="E", domain=domain)
+    v = TestFunction(V, name="v")
+    u = TrialFunction(V, name="u", transient=True)
+    (x,) = V.system.base_scalars()
+    t = V.system.base_time()
+
+    u0 = 3 * wave_speed * sp.sech(0.5 * sp.sqrt(wave_speed) / mu_val * (x - x0)) ** 2
+    weak_form = v * (u.diff(t) + u * u.diff(x) + mu**2 * u.diff(x, 3))
+
+    ssp2 = IMEXRungeKutta(
+        V,
+        weak_form,
+        tableau=IMEX_SSP2_222,
+        time=(0.0, T),
+        initial=u0,
+        sparse=True,
+        sparse_tol=1000,
+    )
+    uhat_t = ssp2.solve(dt=dt, steps=steps, progress=False)
+
+    xj = V.mesh()
+    u_num = V.backward(uhat_t).real
+    u_exact = (
+        3
+        * wave_speed
+        * jnp.cosh(0.5 * jnp.sqrt(wave_speed) / mu_val * (xj - wave_speed * T - x0))
+        ** -2
+    )
+    rel_error = jnp.linalg.norm(u_num - u_exact) / jnp.linalg.norm(u_exact)
+    assert float(rel_error) < 1e-3
+
+
+def test_ark4_kdv_soliton_matches_etdrk4_reference() -> None:
+    """Cross-check IMEX-RK against the existing ETDRK4 reference on the same
+    stiff-linear/nonstiff-nonlinear KdV soliton problem."""
+    N = 64
+    L = 20.0
+    domain = Domain(-L, L)
+    mu_val = 0.4
+    mu = Constant("mu", mu_val)
+    wave_speed = 0.5
+    x0 = -5.0
+    steps = 20
+    dt = 2.5e-4
+    T = steps * dt
+
+    V = FunctionSpace(N, FourierSpace, name="V", fun_str="E", domain=domain)
+    v = TestFunction(V, name="v")
+    u = TrialFunction(V, name="u", transient=True)
+    (x,) = V.system.base_scalars()
+    t = V.system.base_time()
+
+    u0 = 3 * wave_speed * sp.sech(0.5 * sp.sqrt(wave_speed) / mu_val * (x - x0)) ** 2
+    weak_form = v * (u.diff(t) + u * u.diff(x) + mu**2 * u.diff(x, 3))
+
+    ark = IMEXRungeKutta(
+        V,
+        weak_form,
+        tableau=ARK4_3_6L2SA,
+        time=(0.0, T),
+        initial=u0,
+        sparse=True,
+        sparse_tol=1000,
+    )
+    uhat_ark = ark.solve(dt=dt, steps=steps, progress=False)
+
+    etdrk4 = ETDRK4(
+        V,
+        weak_form,
+        time=(0.0, T),
+        initial=u0,
+        sparse=True,
+        sparse_tol=1000,
+    )
+    uhat_etdrk4 = etdrk4.solve(dt=dt, steps=steps, progress=False)
+
+    xj = V.mesh()
+    u_ark = V.backward(uhat_ark).real
+    u_etdrk4 = V.backward(uhat_etdrk4).real
+    rel_error = jnp.linalg.norm(u_ark - u_etdrk4) / jnp.linalg.norm(u_etdrk4)
+    assert float(rel_error) < 5e-3
+
+    u_exact = (
+        3
+        * wave_speed
+        * jnp.cosh(0.5 * jnp.sqrt(wave_speed) / mu_val * (xj - wave_speed * T - x0))
+        ** -2
+    )
+    rel_error_exact = jnp.linalg.norm(u_ark - u_exact) / jnp.linalg.norm(u_exact)
+    assert float(rel_error_exact) < 5e-3

--- a/tests/integrators/test_tableau.py
+++ b/tests/integrators/test_tableau.py
@@ -1,0 +1,140 @@
+import pytest
+
+from jaxfun.integrators.tableau import (
+    ARK2_1_3L2SA,
+    ARK3_2_4L2SA,
+    ARK4_3_6L2SA,
+    ARK5_4_8L2SA,
+    ARS222,
+    ARS443,
+    IMEX_EULER,
+    IMEX_SSP2_222,
+    ButcherTableau,
+    IMEXTableau,
+)
+
+ALL_SCHEMES = {
+    "imex_euler": IMEX_EULER,
+    "imex_ssp2_222": IMEX_SSP2_222,
+    "ark2_1_3l2sa": ARK2_1_3L2SA,
+    "ark3_2_4l2sa": ARK3_2_4L2SA,
+    "ark4_3_6l2sa": ARK4_3_6L2SA,
+    "ark5_4_8l2sa": ARK5_4_8L2SA,
+    "ars222": ARS222,
+    "ars443": ARS443,
+}
+
+
+@pytest.mark.parametrize("tableau", ALL_SCHEMES.values(), ids=ALL_SCHEMES.keys())
+def test_row_sum_consistency(tableau: IMEXTableau) -> None:
+    for a_matrix, c in (
+        (tableau.explicit.A, tableau.explicit.c),
+        (tableau.implicit.A, tableau.implicit.c),
+    ):
+        for i, row in enumerate(a_matrix):
+            assert sum(row) == pytest.approx(c[i], abs=1e-9)
+
+
+@pytest.mark.parametrize("tableau", ALL_SCHEMES.values(), ids=ALL_SCHEMES.keys())
+def test_explicit_tableau_strictly_lower_triangular(tableau: IMEXTableau) -> None:
+    for i, row in enumerate(tableau.explicit.A):
+        assert row[i] == 0.0
+        for j in range(i + 1, len(row)):
+            assert row[j] == 0.0
+
+
+@pytest.mark.parametrize("tableau", ALL_SCHEMES.values(), ids=ALL_SCHEMES.keys())
+def test_implicit_tableau_lower_triangular(tableau: IMEXTableau) -> None:
+    for i, row in enumerate(tableau.implicit.A):
+        for j in range(i + 1, len(row)):
+            assert row[j] == 0.0
+
+
+@pytest.mark.parametrize("tableau", ALL_SCHEMES.values(), ids=ALL_SCHEMES.keys())
+def test_weight_consistency_order_one(tableau: IMEXTableau) -> None:
+    assert sum(tableau.explicit.b) == pytest.approx(1.0, abs=1e-9)
+    assert sum(tableau.implicit.b) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_imex_euler_is_stiffly_accurate_and_matches_backward_euler_structure() -> None:
+    assert IMEX_EULER.is_stiffly_accurate
+    assert IMEX_EULER.distinct_diagonal_coeffs == (1.0,)
+
+
+def test_imex_ssp2_222_is_not_stiffly_accurate() -> None:
+    # SSP2(2,2,2) is L-stable but not stiffly accurate (b != last row of A).
+    assert not IMEX_SSP2_222.is_stiffly_accurate
+    assert len(IMEX_SSP2_222.distinct_diagonal_coeffs) == 1
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [ARK2_1_3L2SA, ARK3_2_4L2SA, ARK4_3_6L2SA, ARK5_4_8L2SA, ARS222, ARS443],
+    ids=[
+        "ark2_1_3l2sa",
+        "ark3_2_4l2sa",
+        "ark4_3_6l2sa",
+        "ark5_4_8l2sa",
+        "ars222",
+        "ars443",
+    ],
+)
+def test_ark_schemes_share_single_diagonal_coefficient(tableau: IMEXTableau) -> None:
+    # ESDIRK-paired ARK/ARS schemes: first stage explicit (a_11=0), remaining
+    # stages share one repeated diagonal coefficient.
+    assert len(tableau.distinct_diagonal_coeffs) == 1
+
+
+@pytest.mark.parametrize("tableau", [ARS222, ARS443], ids=["ars222", "ars443"])
+def test_ars_schemes_are_globally_stiffly_accurate(tableau: IMEXTableau) -> None:
+    # Unlike the Kennedy-Carpenter ARK schemes, the ARS(2,2,2)/(4,4,3)
+    # schemes are constructed so that BOTH tableaux independently satisfy
+    # A[-1] == b (Ascher, Ruuth & Spiteri 1997, condition (2.3)), enabling
+    # the last-stage shortcut.
+    assert tableau.is_stiffly_accurate
+
+
+@pytest.mark.parametrize(
+    "tableau",
+    [ARK2_1_3L2SA, ARK3_2_4L2SA, ARK4_3_6L2SA, ARK5_4_8L2SA],
+    ids=["ark2_1_3l2sa", "ark3_2_4l2sa", "ark4_3_6l2sa", "ark5_4_8l2sa"],
+)
+def test_ark_schemes_are_implicit_only_stiffly_accurate(tableau: IMEXTableau) -> None:
+    # Kennedy-Carpenter ARK schemes: DIRK part satisfies A[-1] == b (enabling
+    # the partial "fold into last stage" shortcut in step()), but the
+    # explicit table's own last row differs from b, so they are not globally
+    # stiffly accurate.
+    assert tableau.implicit_is_stiffly_accurate
+    assert not tableau.explicit_is_stiffly_accurate
+    assert not tableau.is_stiffly_accurate
+
+
+def test_imex_ssp2_222_is_neither_form_of_stiffly_accurate() -> None:
+    assert not IMEX_SSP2_222.implicit_is_stiffly_accurate
+    assert not IMEX_SSP2_222.explicit_is_stiffly_accurate
+    assert not IMEX_SSP2_222.is_stiffly_accurate
+
+
+def test_butcher_tableau_rejects_mismatched_shapes() -> None:
+    with pytest.raises(ValueError, match="square"):
+        ButcherTableau(A=((0.0, 0.0),), b=(1.0, 0.0), c=(0.0, 1.0))
+    with pytest.raises(ValueError, match="entries"):
+        ButcherTableau(A=((0.0, 0.0), (1.0, 0.0)), b=(1.0,), c=(0.0, 1.0))
+    with pytest.raises(ValueError, match="sums to"):
+        ButcherTableau(A=((0.0, 0.0), (1.0, 0.0)), b=(1.0, 0.0), c=(0.0, 0.5))
+
+
+def test_imex_tableau_rejects_nonzero_explicit_diagonal() -> None:
+    bad_explicit = ButcherTableau(A=((1.0,),), b=(1.0,), c=(1.0,))
+    implicit = ButcherTableau(A=((1.0,),), b=(1.0,), c=(1.0,))
+    with pytest.raises(ValueError, match="zero diagonal"):
+        IMEXTableau(explicit=bad_explicit, implicit=implicit)
+
+
+def test_imex_tableau_rejects_non_lower_triangular_implicit() -> None:
+    explicit = ButcherTableau(A=((0.0, 0.0), (1.0, 0.0)), b=(0.0, 1.0), c=(0.0, 1.0))
+    bad_implicit = ButcherTableau(
+        A=((0.0, 1.0), (0.0, 1.0)), b=(0.0, 1.0), c=(1.0, 1.0)
+    )
+    with pytest.raises(ValueError, match="lower triangular"):
+        IMEXTableau(explicit=explicit, implicit=bad_implicit)


### PR DESCRIPTION
## Summary

Adds diagonally-implicit IMEX Runge-Kutta (IMEX-RK) time integration to `jaxfun.integrators`, generalizing the existing ad hoc IMEX-Euler scheme in `BackwardEuler` to a generic, Butcher-tableau-driven family. Motivated by wanting higher-order (>1) implicit-explicit schemes for stiff-linear / nonstiff-nonlinear semi-discrete PDE systems, without changing the framework's existing scalar-field scope (coupled multi-field systems are intentionally out of scope for this PR — see Additional Notes).

## Types of Changes

- [x] New feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Build / CI
- [ ] Other (describe):

## Related Issues

Fixes # \
Refs #

## Description of Changes

- **`src/jaxfun/integrators/tableau.py`** (new): `ButcherTableau` and `IMEXTableau` dataclasses with structural validation (square `A`, row-sum-consistency `sum(A[i]) == c[i]`, strictly-lower-triangular explicit table, lower-triangular/diagonally-implicit implicit table). `IMEXTableau` exposes `stages`, `distinct_diagonal_coeffs` (drives how many implicit system matrices need caching), and stiff-accuracy classification: `explicit_is_stiffly_accurate`, `implicit_is_stiffly_accurate`, and the combined `is_stiffly_accurate` (both).

  Seven named schemes, each transcribed from a primary/authoritative source and independently verified (row-sum consistency, triangularity, and — where feasible — exact `fractions.Fraction` arithmetic) before being trusted, not just copied:
  - `IMEX_EULER` — 2-stage, order 1; reduces exactly to `BackwardEuler` (tested).
  - `IMEX_SSP2_222` — Pareschi & Russo IMEX-SSP2(2,2,2), order 2, L-stable.
  - `ARK2_1_3L2SA`, `ARK3_2_4L2SA`, `ARK4_3_6L2SA`, `ARK5_4_8L2SA` — Kennedy-Carpenter ARK family, orders 2/3/4/5, L-stable, implicit-part-only stiffly accurate. Coefficients transcribed from SUNDIALS ARKODE's raw source, not secondary summaries (an earlier AI-summarized fetch subtly misread PETSc's `TSARKIMEXARS443` default-weight convention — see `ARS443`'s docstring — which is why the later schemes were pulled from raw `.def` source and cross-checked with exact rational arithmetic instead).
  - `ARS222`, `ARS443` — Ascher-Ruuth-Spiteri (1997), orders 2/3, L-stable, and *globally* stiffly accurate (both tableaux independently satisfy `A[-1] == b`), enabling the full last-stage-reuse shortcut.

- **`src/jaxfun/integrators/imex_rk.py`** (new): `IMEXRungeKutta(BaseIntegrator)`. `setup(dt)` caches one implicit system operator (`mass_operator - dt*a_ii*linear_operator`) per distinct diagonal Butcher coefficient. `step()` runs a Python-level (trace-time-unrolled) stage loop reusing `BackwardEuler`'s per-stage solve pattern and `ETDRK4`'s per-stage nonlinear-evaluation pattern, then picks one of three final-combination paths based on the tableau's static stiff-accuracy classification:
  1. **Globally stiffly accurate**: return the last stage directly.
  2. **Implicit-only stiffly accurate**: fold the `b_i`-weighted combination algebraically into the last stage (derived from `implicit.A[-1] == b_i`), leaving only a `(b_e - explicit.A[-1])`-weighted correction over already-cached nonlinear stage values — no linear-operator terms needed at all.
  3. **General**: the full two-sided weighted combination.

  Each path also skips computing the last stage's nonlinear/linear evaluations when the chosen path doesn't need them, avoiding wasted `linear_operator @` matvecs (and, in the fully-GSA case, a wasted nonlinear evaluation) that the naive single-path implementation would otherwise always compute and discard.

- **`src/jaxfun/integrators/__init__.py`**: exports `IMEXRungeKutta`, `ButcherTableau`, `IMEXTableau`, and the seven named schemes.

- **`examples/ginzburg_landau_imex.py`** (new): 2D complex-valued Ginzburg-Landau equation on a Fourier tensor-product space, integrated with `IMEXRungeKutta(tableau=ARS443)` — a real nonlinear/stiff usage example beyond the unit tests.

- Two small, unrelated drive-by fixes bundled in the same commit: `examples/cahn_hilliard2D_etdrk4.py` updated to the current `TensorProduct` API (was using the older `TensorProductSpace` name), and `DiaMatrix.__repr__` now uses `self.__class__.__name__` instead of a hardcoded `"DiaMatrix"`.

Design note on scope: mixing an arbitrary explicit tableau with an arbitrary implicit tableau does **not** generally preserve order above 1 — orders ≥2 require coupling/cross conditions between the two tables (e.g. `Σ bᵢᴱcᵢᴵ = 1/2`), so every scheme here is a specific, jointly-designed, published pair, not an ad hoc combination.

## Screenshots / Logs (if applicable)

```
$ uv run pytest tests/ -q
840 passed, 8 skipped
$ uv run ruff check src/jaxfun/integrators/ tests/integrators/
All checks passed!
$ uv run ty check src/jaxfun/integrators/
All checks passed!
```

## Breaking Changes

- [ ] Yes (describe below)
- [x] No

Purely additive: no existing files in `src/jaxfun/integrators/` (`base.py`, `backward_euler.py`, `etdrk4.py`, `rk4.py`) were modified, and all pre-existing tests pass unchanged.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (README, examples, docstrings) — docstrings/example added; no README changes
- [x] Added type hints
- [x] Linting & formatting pass locally (`pre-commit run --all-files`)
- [x] All new and existing tests pass (`uv run pytest`)
- [ ] Coverage does not decrease — not explicitly measured, but new modules are fully covered by new tests
- [x] Git history is clean (squash/fixup before merge)

## Additional Notes

- Coupled/multi-field time-dependent systems (e.g. a genuine two-field Cahn-Hilliard split, or Navier-Stokes-style coupling) were explored but deliberately **not** included in this PR. An initial design using `CartesianProductSpace`/`BlockMatrix`/`BlockArray` was considered and rejected as too heavy; the preferred direction is a "segregated" approach (each field keeps its own scalar integrator; cross-field terms enter as known/lagged data in another field's nonlinear evaluator). That's follow-up work, not blocking this PR, since `IMEXRungeKutta` is useful standalone for scalar equations today.
- New tests (`tests/integrators/test_tableau.py`, `tests/integrators/test_imex_rk.py`) include: structural/consistency checks for every tableau; `IMEX_EULER` reducing exactly to `BackwardEuler`; empirical convergence-order checks (halving `dt` on a purely-linear problem) for `ARK2_1_3L2SA` (~2.0), `ARS222` (~2.0), `ARK3_2_4L2SA` (~2.9), `ARS443` (~2.9), `ARK4_3_6L2SA` (~3.9), and `ARK5_4_8L2SA` (~5.0); an `ARK4_3_6L2SA` vs. `ETDRK4` cross-check on a KdV soliton; and an `IMEX_SSP2_222` accuracy smoke test (its DIRK companion is only 1st-order standalone, so a pure-linear order test isn't meaningful for it — see the test docstring).
